### PR TITLE
Fix compiler errors (Clang 5.0.0)

### DIFF
--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -3649,7 +3649,7 @@ namespace
                 if ( norm && clampzero ) v = XMVectorSaturate( v ) ; \
                 else if ( clampzero ) v = XMVectorClamp( v, g_XMZero, scalev ); \
                 else if ( norm ) v = XMVectorClamp( v, g_XMNegativeOne, g_XMOne ); \
-                else v = XMVectorClamp( v, -scalev + g_XMOne, scalev ); \
+                else v = XMVectorClamp( v, XMVectorAdd( XMVectorNegate( scalev ), g_XMOne ), scalev ); \
                 v = XMVectorAdd( v, vError ); \
                 if ( norm ) v = XMVectorMultiply( v, scalev ); \
                 \
@@ -3674,7 +3674,7 @@ namespace
                 } \
                 \
                 target = XMVectorMin( scalev, target ); \
-                target = XMVectorMax( (clampzero) ? g_XMZero : ( -scalev + g_XMOne ), target ); \
+                target = XMVectorMax( (clampzero) ? g_XMZero : ( XMVectorAdd( XMVectorNegate( scalev ), g_XMOne ) ), target ); \
                 \
                 XMFLOAT4A tmp; \
                 XMStoreFloat4A( &tmp, target ); \
@@ -3704,7 +3704,7 @@ namespace
                 if ( norm && clampzero ) v = XMVectorSaturate( v ) ; \
                 else if ( clampzero ) v = XMVectorClamp( v, g_XMZero, scalev ); \
                 else if ( norm ) v = XMVectorClamp( v, g_XMNegativeOne, g_XMOne ); \
-                else v = XMVectorClamp( v, -scalev + g_XMOne, scalev ); \
+                else v = XMVectorClamp( v, XMVectorAdd( XMVectorNegate( scalev ), g_XMOne ), scalev ); \
                 v = XMVectorAdd( v, vError ); \
                 if ( norm ) v = XMVectorMultiply( v, scalev ); \
                 \
@@ -3729,7 +3729,7 @@ namespace
                 } \
                 \
                 target = XMVectorMin( scalev, target ); \
-                target = XMVectorMax( (clampzero) ? g_XMZero : ( -scalev + g_XMOne ), target ); \
+                target = XMVectorMax( (clampzero) ? g_XMZero : ( XMVectorAdd( XMVectorNegate( scalev ), g_XMOne ) ), target ); \
                 \
                 XMFLOAT4A tmp; \
                 XMStoreFloat4A( &tmp, target ); \
@@ -3757,7 +3757,7 @@ namespace
                 if ( norm && clampzero ) v = XMVectorSaturate( v ) ; \
                 else if ( clampzero ) v = XMVectorClamp( v, g_XMZero, scalev ); \
                 else if ( norm ) v = XMVectorClamp( v, g_XMNegativeOne, g_XMOne ); \
-                else v = XMVectorClamp( v, -scalev + g_XMOne, scalev ); \
+                else v = XMVectorClamp( v,  XMVectorAdd( XMVectorNegate( scalev ), g_XMOne ), scalev ); \
                 v = XMVectorAdd( v, vError ); \
                 if ( norm ) v = XMVectorMultiply( v, scalev ); \
                 \
@@ -3782,7 +3782,7 @@ namespace
                 } \
                 \
                 target = XMVectorMin( scalev, target ); \
-                target = XMVectorMax( (clampzero) ? g_XMZero : ( -scalev + g_XMOne ), target ); \
+                target = XMVectorMax( (clampzero) ? g_XMZero : (  XMVectorAdd( XMVectorNegate( scalev ), g_XMOne ) ), target ); \
                 \
                 auto dPtr = &dest[ index ]; \
                 if (dPtr >= ePtr) break; \

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -3661,9 +3661,9 @@ namespace
                     if (norm) vError = XMVectorDivide( vError, scalev ); \
                     \
                     /* Distribute error to next scanline and next pixel */ \
