### PR TITLE
DirectTexImage::IsAlphaAllOpaque() changed threshold to handle a case when opacity of pixel defined with color (254,254,254)

### DIFF
--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -764,7 +764,7 @@ bool ScratchImage::IsAlphaAllOpaque() const
         if (!scanline)
             return false;
 
-        static const XMVECTORF32 threshold = { { { 0.99f, 0.99f, 0.99f, 0.99f } } };
+        static const XMVECTORF32 threshold = { { { 0.997f, 0.997f, 0.997f, 0.997f } } };
 
         for (size_t index = 0; index < m_nimages; ++index)
         {


### PR DESCRIPTION
the threshold was changed from { 0.99f, 0.99f, 0.99f, 0.99f } to { 0.997f, 0.997f, 0.997f, 0.997f }
to handle a case when opacity of pixel defined with color (254,254,254)
 in this case alpha = { 0.996078491f, 0.996078491f, 0.996078491f, 0.996078491f }  
All others color values from 0 to 253 works fine with threshold=0.99f, only "254" has exception.