### PR TITLE
pbit related quality fix for BC7 texture encoding

### DIFF
--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -36,6 +36,7 @@ enum BC_FLAGS
     BC_FLAGS_UNIFORM            = 0x40000,  // By default, uses perceptual weighting for BC1-3; this flag makes it a uniform weighting
     BC_FLAGS_USE_3SUBSETS       = 0x80000,  // By default, BC7 skips mode 0 & 2; this flag adds those modes back
     BC_FLAGS_FORCE_BC7_MODE6    = 0x100000, // BC7 should only use mode 6; skip other modes
+    BC_FLAGS_FASTER_BC7         = 0x200000, // BC7 should try much less harder, but still use most modes - ~10x faster
 };
 
 //-------------------------------------------------------------------------------------

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -854,7 +854,7 @@ namespace
             _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex[],
             _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex2[]);
        float Refine(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uRotation, _In_ size_t uIndexMode);
-       void FixEndpointPBits(_In_ const EncodeParams* pEP, _In_ const LDREndPntPair *pOrigEndpoints, _Out_writes_(3) LDREndPntPair *pFixedEndpoints);
+       void FixEndpointPBits(_In_ const EncodeParams* pEP, _In_reads_(BC7_MAX_REGIONS) const LDREndPntPair *pOrigEndpoints, _Out_writes_(BC7_MAX_REGIONS) LDREndPntPair *pFixedEndpoints);
 
         float MapColors(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA aColors[], _In_ size_t np, _In_ size_t uIndexMode,
             _In_ const LDREndPntPair& endPts, _In_ float fMinErr) const;

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -854,7 +854,7 @@ namespace
             _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex[],
             _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex2[]);
        float Refine(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uRotation, _In_ size_t uIndexMode);
-       void FixEndpointPBits(const EncodeParams* pEP, const LDREndPntPair *pOrigEndpoints, LDREndPntPair *pFixedEndpoints);
+       void FixEndpointPBits(_In_ const EncodeParams* pEP, _In_ const LDREndPntPair *pOrigEndpoints, _Out_writes_(3) LDREndPntPair *pFixedEndpoints);
 
         float MapColors(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA aColors[], _In_ size_t np, _In_ size_t uIndexMode,
             _In_ const LDREndPntPair& endPts, _In_ float fMinErr) const;

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -853,7 +853,8 @@ namespace
             _In_reads_(BC7_MAX_REGIONS) const LDREndPntPair aEndPts[],
             _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex[],
             _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex2[]);
-        float Refine(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uRotation, _In_ size_t uIndexMode);
+       float Refine(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uRotation, _In_ size_t uIndexMode);
+       void FixEndpointPBits(const EncodeParams* pEP, const LDREndPntPair *pOrigEndpoints, LDREndPntPair *pFixedEndpoints);
 
         float MapColors(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA aColors[], _In_ size_t np, _In_ size_t uIndexMode,
             _In_ const LDREndPntPair& endPts, _In_ float fMinErr) const;
@@ -3226,14 +3227,96 @@ void D3DX_BC7::EmitBlock(const EncodeParams* pEP, size_t uShape, size_t uRotatio
     assert(uStartBit == 128);
 }
 