-                    pDiffusionErrors[ index-delta ]   += XMVectorMultiply( g_ErrorWeight3, vError ); \
-                    pDiffusionErrors[ index+1 ]       += XMVectorMultiply( g_ErrorWeight5, vError ); \
-                    pDiffusionErrors[ index+2+delta ] += XMVectorMultiply( g_ErrorWeight1, vError ); \
+                    pDiffusionErrors[ index-delta ]   = XMVectorMultiplyAdd( g_ErrorWeight3, vError, pDiffusionErrors[ index-delta ] ); \
+                    pDiffusionErrors[ index+1 ]       = XMVectorMultiplyAdd( g_ErrorWeight5, vError, pDiffusionErrors[ index+1 ] ); \
+                    pDiffusionErrors[ index+2+delta ] = XMVectorMultiplyAdd( g_ErrorWeight1, vError, pDiffusionErrors[ index+2+delta ] ); \
                     vError = XMVectorMultiply( vError, g_ErrorWeight7 ); \
                 } \
                 else \
@@ -3716,9 +3716,9 @@ namespace
                     if (norm) vError = XMVectorDivide( vError, scalev ); \
                     \
                     /* Distribute error to next scanline and next pixel */ \
-                    pDiffusionErrors[ index-delta ]   += XMVectorMultiply( g_ErrorWeight3, vError ); \
-                    pDiffusionErrors[ index+1 ]       += XMVectorMultiply( g_ErrorWeight5, vError ); \
-                    pDiffusionErrors[ index+2+delta ] += XMVectorMultiply( g_ErrorWeight1, vError ); \
+                    pDiffusionErrors[ index-delta ]   = XMVectorMultiplyAdd( g_ErrorWeight3, vError, pDiffusionErrors[ index-delta ] ); \
+                    pDiffusionErrors[ index+1 ]       = XMVectorMultiplyAdd( g_ErrorWeight5, vError, pDiffusionErrors[ index+1 ] ); \
+                    pDiffusionErrors[ index+2+delta ] = XMVectorMultiplyAdd( g_ErrorWeight1, vError, pDiffusionErrors[ index+2+delta ] ); \
                     vError = XMVectorMultiply( vError, g_ErrorWeight7 ); \
                 } \
                 else \
@@ -3769,9 +3769,9 @@ namespace
                     if (norm) vError = XMVectorDivide( vError, scalev ); \
                     \
                     /* Distribute error to next scanline and next pixel */ \
-                    pDiffusionErrors[ index-delta ]   += XMVectorMultiply( g_ErrorWeight3, vError ); \
-                    pDiffusionErrors[ index+1 ]       += XMVectorMultiply( g_ErrorWeight5, vError ); \
-                    pDiffusionErrors[ index+2+delta ] += XMVectorMultiply( g_ErrorWeight1, vError ); \
+                    pDiffusionErrors[ index-delta ]   = XMVectorMultiplyAdd( g_ErrorWeight3, vError, pDiffusionErrors[ index-delta ] ); \
+                    pDiffusionErrors[ index+1 ]       = XMVectorMultiplyAdd( g_ErrorWeight5, vError, pDiffusionErrors[ index+1 ] ); \
+                    pDiffusionErrors[ index+2+delta ] = XMVectorMultiplyAdd( g_ErrorWeight1, vError, pDiffusionErrors[ index+2+delta ] ); \
                     vError = XMVectorMultiply( vError, g_ErrorWeight7 ); \
                 } \
                 else \
@@ -3897,9 +3897,9 @@ bool DirectX::_StoreScanlineDither(
                     vError = XMVectorDivide(vError, Scale);
 
                     // Distribute error to next scanline and next pixel
-                    pDiffusionErrors[index - delta] += XMVectorMultiply(g_ErrorWeight3, vError);
-                    pDiffusionErrors[index + 1] += XMVectorMultiply(g_ErrorWeight5, vError);
-                    pDiffusionErrors[index + 2 + delta] += XMVectorMultiply(g_ErrorWeight1, vError);
+                    pDiffusionErrors[index - delta]     = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1]         = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
                     vError = XMVectorMultiply(vError, g_ErrorWeight7);
                 }
                 else
