### PR TITLE
[TexConv] Add alpha coverage to mipmap generation.

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -274,6 +274,7 @@ namespace DirectX
 
         const TexMetadata& __cdecl GetMetadata() const { return m_metadata; }
         const Image* __cdecl GetImage(_In_ size_t mip, _In_ size_t item, _In_ size_t slice) const;
+        Image* __cdecl GetWritableImage(_In_ size_t mip, _In_ size_t item, _In_ size_t slice) const;
 
         const Image* __cdecl GetImages() const { return m_image; }
         size_t __cdecl GetImageCount() const { return m_nimages; }
@@ -471,7 +472,7 @@ namespace DirectX
     HRESULT __cdecl GenerateMipMaps( _In_ const Image& baseImage, _In_ DWORD filter, _In_ size_t levels,
                                      _Inout_ ScratchImage& mipChain, _In_ bool allow1D = false );
     HRESULT __cdecl GenerateMipMaps( _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-                                     _In_ DWORD filter, _In_ size_t levels, _Inout_ ScratchImage& mipChain );
+                                     _In_ DWORD filter, _In_ size_t levels, _Inout_ ScratchImage& mipChain, const float alphaCoverageRatio = 1.0f);
         // levels of '0' indicates a full mipchain, otherwise is generates that number of total levels (including the source base image)
         // Defaults to Fant filtering which is equivalent to a box filter
 

