### PR TITLE
Force non-WIC paths for FP32->FP16 conversions

### DIFF
--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -4301,6 +4301,7 @@ namespace
             return false;
         }
 
+        // Check for special cases
 #if defined(_XBOX_ONE) && defined(_TITLE)
         if (sformat == DXGI_FORMAT_R16G16B16A16_FLOAT
             || sformat == DXGI_FORMAT_R16_FLOAT
@@ -4312,7 +4313,30 @@ namespace
         }
 #endif
 
-        // Check for special cases
+        switch (sformat)
+        {
+        case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        case DXGI_FORMAT_R32G32B32_FLOAT:
+        case DXGI_FORMAT_R32G32_FLOAT:
+        case DXGI_FORMAT_R32_FLOAT:
+        case DXGI_FORMAT_D32_FLOAT:
+            switch (tformat)
+            {
+            case DXGI_FORMAT_R16G16B16A16_FLOAT:
+            case DXGI_FORMAT_R16G16_FLOAT:
+            case DXGI_FORMAT_R16_FLOAT:
+                // WIC conversions for FP32->FP16 can result in NaN values instead of clamping for min/max value
+                return false;
+
+            default:
+                break;
+            }
+            break;
+
+        default:
+            break;
+        }
+
         switch (sformat)
         {
         case DXGI_FORMAT_R32G32B32A32_FLOAT:


### PR DESCRIPTION
WIC when converting FP32 values that are out of range to FP16 will end up producing NaNs, which are pretty much never good for textures. The non-WIC paths clamp values to the Min/Max range instead.

The fix was to just add another case to the ``UseWICConversion`` test function that tries to steer clear of scenarios where WIC "does the wrong thing"