@@ -3976,9 +3976,9 @@ bool DirectX::_StoreScanlineDither(
                     vError = XMVectorDivide(vError, Scale);
 
                     // Distribute error to next scanline and next pixel
-                    pDiffusionErrors[index - delta] += XMVectorMultiply(g_ErrorWeight3, vError);
-                    pDiffusionErrors[index + 1] += XMVectorMultiply(g_ErrorWeight5, vError);
-                    pDiffusionErrors[index + 2 + delta] += XMVectorMultiply(g_ErrorWeight1, vError);
+                    pDiffusionErrors[index - delta]     = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1]         = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
                     vError = XMVectorMultiply(vError, g_ErrorWeight7);
                 }
                 else
@@ -4064,9 +4064,9 @@ bool DirectX::_StoreScanlineDither(
                     vError = XMVectorDivide(vError, g_Scale565pc);
 
                     // Distribute error to next scanline and next pixel
-                    pDiffusionErrors[index - delta] += XMVectorMultiply(g_ErrorWeight3, vError);
-                    pDiffusionErrors[index + 1] += XMVectorMultiply(g_ErrorWeight5, vError);
-                    pDiffusionErrors[index + 2 + delta] += XMVectorMultiply(g_ErrorWeight1, vError);
+                    pDiffusionErrors[index - delta]     = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1]         = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
                     vError = XMVectorMultiply(vError, g_ErrorWeight7);
                 }
                 else
@@ -4113,9 +4113,9 @@ bool DirectX::_StoreScanlineDither(
                     vError = XMVectorDivide(vError, g_Scale5551pc);
 
                     // Distribute error to next scanline and next pixel
-                    pDiffusionErrors[index - delta] += XMVectorMultiply(g_ErrorWeight3, vError);
-                    pDiffusionErrors[index + 1] += XMVectorMultiply(g_ErrorWeight5, vError);
-                    pDiffusionErrors[index + 2 + delta] += XMVectorMultiply(g_ErrorWeight1, vError);
+                    pDiffusionErrors[index - delta]     = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1]         = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
                     vError = XMVectorMultiply(vError, g_ErrorWeight7);
                 }
                 else
@@ -4168,9 +4168,9 @@ bool DirectX::_StoreScanlineDither(
                     vError = XMVectorDivide(vError, g_Scale8pc);
 
                     // Distribute error to next scanline and next pixel
-                    pDiffusionErrors[index - delta] += XMVectorMultiply(g_ErrorWeight3, vError);
-                    pDiffusionErrors[index + 1] += XMVectorMultiply(g_ErrorWeight5, vError);
-                    pDiffusionErrors[index + 2 + delta] += XMVectorMultiply(g_ErrorWeight1, vError);
+                    pDiffusionErrors[index - delta]     = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1]         = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
                     vError = XMVectorMultiply(vError, g_ErrorWeight7);
                 }
                 else
@@ -4223,9 +4223,9 @@ bool DirectX::_StoreScanlineDither(
                     vError = XMVectorDivide(vError, g_Scale4pc);
 
                     // Distribute error to next scanline and next pixel
-                    pDiffusionErrors[index - delta] += XMVectorMultiply(g_ErrorWeight3, vError);
-                    pDiffusionErrors[index + 1] += XMVectorMultiply(g_ErrorWeight5, vError);
-                    pDiffusionErrors[index + 2 + delta] += XMVectorMultiply(g_ErrorWeight1, vError);
+                    pDiffusionErrors[index - delta]     = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1]         = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
                     vError = XMVectorMultiply(vError, g_ErrorWeight7);
                 }
                 else

--- a/DirectXTex/Filters.h
+++ b/DirectXTex/Filters.h
@@ -201,7 +201,7 @@ inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool w
     a1 = XMVectorSubtract( a1, XMVectorMultiply( g_cubicSixth, d3 ) ); \
     XMVECTOR a2 = XMVectorAdd( XMVectorMultiply( g_cubicHalf, d0 ), XMVectorMultiply( g_cubicHalf, d2 ) ); \
     XMVECTOR a3 = XMVectorSubtract( XMVectorMultiply( g_cubicSixth, d3 ), XMVectorMultiply( g_cubicSixth, d0 ) ); \