--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -697,6 +697,12 @@ bool ScratchImage::OverrideFormat(DXGI_FORMAT f)
 _Use_decl_annotations_
 const Image* ScratchImage::GetImage(size_t mip, size_t item, size_t slice) const
 {
+    return GetWritableImage(mip, item, slice);
+}
+
+_Use_decl_annotations_
+Image* ScratchImage::GetWritableImage(size_t mip, size_t item, size_t slice) const
+{
     if (mip >= m_metadata.mipLevels)
         return nullptr;
 

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -2521,6 +2521,129 @@ namespace
 // Entry-points
 //=====================================================================================
 
+float clamp(float value, float min, float max)
+{
+    return value < min ? min : value > max ? max : value;
+}
+
+//-------------------------------------------------------------------------------------
+// Alpha to coverage, for mip generation
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+float CalculateAlphaCoverage(const Image& image, const float alphaCoverageRatio, const float scale)
+{
+    float coverage = 0.0f;
+
+    ScopedAlignedArrayXMVECTOR scanline(reinterpret_cast<XMVECTOR*>(_aligned_malloc((sizeof(XMVECTOR) * image.width), 16)));
+    const uint8_t *pPixels = image.pixels;
+    assert(pPixels);
+
+    const float width = static_cast<float>(image.width);
+    const float height = static_cast<float>(image.height);
+
+    const unsigned int n = 8;
+
+    for (size_t h = 0; h < image.height - 1; ++h)
+    {
+        if (!_LoadScanline(scanline.get(), image.width, pPixels, image.rowPitch, image.format))
+            continue;
+
+        XMVECTOR* currentRowPixels = scanline.get();
+
+        if (!_LoadScanline(scanline.get(), image.width, pPixels  + image.rowPitch, image.rowPitch, image.format))
+            continue;
+
+        XMVECTOR* nextRowPixels = scanline.get();
+
+        for (size_t w = 0; w < image.width - 1; ++w)
+        {            
+            // TODO: Use std::clamp when c++17 is available.
+            float alpha00 = clamp(currentRowPixels[w].m128_f32[3] * scale, 0.0f, 1.0f);
+            float alpha10 = clamp(currentRowPixels[w + 1].m128_f32[3] * scale, 0.0f, 1.0f);
+            float alpha01 = clamp(nextRowPixels[w].m128_f32[3] * scale, 0.0f, 1.0f);
+            float alpha11 = clamp(nextRowPixels[w + 1].m128_f32[3] * scale, 0.0f, 1.0f);
+
+            for (float fy = 0.5f / n; fy < 1.0f; fy++) {
+                for (float fx = 0.5f / n; fx < 1.0f; fx++) {
+                    float alpha = alpha00 * (1 - fx) * (1 - fy) + alpha10 * fx * (1 - fy) + alpha01 * (1 - fx) * fy + alpha11 * fx * fy;
+                    if (alpha > alphaCoverageRatio)
+                    {
+                        coverage += 1.0f;
+                    }
+                }
+            }
+        }
+
+        pPixels += image.rowPitch;
+    }
+
+    return coverage / float(width * height * n * n);
+}
+
+_Use_decl_annotations_
+void ScaleAlphaToCoverage(Image& image, const float alphaCoverageRatio, const float desiredCoverage)
+{
+    float minScale = 0.0f;
+    float maxScale = 4.0f;
+    float scale = 1.0f;
+
+    static const int s_iterationCount = 10;
+    for (int scalingIndex = 0; scalingIndex < s_iterationCount; ++scalingIndex)
+    {
+        const float curCoverage = CalculateAlphaCoverage(image, alphaCoverageRatio, scale);
+        if (curCoverage < desiredCoverage)
+        {
+            minScale = scale;
+        }
+        else if (curCoverage > desiredCoverage)
+        {
+            maxScale = scale;
+        }
+        scale = (minScale + maxScale) * 0.5f;
+    }
+
+    // No scaling required
+    if (scale == 1.0f)
+    {
+        return;
+    }
+
+    // Find closest scale
+    const float minVarience = abs(desiredCoverage - CalculateAlphaCoverage(image, alphaCoverageRatio, minScale));
+    const float curVarience = abs(desiredCoverage - CalculateAlphaCoverage(image, alphaCoverageRatio, scale));
+    const float maxVarience = abs(desiredCoverage - CalculateAlphaCoverage(image, alphaCoverageRatio, maxScale));
+
+    if (minVarience < curVarience && minVarience < maxVarience)
+    {
+        scale = minScale;
+    }
+    else if (maxVarience < minVarience && maxVarience < curVarience)
+    {
+        scale = maxScale;
+    }
+
+    ScopedAlignedArrayXMVECTOR scanline(reinterpret_cast<XMVECTOR*>(_aligned_malloc((sizeof(XMVECTOR) * image.width), 16)));
+    uint8_t *pPixels = image.pixels;
+    assert(pPixels);
+
+    for (size_t h = 0; h < image.height; ++h)
+    {
+        if (!_LoadScanline(scanline.get(), image.width, pPixels, image.rowPitch, image.format))
+            continue;
+
+        XMVECTOR* currentRowPixels = scanline.get();
+        for (size_t w = 0; w < image.width; ++w)
+        {
+            XMVECTOR& rgba = currentRowPixels[w];
+            rgba.m128_f32[3] = std::min<float>(rgba.m128_f32[3] * scale, 1.0f);
+        }
+
+        _StoreScanline(pPixels, image.rowPitch, image.format, scanline.get(), image.width);
+
+        pPixels += image.rowPitch;
+    }
+}
+
 //-------------------------------------------------------------------------------------
 // Generate mipmap chain
 //-------------------------------------------------------------------------------------
@@ -2704,7 +2827,8 @@ HRESULT DirectX::GenerateMipMaps(
     const TexMetadata& metadata,
     DWORD filter,
     size_t levels,
-    ScratchImage& mipChain)
+    ScratchImage& mipChain,
+    const float alphaCoverageRatio)
 {
     if (!srcImages || !nimages || !IsValid(metadata.format))
         return E_INVALIDARG;
@@ -2742,7 +2866,18 @@ HRESULT DirectX::GenerateMipMaps(
 
     assert(baseImages.size() == metadata.arraySize);
 
-    HRESULT hr;
+    // Determine the alpha coverage for each map.
+    std::vector<float> alphaCoverages;
+    if (alphaCoverageRatio < 1.0f)
+    {
+        alphaCoverages.reserve(baseImages.size());
+        for (auto imageIt = baseImages.begin(); imageIt != baseImages.end(); ++imageIt)
+        {
+            alphaCoverages.emplace_back(CalculateAlphaCoverage(*imageIt, alphaCoverageRatio, 1.0f));
+        }
+    }
+
+    HRESULT hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
     static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
 
@@ -2779,7 +2914,7 @@ HRESULT DirectX::GenerateMipMaps(
                     }
                 }
 
-                return S_OK;
+                hr = S_OK;
             }
             else
             {
@@ -2810,7 +2945,7 @@ HRESULT DirectX::GenerateMipMaps(
                         return hr;
                 }
 
-                return _ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), metadata.format, mipChain);
+                hr = _ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), metadata.format, mipChain);
             }
         }
         break;
@@ -2845,7 +2980,7 @@ HRESULT DirectX::GenerateMipMaps(
                 if (FAILED(hr))
                     mipChain.Release();
             }
-            return hr;
+            break;
 
         case TEX_FILTER_POINT:
             hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
@@ -2858,7 +2993,7 @@ HRESULT DirectX::GenerateMipMaps(
                 if (FAILED(hr))
                     mipChain.Release();
             }
-            return hr;
+            break;
 
         case TEX_FILTER_LINEAR:
             hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
@@ -2871,7 +3006,7 @@ HRESULT DirectX::GenerateMipMaps(
                 if (FAILED(hr))
                     mipChain.Release();
             }
-            return hr;
+            break;
 
         case TEX_FILTER_CUBIC:
             hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
@@ -2884,7 +3019,7 @@ HRESULT DirectX::GenerateMipMaps(
                 if (FAILED(hr))
                     mipChain.Release();
             }
