### PR TITLE
Added support for linear color space PNG writing

### DIFF
--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -588,6 +588,17 @@ namespace
                     value.bVal = 0;
                     (void)metawriter->SetMetadataByName(L"/sRGB/RenderingIntent", &value);
                 }
+                // linear space.
+                else
+                {
+                    // add gAMA chunk with gamma 1.0
+                    value.vt = VT_UI4;
+                    value.uintVal = 100000; // gama value * 100,000 -- i.e. gamma 1.0
+                    (void)metawriter->SetMetadataByName( L"/gAMA/ImageGamma", &value );
+
+                    // remove sRGB chunk which is added by default.
+                    (void)metawriter->RemoveMetadataByName(L"/sRGB/RenderingIntent");
+                }
             }
 #if defined(_XBOX_ONE) && defined(_TITLE)
             else if (memcmp(&containerFormat, &GUID_ContainerFormatJpeg, sizeof(GUID)) == 0)


### PR DESCRIPTION
I noticed that if srgb is not set for the texture formet, the PNG writer will still put an sRGB/RenderingIntent into the PNG header, and will not have a correct gamma value of 1.0. I added code that works for my application.