+// Adjusts the endpoints with the actual pbits that would be used to encode this block.
+_Use_decl_annotations_
+void D3DX_BC7::FixEndpointPBits(const EncodeParams* pEP, const LDREndPntPair *pOrigEndpoints, LDREndPntPair *pFixedEndpoints)
+{
+	const size_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+
+	pFixedEndpoints[0] = pOrigEndpoints[0];
+	pFixedEndpoints[1] = pOrigEndpoints[1];
+	pFixedEndpoints[2] = pOrigEndpoints[2];
+
+	const size_t uPBits = ms_aInfo[pEP->uMode].uPBits;
+		
+	if (uPBits)
+	{
+		const size_t uNumEP = size_t(1 + uPartitions) << 1;
+		uint8_t aPVote[BC7_MAX_REGIONS << 1] = { 0,0,0,0,0,0 };
+		uint8_t aCount[BC7_MAX_REGIONS << 1] = { 0,0,0,0,0,0 };
+
+		const LDRColorA RGBAPrec = ms_aInfo[pEP->uMode].RGBAPrec;
+		const LDRColorA RGBAPrecWithP = ms_aInfo[pEP->uMode].RGBAPrecWithP;
+
+		for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+		{
+			uint8_t ep = 0;
+			for (uint32_t i = 0; i <= uPartitions; i++)
+			{
+				if (RGBAPrec[ch] == RGBAPrecWithP[ch])
+				{
+					pFixedEndpoints[i].A[ch] = pOrigEndpoints[i].A[ch];
+					pFixedEndpoints[i].B[ch] = pOrigEndpoints[i].B[ch];
+				}
+				else
+				{
+					pFixedEndpoints[i].A[ch] = pOrigEndpoints[i].A[ch] >> 1;
+					pFixedEndpoints[i].B[ch] = pOrigEndpoints[i].B[ch] >> 1;
+
+					size_t idx = ep++ * uPBits / uNumEP;
+					assert(idx < (BC7_MAX_REGIONS << 1));
+					_Analysis_assume_(idx < (BC7_MAX_REGIONS << 1));
+					aPVote[idx] += pOrigEndpoints[i].A[ch] & 0x01;
+					aCount[idx]++;
+					idx = ep++ * uPBits / uNumEP;
+					assert(idx < (BC7_MAX_REGIONS << 1));
+					_Analysis_assume_(idx < (BC7_MAX_REGIONS << 1));
+					aPVote[idx] += pOrigEndpoints[i].B[ch] & 0x01;
+					aCount[idx]++;
+				}
+			}
+		}
+
+		// Compute the actual pbits we'll use when we encode block. Note this is not 
+		// rounding the component indices correctly in cases the pbits != a component's LSB.
+		int pbits[BC7_MAX_REGIONS << 1];
+		for (uint32_t i = 0; i < uPBits; i++)
+			pbits[i] = aPVote[i] > (aCount[i] >> 1) ? 1 : 0;
+
+		// Now calculate the actual endpoints with proper pbits, so error calculations are accurate.
+		if (pEP->uMode == 1)
+		{
+			// shared pbits
+			for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+			{
+				for (uint32_t i = 0; i <= uPartitions; i++)
+				{
+					pFixedEndpoints[i].A[ch] = static_cast<uint8_t>((pFixedEndpoints[i].A[ch] << 1) | pbits[i]);
+					pFixedEndpoints[i].B[ch] = static_cast<uint8_t>((pFixedEndpoints[i].B[ch] << 1) | pbits[i]);
+				}
+			}
+		}
+		else
+		{
+			for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+			{
+				for (uint32_t i = 0; i <= uPartitions; i++)
+				{
+					pFixedEndpoints[i].A[ch] = static_cast<uint8_t>((pFixedEndpoints[i].A[ch] << 1) | pbits[i * 2 + 0]);
+					pFixedEndpoints[i].B[ch] = static_cast<uint8_t>((pFixedEndpoints[i].B[ch] << 1) | pbits[i * 2 + 1]);
+				}
+			}
+		}
+	}
+}
+
 _Use_decl_annotations_
 float D3DX_BC7::Refine(const EncodeParams* pEP, size_t uShape, size_t uRotation, size_t uIndexMode)
 {
     assert(pEP);
     assert(uShape < BC7_MAX_SHAPES);
     _Analysis_assume_(uShape < BC7_MAX_SHAPES);
-    const LDREndPntPair* aEndPts = pEP->aEndPts[uShape];
-
+    
     const size_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
     assert(uPartitions < BC7_MAX_REGIONS);
     _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
@@ -3247,15 +3330,25 @@ float D3DX_BC7::Refine(const EncodeParams* pEP, size_t uShape, size_t uRotation,
     float aOrgErr[BC7_MAX_REGIONS];
     float aOptErr[BC7_MAX_REGIONS];
 
+    const LDREndPntPair *aEndPts = &pEP->aEndPts[uShape][0];
+	 	 
     for (size_t p = 0; p <= uPartitions; p++)
     {
         aOrgEndPts[p].A = Quantize(aEndPts[p].A, ms_aInfo[pEP->uMode].RGBAPrecWithP);
         aOrgEndPts[p].B = Quantize(aEndPts[p].B, ms_aInfo[pEP->uMode].RGBAPrecWithP);
     }
 
-    AssignIndices(pEP, uShape, uIndexMode, aOrgEndPts, aOrgIdx, aOrgIdx2, aOrgErr);
-    OptimizeEndPoints(pEP, uShape, uIndexMode, aOrgErr, aOrgEndPts, aOptEndPts);
-    AssignIndices(pEP, uShape, uIndexMode, aOptEndPts, aOptIdx, aOptIdx2, aOptErr);
+    LDREndPntPair newEndPts1[BC7_MAX_REGIONS];
+    FixEndpointPBits(pEP, aOrgEndPts, newEndPts1);
+
+    AssignIndices(pEP, uShape, uIndexMode, newEndPts1, aOrgIdx, aOrgIdx2, aOrgErr);
+    
+    OptimizeEndPoints(pEP, uShape, uIndexMode, aOrgErr, newEndPts1, aOptEndPts);
+	 
+    LDREndPntPair newEndPts2[BC7_MAX_REGIONS];
+    FixEndpointPBits(pEP, aOptEndPts, newEndPts2);
+
+    AssignIndices(pEP, uShape, uIndexMode, newEndPts2, aOptIdx, aOptIdx2, aOptErr);
 
     float fOrgTotErr = 0, fOptTotErr = 0;
     for (size_t p = 0; p <= uPartitions; p++)
@@ -3263,16 +3356,20 @@ float D3DX_BC7::Refine(const EncodeParams* pEP, size_t uShape, size_t uRotation,
         fOrgTotErr += aOrgErr[p];
         fOptTotErr += aOptErr[p];
     }
+	 
+    float fResult = 0;
     if (fOptTotErr < fOrgTotErr)
     {
-        EmitBlock(pEP, uShape, uRotation, uIndexMode, aOptEndPts, aOptIdx, aOptIdx2);
-        return fOptTotErr;
+        EmitBlock(pEP, uShape, uRotation, uIndexMode, newEndPts2, aOptIdx, aOptIdx2);
+        fResult = fOptTotErr;
     }
     else
     {
-        EmitBlock(pEP, uShape, uRotation, uIndexMode, aOrgEndPts, aOrgIdx, aOrgIdx2);
-        return fOrgTotErr;
+        EmitBlock(pEP, uShape, uRotation, uIndexMode, newEndPts1, aOrgIdx, aOrgIdx2);
+        fResult = fOrgTotErr;
     }
+
+    return fResult;
 }
 
 _Use_decl_annotations_

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -573,6 +573,9 @@ namespace DirectX
         TEX_COMPRESS_BC7_QUICK          = 0x100000,
             // Minimal modes (usually mode 6) for BC7 compression
 
+		TEX_COMPRESS_BC7_FASTER			= 0x200000,
+			// Try less hard to encode the output in BC7, also combinable with TEX_COMPRESS_BC7_QUICK. >10x faster, still uses most modes.
+
         TEX_COMPRESS_SRGB_IN            = 0x1000000,
         TEX_COMPRESS_SRGB_OUT           = 0x2000000,
         TEX_COMPRESS_SRGB               = (TEX_COMPRESS_SRGB_IN | TEX_COMPRESS_SRGB_OUT),

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -30,7 +30,8 @@ namespace
         static_assert(static_cast<int>(TEX_COMPRESS_UNIFORM) == static_cast<int>(BC_FLAGS_UNIFORM), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
         static_assert(static_cast<int>(TEX_COMPRESS_BC7_USE_3SUBSETS) == static_cast<int>(BC_FLAGS_USE_3SUBSETS), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
         static_assert(static_cast<int>(TEX_COMPRESS_BC7_QUICK) == static_cast<int>(BC_FLAGS_FORCE_BC7_MODE6), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
-        return (compress & (BC_FLAGS_DITHER_RGB | BC_FLAGS_DITHER_A | BC_FLAGS_UNIFORM | BC_FLAGS_USE_3SUBSETS | BC_FLAGS_FORCE_BC7_MODE6));
+		static_assert(static_cast<int>(TEX_COMPRESS_BC7_FASTER) == static_cast<int>(BC_FLAGS_FASTER_BC7), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        return (compress & (BC_FLAGS_DITHER_RGB | BC_FLAGS_DITHER_A | BC_FLAGS_UNIFORM | BC_FLAGS_USE_3SUBSETS | BC_FLAGS_FORCE_BC7_MODE6 | BC_FLAGS_FASTER_BC7));
     }
 
     inline DWORD GetSRGBFlags(_In_ DWORD compress)


### PR DESCRIPTION
When I call DirectX::D3DXEncodeBC7() with DirectX::BC_FLAGS_USE_3SUBSETS, the overall output error increases across the kodim test corpus. This is incorrect: the overall error should decrease. Other BC7 encoders don't behave in this way, so I investigated further. I modified D3DX_BC7::Refine() to call D3DXDecodeBC7() on the encoded block, computed the actual error, and compared that vs. the error computed by Refine(). They differed, which is incorrect.

The bug is caused by D3DX_BC7::Refine() not correctly computing the block error in a way that factors in the actual coded pbits. It computes the error using the endpoints before the LSB's are slammed to the pbits, causing the encoder to choose blocks that actually increase error. This will wreck quality in pbit modes.

The fix introduces a new helper function D3DX_BC7::FixEndpointPBits(), which Refine() calls after it computes new endpoints. It could be easily improved further for more gains (it doesn't round the component values correctly factoring in the pbits), but it's a massive improvement.

With this fix applied the encoding quality across my test corpus increased from 44.25 to 46.02 with 3 subsets enabled, and 45.64 with 3 subsets disabled. Tested with opaque and transparent textures.