-    d3 = XMVectorSubtract( d3, XMVectorMultiply( g_cubicHalf, d2 ) ); \
+    a3 = XMVectorSubtract( a3, XMVectorMultiply( g_cubicHalf, d2 ) ); \
     XMVECTOR vdx = XMVectorReplicate( dx ); \
     XMVECTOR vdx2 = XMVectorMultiply( vdx, vdx ); \
     XMVECTOR vdx3 = XMVectorMultiply( vdx2, vdx ); \

--- a/DirectXTex/Filters.h
+++ b/DirectXTex/Filters.h
@@ -102,15 +102,17 @@ inline void _CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool 
 }
 
 #define BILINEAR_INTERPOLATE( res, x, y, r0, r1 ) \
-    res = ( y.weight0 * ( (r0)[ x.u0 ] * x.weight0 + (r0)[ x.u1 ] * x.weight1 ) ) \
-          + ( y.weight1 * ( (r1)[ x.u0 ] * x.weight0 + (r1)[ x.u1 ] * x.weight1 ) )
+    res = XMVectorAdd( XMVectorScale( XMVectorAdd( XMVectorScale( (r0)[ x.u0 ], x.weight0 ), XMVectorScale( (r0)[ x.u1 ], x.weight1 ) ), y.weight0 ), \
+                       XMVectorScale( XMVectorAdd( XMVectorScale( (r1)[ x.u0 ], x.weight0 ), XMVectorScale( (r1)[ x.u1 ], x.weight1 ) ), y.weight1 ) )
 
 #define TRILINEAR_INTERPOLATE( res, x, y, z, r0, r1, r2, r3 ) \
-    res = ( z.weight0 * ( ( y.weight0 * ( (r0)[ x.u0 ] * x.weight0 + (r0)[ x.u1 ] * x.weight1 ) ) \
-                          + ( y.weight1 * ( (r1)[ x.u0 ] * x.weight0 + (r1)[ x.u1 ] * x.weight1 ) ) ) ) \
-          + ( z.weight1 * ( ( y.weight0 * ( (r2)[ x.u0 ] * x.weight0 + (r2)[ x.u1 ] * x.weight1 ) ) \
-                             + ( y.weight1 * ( (r3)[ x.u0 ] * x.weight0 + (r3)[ x.u1 ] * x.weight1 ) ) ) )
-
+{\
+    XMVECTOR a0 = XMVectorScale( XMVectorAdd( XMVectorScale( (r0)[ x.u0 ], x.weight0 ), XMVectorScale( (r0)[ x.u1 ], x.weight1 ) ), y.weight0 ); \
+    XMVECTOR a1 = XMVectorScale( XMVectorAdd( XMVectorScale( (r1)[ x.u0 ], x.weight0 ), XMVectorScale( (r1)[ x.u1 ], x.weight1 ) ), y.weight1 ); \
+    XMVECTOR a2 = XMVectorScale( XMVectorAdd( XMVectorScale( (r2)[ x.u0 ], x.weight0 ), XMVectorScale( (r2)[ x.u1 ], x.weight1 ) ), y.weight0 ); \
+    XMVECTOR a3 = XMVectorScale( XMVectorAdd( XMVectorScale( (r3)[ x.u0 ], x.weight0 ), XMVectorScale( (r3)[ x.u1 ], x.weight1 ) ), y.weight1 ); \
+    res = XMVectorAdd( XMVectorScale( XMVectorAdd( a0, a1 ), z.weight0 ), XMVectorScale( XMVectorAdd( a2, a3 ), z.weight1 ) ); \
+}
 
 //-------------------------------------------------------------------------------------
 // Cubic filtering helpers