-            return hr;
+            break;
 
         case TEX_FILTER_TRIANGLE:
             hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
@@ -2897,12 +3032,27 @@ HRESULT DirectX::GenerateMipMaps(
                 if (FAILED(hr))
                     mipChain.Release();
             }
-            return hr;
+            break;
 
         default:
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
         }
     }
+
+    // Scale alpha on all mips
+    if (hr == S_OK && alphaCoverageRatio < 1.0f)
+    {
+        for (size_t imageIndex = 0; imageIndex < metadata.arraySize; ++imageIndex)
+        {
+            const float alphaCoverage = alphaCoverages[imageIndex];
+            for (size_t mipIndex = 1; mipIndex < levels; ++mipIndex)
+            {
+                ScaleAlphaToCoverage(*mipChain.GetWritableImage(mipIndex, 0, 0), alphaCoverageRatio, alphaCoverage);
+            }
+        }
+    }
+
+    return hr;
 }
 
 

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -97,6 +97,7 @@ enum OPTIONS
     OPT_COLORKEY,
     OPT_TONEMAP,
     OPT_X2_BIAS,
+    OPT_ALPHA_COVERAGE,
     OPT_MAX
 };
 
@@ -167,6 +168,7 @@ const SValue g_pOptions[] =
     { L"c",             OPT_COLORKEY },
     { L"tonemap",       OPT_TONEMAP },
     { L"x2bias",        OPT_X2_BIAS },
+    { L"alphacoverage", OPT_ALPHA_COVERAGE },    
     { nullptr,          0 }
 };
 
@@ -691,6 +693,9 @@ namespace
         wprintf(L"   -c <hex-RGB>        colorkey (a.k.a. chromakey) transparency\n");
         wprintf(L"   -tonemap            Apply a tonemap operator based on maximum luminance\n");
         wprintf(L"   -x2bias             Enable *2 - 1 conversion cases for unorm/pos-only-float\n");
+        wprintf(L"   -alphacoverage      The alpha coverage threshold to use when computing mipmaps.\n"
+                L"                       (0.0 to 1.0, where 1.0 or greater will disable the feature).\n"
+                L"                       (defaults to 1.0)\n");
 
         wprintf(L"\n   <format>: ");
         PrintList(13, g_pFormats);
@@ -889,6 +894,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     bool wicLossless = false;
     bool useColorKey = false;
     DWORD colorKey = 0;
+    float alphaCoverageRatio = 1.0f;
 
     wchar_t szPrefix[MAX_PATH];
     wchar_t szSuffix[MAX_PATH];
@@ -953,6 +959,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             case OPT_NORMAL_MAP_AMPLITUDE:
             case OPT_WIC_QUALITY:
             case OPT_COLORKEY:
+            case OPT_ALPHA_COVERAGE:
                 if (!*pValue)
                 {
                     if ((iArg + 1 >= argc))
@@ -1278,6 +1285,24 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 
             case OPT_X2_BIAS:
                 dwConvert |= TEX_FILTER_FLOAT_X2BIAS;
+                break;
+
+            case OPT_ALPHA_COVERAGE:
+                if (swscanf_s(pValue, L"%f", &alphaCoverageRatio) != 1)
+                {
+                    wprintf(L"Invalid value specified with -alphacoverage (%s)\n", pValue);
+                    wprintf(L"\n");
+                    PrintUsage();
+                    return 1;
+                }
+
+                if (alphaCoverageRatio < 0.0f)
+                {
+                    wprintf(L"Invalid value specified with -alphacoverage (%s). Value must be positive.\n", pValue);
+                    wprintf(L"\n");
+                    PrintUsage();
+                    return 1;
+                }
                 break;
             }
         }
@@ -1970,7 +1995,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             }
             else
             {
-                hr = GenerateMipMaps(image->GetImages(), image->GetImageCount(), image->GetMetadata(), dwFilter | dwFilterOpts, tMips, *timage);
+                hr = GenerateMipMaps(image->GetImages(), image->GetImageCount(), image->GetMetadata(), dwFilter | dwFilterOpts, tMips, *timage, alphaCoverageRatio);
             }
             if (FAILED(hr))
             {


### PR DESCRIPTION
Alpha coverage increases alpha accuracy at lower mip levels by scaling the alpha channel based upon the alpha coverage of the original image.

Alpha coverage takes a ratio between 0 and 1, Any number greater than 1 disables alpha coverage.
The default value (if the command line option is not supplied) is 1, disabling the feature by default.

This technique allows noisy textures (such as leaves on a tree) to retain a high accuracy in the mips when compared against the original source image.

An overview of the technique implemented can be found here: http://the-witness.net/news/2010/09/computing-alpha-mipmaps/
However, some optimizations have been made, as well as using multi-sampling from the source image to give a smoother distribution within the alpha of the mips.