@@ -192,16 +194,18 @@ inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool w
 #define CUBIC_INTERPOLATE( res, dx, p0, p1, p2, p3 ) \
 { \
     XMVECTOR a0 = (p1); \
-    XMVECTOR d0 = (p0) - a0; \
-    XMVECTOR d2 = (p2) - a0; \
-    XMVECTOR d3 = (p3) - a0; \
-    XMVECTOR a1 = d2 - XMVectorMultiply( g_cubicThird, d0 ) - XMVectorMultiply( g_cubicSixth, d3 ); \
-    XMVECTOR a2 = XMVectorMultiply( g_cubicHalf, d0 ) + XMVectorMultiply( g_cubicHalf, d2 ); \
-    XMVECTOR a3 = XMVectorMultiply( g_cubicSixth, d3 ) - XMVectorMultiply( g_cubicSixth, d0 ) - XMVectorMultiply( g_cubicHalf, d2 ); \
+    XMVECTOR d0 = XMVectorSubtract( p0, a0 ); \
+    XMVECTOR d2 = XMVectorSubtract( p2, a0 ); \
+    XMVECTOR d3 = XMVectorSubtract( p3, a0 ); \
+    XMVECTOR a1 = XMVectorSubtract( d2, XMVectorMultiply( g_cubicThird, d0 ) ); \
+    a1 = XMVectorSubtract( a1, XMVectorMultiply( g_cubicSixth, d3 ) ); \
+    XMVECTOR a2 = XMVectorAdd( XMVectorMultiply( g_cubicHalf, d0 ), XMVectorMultiply( g_cubicHalf, d2 ) ); \
+    XMVECTOR a3 = XMVectorSubtract( XMVectorMultiply( g_cubicSixth, d3 ), XMVectorMultiply( g_cubicSixth, d0 ) ); \
+    d3 = XMVectorSubtract( d3, XMVectorMultiply( g_cubicHalf, d2 ) ); \
     XMVECTOR vdx = XMVectorReplicate( dx ); \
-    XMVECTOR vdx2 = vdx * vdx; \
-    XMVECTOR vdx3 = vdx2 * vdx; \
-    res = a0 + a1*vdx + a2*vdx2 + a3*vdx3; \
+    XMVECTOR vdx2 = XMVectorMultiply( vdx, vdx ); \
+    XMVECTOR vdx3 = XMVectorMultiply( vdx2, vdx ); \
+    res = XMVectorAdd( XMVectorAdd( XMVectorAdd( a0, XMVectorMultiply( a1, vdx ) ), XMVectorMultiply( a2, vdx2 ) ), XMVectorMultiply( a3, vdx3 ) ); \
 }
 
 

--- a/DirectXTex/Filters.h
+++ b/DirectXTex/Filters.h
@@ -195,9 +195,9 @@ inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool w
     XMVECTOR d0 = (p0) - a0; \
     XMVECTOR d2 = (p2) - a0; \
     XMVECTOR d3 = (p3) - a0; \
-    XMVECTOR a1 = d2 - g_cubicThird*d0 - g_cubicSixth*d3; \
-    XMVECTOR a2 = g_cubicHalf*d0 + g_cubicHalf*d2; \
-    XMVECTOR a3 = g_cubicSixth*d3 - g_cubicSixth*d0 - g_cubicHalf*d2;  \
+    XMVECTOR a1 = d2 - XMVectorMultiply( g_cubicThird, d0 ) - XMVectorMultiply( g_cubicSixth, d3 ); \
+    XMVECTOR a2 = XMVectorMultiply( g_cubicHalf, d0 ) + XMVectorMultiply( g_cubicHalf, d2 ); \
+    XMVECTOR a3 = XMVectorMultiply( g_cubicSixth, d3 ) - XMVectorMultiply( g_cubicSixth, d0 ) - XMVectorMultiply( g_cubicHalf, d2 ); \
     XMVECTOR vdx = XMVectorReplicate( dx ); \
     XMVECTOR vdx2 = vdx * vdx; \
     XMVECTOR vdx3 = vdx2 * vdx; \


### PR DESCRIPTION
Hello,
I'm trying to compile DirectXTex with Clang 5 (inside Visual Studio 2017) but I'm getting errors:

In file included from DirectXTex\DirectXTex_Z.cpp:15:
DirectXTex/DirectXTexConvert.cpp(3851,9): error : use of overloaded operator '-' is ambiguous (operand type 'const DirectX::XMVECTORF32')

I propose this fix, but maybe a better thing to do is to fix FXMVECTOR operators ?