### PR TITLE
Fix compiler errors (Clang 6)

### DIFF
--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 // Experiemental encoding variants, not enabled by default
 //#define COLOR_WEIGHTS
@@ -35,9 +35,9 @@ namespace
     //-------------------------------------------------------------------------------------
     inline void Decode565(_Out_ HDRColorA *pColor, _In_ const uint16_t w565)
     {
-        pColor->r = (float)((w565 >> 11) & 31) * (1.0f / 31.0f);
-        pColor->g = (float)((w565 >> 5) & 63) * (1.0f / 63.0f);
-        pColor->b = (float)((w565 >> 0) & 31) * (1.0f / 31.0f);
+        pColor->r = static_cast<float>((w565 >> 11) & 31) * (1.0f / 31.0f);
+        pColor->g = static_cast<float>((w565 >> 5) & 63) * (1.0f / 63.0f);
+        pColor->b = static_cast<float>((w565 >> 0) & 31) * (1.0f / 31.0f);
         pColor->a = 1.0f;
     }
 
@@ -51,9 +51,10 @@ namespace
 
         uint16_t w;
 
-        w = (uint16_t)((static_cast<int32_t>(Color.r * 31.0f + 0.5f) << 11) |
-            (static_cast<int32_t>(Color.g * 63.0f + 0.5f) << 5) |
-            (static_cast<int32_t>(Color.b * 31.0f + 0.5f) << 0));
+        w = static_cast<uint16_t>(
+            (static_cast<int32_t>(Color.r * 31.0f + 0.5f) << 11)
+            | (static_cast<int32_t>(Color.g * 63.0f + 0.5f) << 5)
+            | (static_cast<int32_t>(Color.b * 31.0f + 0.5f) << 0));
 
         return w;
     }
@@ -208,7 +209,7 @@ namespace
         }
 
         // Use Newton's Method to find local minima of sum-of-squares error.
-        float fSteps = (float)(cSteps - 1);
+        auto fSteps = static_cast<float>(cSteps - 1);
 
         for (size_t iIteration = 0; iIteration < 8; iIteration++)
         {
@@ -431,9 +432,9 @@ namespace
                 Clr.b += Error[i].b;
             }
 
-            Color[i].r = (float) static_cast<int32_t>(Clr.r * 31.0f + 0.5f) * (1.0f / 31.0f);
-            Color[i].g = (float) static_cast<int32_t>(Clr.g * 63.0f + 0.5f) * (1.0f / 63.0f);
-            Color[i].b = (float) static_cast<int32_t>(Clr.b * 31.0f + 0.5f) * (1.0f / 31.0f);
+            Color[i].r = static_cast<float>(static_cast<int32_t>(Clr.r * 31.0f + 0.5f) * (1.0f / 31.0f));
+            Color[i].g = static_cast<float>(static_cast<int32_t>(Clr.g * 63.0f + 0.5f) * (1.0f / 63.0f));
+            Color[i].b = static_cast<float>(static_cast<int32_t>(Clr.b * 31.0f + 0.5f) * (1.0f / 31.0f));
 
 #ifdef COLOR_WEIGHTS
             Color[i].a = pColor[i].a;
@@ -586,7 +587,7 @@ namespace
         Dir.g = Step[1].g - Step[0].g;
         Dir.b = Step[1].b - Step[0].b;
 
-        float fSteps = (float)(uSteps - 1);
+        auto fSteps = static_cast<float>(uSteps - 1);
         float fScale = (wColorA != wColorB) ? (fSteps / (Dir.r * Dir.r + Dir.g * Dir.g + Dir.b * Dir.b)) : 0.0f;
 
         Dir.r *= fScale;
@@ -602,7 +603,7 @@ namespace
         {
             if ((3 == uSteps) && (pColor[i].a < threshold))
             {
-                dw = (3 << 30) | (dw >> 2);
+                dw = (3u << 30) | (dw >> 2);
             }
             else
             {
@@ -751,7 +752,7 @@ void DirectX::D3DXEncodeBC1(uint8_t *pBC, const XMVECTOR *pColor, float threshol
             Color[i].r = clr.r;
             Color[i].g = clr.g;
             Color[i].b = clr.b;
-            Color[i].a = (float) static_cast<int32_t>(clr.a + fError[i] + 0.5f);
+            Color[i].a = static_cast<float>(static_cast<int32_t>(clr.a + fError[i] + 0.5f));
 
             float fDiff = fAlph - Color[i].a;
 
@@ -811,13 +812,13 @@ void DirectX::D3DXDecodeBC2(XMVECTOR *pColor, const uint8_t *pBC)
     for (size_t i = 0; i < 8; ++i, dw >>= 4)
     {
 #pragma prefast(suppress:22103, "writing blocks in two halves confuses tool")
-        pColor[i] = XMVectorSetW(pColor[i], (float)(dw & 0xf) * (1.0f / 15.0f));
+        pColor[i] = XMVectorSetW(pColor[i], static_cast<float>(dw & 0xf) * (1.0f / 15.0f));
     }
 
     dw = pBC2->bitmap[1];
 
     for (size_t i = 8; i < NUM_PIXELS_PER_BLOCK; ++i, dw >>= 4)
-        pColor[i] = XMVectorSetW(pColor[i], (float)(dw & 0xf) * (1.0f / 15.0f));
+        pColor[i] = XMVectorSetW(pColor[i], static_cast<float>(dw & 0xf) * (1.0f / 15.0f));
 }
 
 _Use_decl_annotations_
@@ -845,14 +846,14 @@ void DirectX::D3DXEncodeBC2(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
         if (flags & BC_FLAGS_DITHER_A)
             fAlph += fError[i];
 
-        uint32_t u = (uint32_t) static_cast<int32_t>(fAlph * 15.0f + 0.5f);
+        auto u = static_cast<uint32_t>(fAlph * 15.0f + 0.5f);
 
         pBC2->bitmap[i >> 3] >>= 4;
         pBC2->bitmap[i >> 3] |= (u << 28);
 
         if (flags & BC_FLAGS_DITHER_A)
         {
-            float fDiff = fAlph - (float)u * (1.0f / 15.0f);
+            float fDiff = fAlph - float(u) * (1.0f / 15.0f);
 
             if (3 != (i & 3))
             {
@@ -908,8 +909,8 @@ void DirectX::D3DXDecodeBC3(XMVECTOR *pColor, const uint8_t *pBC)
     // Adaptive 3-bit alpha part
     float fAlpha[8];
 
-    fAlpha[0] = ((float)pBC3->alpha[0]) * (1.0f / 255.0f);
-    fAlpha[1] = ((float)pBC3->alpha[1]) * (1.0f / 255.0f);
+    fAlpha[0] = static_cast<float>(pBC3->alpha[0]) * (1.0f / 255.0f);
+    fAlpha[1] = static_cast<float>(pBC3->alpha[1]) * (1.0f / 255.0f);
 
     if (pBC3->alpha[0] > pBC3->alpha[1])
     {
@@ -1028,11 +1029,11 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
     float fAlphaA, fAlphaB;
     OptimizeAlpha<false>(&fAlphaA, &fAlphaB, fAlpha, uSteps);
 
-    uint8_t bAlphaA = (uint8_t) static_cast<int32_t>(fAlphaA * 255.0f + 0.5f);
-    uint8_t bAlphaB = (uint8_t) static_cast<int32_t>(fAlphaB * 255.0f + 0.5f);
+    auto bAlphaA = static_cast<uint8_t>(static_cast<int32_t>(fAlphaA * 255.0f + 0.5f));
+    auto bAlphaB = static_cast<uint8_t>(static_cast<int32_t>(fAlphaB * 255.0f + 0.5f));
 
-    fAlphaA = (float)bAlphaA * (1.0f / 255.0f);
-    fAlphaB = (float)bAlphaB * (1.0f / 255.0f);
+    fAlphaA = static_cast<float>(bAlphaA) * (1.0f / 255.0f);
+    fAlphaB = static_cast<float>(bAlphaB) * (1.0f / 255.0f);
 
     // Setup block
     if ((8 == uSteps) && (bAlphaA == bAlphaB))
@@ -1080,7 +1081,7 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
     }
 
     // Encode alpha bitmap
-    float fSteps = (float)(uSteps - 1);
+    auto fSteps = static_cast<float>(uSteps - 1);
     float fScale = (fStep[0] != fStep[1]) ? (fSteps / (fStep[1] - fStep[0])) : 0.0f;
 
     if (flags & BC_FLAGS_DITHER_A)
@@ -1130,8 +1131,8 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
             }
         }
 
-        pBC3->bitmap[0 + iSet * 3] = ((uint8_t *)&dw)[0];
-        pBC3->bitmap[1 + iSet * 3] = ((uint8_t *)&dw)[1];
-        pBC3->bitmap[2 + iSet * 3] = ((uint8_t *)&dw)[2];
+        pBC3->bitmap[0 + iSet * 3] = reinterpret_cast<uint8_t *>(&dw)[0];
+        pBC3->bitmap[1 + iSet * 3] = reinterpret_cast<uint8_t *>(&dw)[1];
+        pBC3->bitmap[2 + iSet * 3] = reinterpret_cast<uint8_t *>(&dw)[2];
     }
 }

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -216,7 +216,7 @@ template <bool bRange> void OptimizeAlpha(float *pX, float *pY, const float *pPo
     }
 
     // Use Newton's Method to find local minima of sum-of-squares error.
-    float fSteps = (float)(cSteps - 1);
+    auto fSteps = static_cast<float>(cSteps - 1);
 
     for (size_t iIteration = 0; iIteration < 8; iIteration++)
     {

--- a/DirectXTex/BC4BC5.cpp
+++ b/DirectXTex/BC4BC5.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #include "BC.h"
 
@@ -70,13 +70,13 @@ namespace
 
         size_t GetIndex(size_t uOffset) const
         {
-            return (size_t)((data >> (3 * uOffset + 16)) & 0x07);
+            return static_cast<size_t>((data >> (3 * uOffset + 16)) & 0x07);
         }
 
         void SetIndex(size_t uOffset, size_t uIndex)
         {
-            data &= ~((uint64_t)0x07 << (3 * uOffset + 16));
-            data |= ((uint64_t)uIndex << (3 * uOffset + 16));
+            data &= ~(uint64_t(0x07) << (3 * uOffset + 16));
+            data |= (uint64_t(uIndex) << (3 * uOffset + 16));
         }
 
         union
@@ -129,13 +129,13 @@ namespace
 
         size_t GetIndex(size_t uOffset) const
         {
-            return (size_t)((data >> (3 * uOffset + 16)) & 0x07);
+            return static_cast<size_t>((data >> (3 * uOffset + 16)) & 0x07);
         }
 
         void SetIndex(size_t uOffset, size_t uIndex)
         {
-            data &= ~((uint64_t)0x07 << (3 * uOffset + 16));
-            data |= ((uint64_t)uIndex << (3 * uOffset + 16));
+            data &= ~(uint64_t(0x07) << (3 * uOffset + 16));
+            data |= (uint64_t(uIndex) << (3 * uOffset + 16));
         }
 
         union
@@ -168,14 +168,14 @@ namespace
                 if (fVal < -1)
                     fVal = -1;    // Clamp to -1
 
-        fVal = fVal * (int8_t)(dwMostNeg - 1);
+        fVal = fVal * static_cast<int8_t>(dwMostNeg - 1);
 
         if (fVal >= 0)
             fVal += .5f;
         else
             fVal -= .5f;
 
-        *piSNorm = (int8_t)(fVal);
+        *piSNorm = static_cast<int8_t>(fVal);
     }
 
 
@@ -216,8 +216,8 @@ namespace
             // 6 interpolated color values
             OptimizeAlpha<false>(&fStart, &fEnd, theTexelsU, 8);
 
-            uint8_t iStart = static_cast<uint8_t>(fStart * 255.0f);
-            uint8_t iEnd = static_cast<uint8_t>(fEnd * 255.0f);
+            auto iStart = static_cast<uint8_t>(fStart * 255.0f);
+            auto iEnd = static_cast<uint8_t>(fEnd * 255.0f);
 
             endpointU_0 = iEnd;
             endpointU_1 = iStart;
@@ -227,8 +227,8 @@ namespace
             // 4 interpolated color values
             OptimizeAlpha<false>(&fStart, &fEnd, theTexelsU, 6);
 
-            uint8_t iStart = static_cast<uint8_t>(fStart * 255.0f);
-            uint8_t iEnd = static_cast<uint8_t>(fEnd * 255.0f);
+            auto iStart = static_cast<uint8_t>(fStart * 255.0f);
+            auto iEnd = static_cast<uint8_t>(fEnd * 255.0f);
 
             endpointU_1 = iEnd;
             endpointU_0 = iStart;

--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -7,7 +7,7 @@
 // Licensed under the MIT License.
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #include "BCDirectCompute.h"
 
@@ -427,7 +427,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
     size_t xblocks = std::max<size_t>(1, (m_width + 3) >> 2);
     size_t yblocks = std::max<size_t>(1, (m_height + 3) >> 2);
 
-    UINT num_total_blocks = static_cast<UINT>(xblocks * yblocks);
+    auto num_total_blocks = static_cast<UINT>(xblocks * yblocks);
     UINT num_blocks = num_total_blocks;
     int start_block_id = 0;
     while (num_blocks > 0)

--- a/DirectXTex/DDS.h
+++ b/DirectXTex/DDS.h
@@ -50,9 +50,11 @@ struct DDS_PIXELFORMAT
 #define DDS_BUMPDUDV    0x00080000  // DDPF_BUMPDUDV
 
 #ifndef MAKEFOURCC
-    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3) \
+                (static_cast<uint32_t>(static_cast<uint8_t>(ch0)) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch1)) << 8) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch2)) << 16) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch3)) << 24))
 #endif /* defined(MAKEFOURCC) */
 
 extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_DXT1 =

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #include "bcdirectcompute.h"
 

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 using namespace DirectX;
 using namespace DirectX::PackedVector;
@@ -52,12 +52,12 @@ namespace
 
     inline float FloatFrom7e3(uint32_t Value)
     {
-        uint32_t Mantissa = (uint32_t)(Value & 0x7F);
+        auto Mantissa = static_cast<uint32_t>(Value & 0x7F);
 
         uint32_t Exponent = (Value & 0x380);
         if (Exponent != 0)  // The value is normalized
         {
-            Exponent = (uint32_t)((Value >> 7) & 0x7);
+            Exponent = static_cast<uint32_t>((Value >> 7) & 0x7);
         }
         else if (Mantissa != 0)     // The value is denormalized
         {
@@ -74,7 +74,7 @@ namespace
         }
         else                        // The value is zero
         {
-            Exponent = (uint32_t)-124;
+            Exponent = uint32_t(-124);
         }
 
         uint32_t Result = ((Exponent + 124) << 23) | // Exponent
@@ -118,12 +118,12 @@ namespace
 
     inline float FloatFrom6e4(uint32_t Value)
     {
-        uint32_t Mantissa = (uint32_t)(Value & 0x3F);
+        uint32_t Mantissa = static_cast<uint32_t>(Value & 0x3F);
 
         uint32_t Exponent = (Value & 0x3C0);
         if (Exponent != 0)  // The value is normalized
         {
-            Exponent = (uint32_t)((Value >> 6) & 0xF);
+            Exponent = static_cast<uint32_t>((Value >> 6) & 0xF);
         }
         else if (Mantissa != 0)     // The value is denormalized
         {
@@ -140,7 +140,7 @@ namespace
         }
         else                        // The value is zero
         {
-            Exponent = (uint32_t)-120;
+            Exponent = uint32_t(-120);
         }
 
         uint32_t Result = ((Exponent + 120) << 23) | // Exponent
@@ -762,7 +762,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
     size_t size,
     DXGI_FORMAT format)
 {
-    assert(pDestination && count > 0 && (((uintptr_t)pDestination & 0xF) == 0));
+    assert(pDestination && count > 0 && ((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0));
     assert(pSource && size > 0);
     assert(IsValid(format) && !IsTypeless(format, false) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
 
@@ -828,7 +828,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                 auto sPtr = static_cast<const float*>(pSource);
                 for (size_t icount = 0; icount < (size - psize + 1); icount += psize)
                 {
-                    const uint8_t* ps8 = reinterpret_cast<const uint8_t*>(&sPtr[1]);
+                    auto ps8 = reinterpret_cast<const uint8_t*>(&sPtr[1]);
                     if (dPtr >= ePtr) break;
                     *(dPtr++) = XMVectorSet(sPtr[0], static_cast<float>(*ps8), 0.f, 1.f);
                     sPtr += 2;
@@ -863,7 +863,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
             auto sPtr = static_cast<const float*>(pSource);
             for (size_t icount = 0; icount < (size - psize + 1); icount += psize)
             {
-                const uint8_t* pg8 = reinterpret_cast<const uint8_t*>(&sPtr[1]);
+                auto pg8 = reinterpret_cast<const uint8_t*>(&sPtr[1]);
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(0.f /* typeless component assumed zero */, static_cast<float>(*pg8), 0.f, 1.f);
                 sPtr += 2;
@@ -964,8 +964,8 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
             auto sPtr = static_cast<const uint32_t*>(pSource);
             for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
             {
-                float d = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
-                float s = static_cast<float>((*sPtr & 0xFF000000) >> 24);
+                auto d = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
+                auto s = static_cast<float>((*sPtr & 0xFF000000) >> 24);
                 ++sPtr;
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(d, s, 0.f, 1.f);
@@ -980,7 +980,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
             auto sPtr = static_cast<const uint32_t*>(pSource);
             for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
             {
-                float r = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
+                auto r = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
                 ++sPtr;
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(r, 0.f /* typeless component assumed zero */, 0.f, 1.f);
@@ -995,7 +995,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
             auto sPtr = static_cast<const uint32_t*>(pSource);
             for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
             {
-                float g = static_cast<float>((*sPtr & 0xFF000000) >> 24);
+                auto g = static_cast<float>((*sPtr & 0xFF000000) >> 24);
                 ++sPtr;
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(0.f /* typeless component assumed zero */, g, 0.f, 1.f);
@@ -1325,9 +1325,9 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                 // G = 1.1678Y' - 0.3929Cb' - 0.8152Cr'
                 // B = 1.1678Y' + 2.0232Cb'
 
-                int r = static_cast<int>((76533 * y + 104905 * v + 32768) >> 16);
-                int g = static_cast<int>((76533 * y - 25747 * u - 53425 * v + 32768) >> 16);
-                int b = static_cast<int>((76533 * y + 132590 * u + 32768) >> 16);
+                auto r = static_cast<int>((76533 * y + 104905 * v + 32768) >> 16);
+                auto g = static_cast<int>((76533 * y - 25747 * u - 53425 * v + 32768) >> 16);
+                auto b = static_cast<int>((76533 * y + 132590 * u + 32768) >> 16);
 
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 1023)) / 1023.f,
@@ -1426,9 +1426,9 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                 ++sPtr;
 
                 // See Y410
-                int r = static_cast<int>((76533 * y0 + 104905 * v + 32768) >> 16);
-                int g = static_cast<int>((76533 * y0 - 25747 * u - 53425 * v + 32768) >> 16);
-                int b = static_cast<int>((76533 * y0 + 132590 * u + 32768) >> 16);
+                auto r = static_cast<int>((76533 * y0 + 104905 * v + 32768) >> 16);
+                auto g = static_cast<int>((76533 * y0 - 25747 * u - 53425 * v + 32768) >> 16);
+                auto b = static_cast<int>((76533 * y0 + 132590 * u + 32768) >> 16);
 
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 1023)) / 1023.f,
@@ -1463,9 +1463,9 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                 ++sPtr;
 
                 // See Y416
-                int r = static_cast<int>((76607 * y0 + 105006 * v + 32768) >> 16);
-                int g = static_cast<int>((76607 * y0 - 25772 * u - 53477 * v + 32768) >> 16);
-                int b = static_cast<int>((76607 * y0 + 132718 * u + 32768) >> 16);
+                auto r = static_cast<int>((76607 * y0 + 105006 * v + 32768) >> 16);
+                auto g = static_cast<int>((76607 * y0 - 25772 * u - 53477 * v + 32768) >> 16);
+                auto b = static_cast<int>((76607 * y0 + 132718 * u + 32768) >> 16);
 
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 65535)) / 65535.f,
@@ -1516,7 +1516,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                     FloatFrom7e3(sPtr->x),
                     FloatFrom7e3(sPtr->y),
                     FloatFrom7e3(sPtr->z),
-                    (float)(sPtr->v >> 30) / 3.0f
+                    static_cast<float>(sPtr->v >> 30) / 3.0f
                 } } };
 
                 ++sPtr;
@@ -1540,7 +1540,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                     FloatFrom6e4(sPtr->x),
                     FloatFrom6e4(sPtr->y),
                     FloatFrom6e4(sPtr->z),
-                    (float)(sPtr->v >> 30) / 3.0f
+                    static_cast<float>(sPtr->v >> 30) / 3.0f
                 } } };
 
                 ++sPtr;
@@ -1612,7 +1612,7 @@ bool DirectX::_StoreScanline(
     float threshold)
 {
     assert(pDestination && size > 0);
-    assert(pSource && count > 0 && (((uintptr_t)pSource & 0xF) == 0));
+    assert(pSource && count > 0 && ((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0));
     assert(IsValid(format) && !IsTypeless(format) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
 
     const XMVECTOR* __restrict sPtr = pSource;
@@ -1689,7 +1689,7 @@ bool DirectX::_StoreScanline(
                     XMFLOAT4 f;
                     XMStoreFloat4(&f, *sPtr++);
                     dPtr[0] = f.x;
-                    uint8_t* ps8 = reinterpret_cast<uint8_t*>(&dPtr[1]);
+                    auto ps8 = reinterpret_cast<uint8_t*>(&dPtr[1]);
                     ps8[0] = static_cast<uint8_t>(std::min<float>(255.f, std::max<float>(0.f, f.y)));
                     ps8[1] = ps8[2] = ps8[3] = 0;
                     dPtr += 2;
@@ -2417,7 +2417,7 @@ bool DirectX::_StoreScanline(
                 dPtr->x = FloatTo6e4(tmp.x);
                 dPtr->y = FloatTo6e4(tmp.y);
                 dPtr->z = FloatTo6e4(tmp.z);
-                dPtr->w = (uint32_t)tmp.w;
+                dPtr->w = static_cast<uint32_t>(tmp.w);
                 ++dPtr;
             }
             return true;
@@ -2645,7 +2645,7 @@ bool DirectX::_StoreScanlineLinear(
     float threshold)
 {
     assert(pDestination && size > 0);
-    assert(pSource && count > 0 && (((uintptr_t)pSource & 0xF) == 0));
+    assert(pSource && count > 0 && ((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0));
     assert(IsValid(format) && !IsTypeless(format) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
 
     switch (format)
@@ -2719,7 +2719,7 @@ bool DirectX::_LoadScanlineLinear(
     DXGI_FORMAT format,
     DWORD flags)
 {
-    assert(pDestination && count > 0 && (((uintptr_t)pDestination & 0xF) == 0));
+    assert(pDestination && count > 0 && ((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0));
     assert(pSource && size > 0);
     assert(IsValid(format) && !IsTypeless(format, false) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
 
@@ -2906,9 +2906,9 @@ DWORD DirectX::_GetConvertFlags(DXGI_FORMAT format)
     }
 #endif
 
-    ConvertData key = { format, 0 };
-    const ConvertData* in = (const ConvertData*)bsearch_s(&key, g_ConvertTable, _countof(g_ConvertTable), sizeof(ConvertData),
-        ConvertCompare, nullptr);
+    ConvertData key = { format, 0, 0 };
+    auto in = reinterpret_cast<const ConvertData*>(bsearch_s(&key, g_ConvertTable, _countof(g_ConvertTable), sizeof(ConvertData),
+        ConvertCompare, nullptr));
     return (in) ? in->flags : 0;
 }
 
@@ -2920,7 +2920,7 @@ void DirectX::_ConvertScanline(
     DXGI_FORMAT inFormat,
     DWORD flags)
 {
-    assert(pBuffer && count > 0 && (((uintptr_t)pBuffer & 0xF) == 0));
+    assert(pBuffer && count > 0 && ((reinterpret_cast<uintptr_t>(pBuffer) & 0xF) == 0));
     assert(IsValid(outFormat) && !IsTypeless(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
     assert(IsValid(inFormat) && !IsTypeless(inFormat) && !IsPlanar(inFormat) && !IsPalettized(inFormat));
 
@@ -2939,12 +2939,12 @@ void DirectX::_ConvertScanline(
 #endif
 
     // Determine conversion details about source and dest formats
-    ConvertData key = { inFormat, 0 };
-    const ConvertData* in = (const ConvertData*)bsearch_s(&key, g_ConvertTable, _countof(g_ConvertTable), sizeof(ConvertData),
-        ConvertCompare, nullptr);
+    ConvertData key = { inFormat, 0, 0 };
+    auto in = reinterpret_cast<const ConvertData*>(
+        bsearch_s(&key, g_ConvertTable, _countof(g_ConvertTable), sizeof(ConvertData), ConvertCompare, nullptr));
     key.format = outFormat;
-    const ConvertData* out = (const ConvertData*)bsearch_s(&key, g_ConvertTable, _countof(g_ConvertTable), sizeof(ConvertData),
-        ConvertCompare, nullptr);
+    auto out = reinterpret_cast<const ConvertData*>(
+        bsearch_s(&key, g_ConvertTable, _countof(g_ConvertTable), sizeof(ConvertData), ConvertCompare, nullptr));
     if (!in || !out)
     {
         assert(false);
@@ -3637,7 +3637,7 @@ namespace
             type * __restrict dest = reinterpret_cast<type*>(pDestination); \
             for(size_t i = 0; i < count; ++i) \
             { \
-                ptrdiff_t index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
+                auto index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
                 ptrdiff_t delta = (row & 1) ? -2 : 0; \
                 \
                 XMVECTOR v = sPtr[ index ]; \
@@ -3693,7 +3693,7 @@ namespace
             type * __restrict dest = reinterpret_cast<type*>(pDestination); \
             for(size_t i = 0; i < count; ++i) \
             { \
-                ptrdiff_t index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
+                auto index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
                 ptrdiff_t delta = (row & 1) ? -2 : 0; \
                 \
                 XMVECTOR v = sPtr[ index ]; \
@@ -3746,7 +3746,7 @@ namespace
             type * __restrict dest = reinterpret_cast<type*>(pDestination); \
             for(size_t i = 0; i < count; ++i) \
             { \
-                ptrdiff_t index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
+                auto index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
                 ptrdiff_t delta = (row & 1) ? -2 : 0; \
                 \
                 XMVECTOR v = sPtr[ index ]; \
@@ -3805,7 +3805,7 @@ bool DirectX::_StoreScanlineDither(
     XMVECTOR* pDiffusionErrors)
 {
     assert(pDestination && size > 0);
-    assert(pSource && count > 0 && (((uintptr_t)pSource & 0xF) == 0));
+    assert(pSource && count > 0 && ((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0));
     assert(IsValid(format) && !IsTypeless(format) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
 
     XMVECTOR ordered[4];
@@ -3879,7 +3879,7 @@ bool DirectX::_StoreScanlineDither(
             XMUDEC4 * __restrict dest = static_cast<XMUDEC4*>(pDestination);
             for (size_t i = 0; i < count; ++i)
             {
-                ptrdiff_t index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
                 ptrdiff_t delta = (y & 1) ? -2 : 0;
 
                 XMVECTOR v = XMVectorClamp(sPtr[index], MinXR, MaxXR);
@@ -3957,7 +3957,7 @@ bool DirectX::_StoreScanlineDither(
             uint32_t * __restrict dest = static_cast<uint32_t*>(pDestination);
             for (size_t i = 0; i < count; ++i)
             {
-                ptrdiff_t index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
                 ptrdiff_t delta = (y & 1) ? -2 : 0;
 
                 XMVECTOR v = XMVectorClamp(sPtr[index], g_XMZero, Clamp);
@@ -4044,7 +4044,7 @@ bool DirectX::_StoreScanlineDither(
             XMU565 * __restrict dest = static_cast<XMU565*>(pDestination);
             for (size_t i = 0; i < count; ++i)
             {
-                ptrdiff_t index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
                 ptrdiff_t delta = (y & 1) ? -2 : 0;
 
                 XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(sPtr[index]);
@@ -4093,7 +4093,7 @@ bool DirectX::_StoreScanlineDither(
             XMU555 * __restrict dest = static_cast<XMU555*>(pDestination);
             for (size_t i = 0; i < count; ++i)
             {
-                ptrdiff_t index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
                 ptrdiff_t delta = (y & 1) ? -2 : 0;
 
                 XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(sPtr[index]);
@@ -4148,7 +4148,7 @@ bool DirectX::_StoreScanlineDither(
             XMUBYTEN4 * __restrict dest = static_cast<XMUBYTEN4*>(pDestination);
             for (size_t i = 0; i < count; ++i)
             {
-                ptrdiff_t index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
                 ptrdiff_t delta = (y & 1) ? -2 : 0;
 
                 XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(sPtr[index]);
@@ -4204,7 +4204,7 @@ bool DirectX::_StoreScanlineDither(
             uint8_t * __restrict dest = static_cast<uint8_t*>(pDestination);
             for (size_t i = 0; i < count; ++i)
             {
-                ptrdiff_t index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
                 ptrdiff_t delta = (y & 1) ? -2 : 0;
 
                 XMVECTOR v = XMVectorSaturate(sPtr[index]);
@@ -4238,8 +4238,7 @@ bool DirectX::_StoreScanlineDither(
 
                 auto dPtr = &dest[index];
                 if (dPtr >= ePtr) break;
-                *dPtr = (static_cast<uint8_t>(tmp.x) & 0xF)
-                    | ((static_cast<uint8_t>(tmp.y) & 0xF) << 4);
+                *dPtr = static_cast<uint8_t>((unsigned(tmp.x) & 0xF) | ((unsigned(tmp.y) & 0xF) << 4));
             }
             return true;
         }

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #if !defined(_XBOX_ONE) || !defined(_TITLE)
 #include <d3d10.h>
@@ -763,7 +763,7 @@ HRESULT DirectX::CaptureTexture(
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
             desc.Usage = D3D11_USAGE_STAGING;
 
-            hr = pDevice->CreateTexture1D(&desc, 0, pStaging.GetAddressOf());
+            hr = pDevice->CreateTexture1D(&desc, nullptr, pStaging.GetAddressOf());
             if (FAILED(hr))
                 break;
 
@@ -809,7 +809,7 @@ HRESULT DirectX::CaptureTexture(
             desc.SampleDesc.Quality = 0;
 
             ComPtr<ID3D11Texture2D> pTemp;
-            hr = pDevice->CreateTexture2D(&desc, 0, pTemp.GetAddressOf());
+            hr = pDevice->CreateTexture2D(&desc, nullptr, pTemp.GetAddressOf());
             if (FAILED(hr))
                 break;
 
@@ -848,7 +848,7 @@ HRESULT DirectX::CaptureTexture(
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
             desc.Usage = D3D11_USAGE_STAGING;
 
-            hr = pDevice->CreateTexture2D(&desc, 0, pStaging.GetAddressOf());
+            hr = pDevice->CreateTexture2D(&desc, nullptr, pStaging.GetAddressOf());
             if (FAILED(hr))
                 break;
 
@@ -868,7 +868,7 @@ HRESULT DirectX::CaptureTexture(
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
             desc.Usage = D3D11_USAGE_STAGING;
 
-            hr = pDevice->CreateTexture2D(&desc, 0, &pStaging);
+            hr = pDevice->CreateTexture2D(&desc, nullptr, &pStaging);
             if (FAILED(hr))
                 break;
 
@@ -921,7 +921,7 @@ HRESULT DirectX::CaptureTexture(
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
             desc.Usage = D3D11_USAGE_STAGING;
 
-            hr = pDevice->CreateTexture3D(&desc, 0, pStaging.GetAddressOf());
+            hr = pDevice->CreateTexture3D(&desc, nullptr, pStaging.GetAddressOf());
             if (FAILED(hr))
                 break;
 

--- a/DirectXTex/DirectXTexFlipRotate.cpp
+++ b/DirectXTex/DirectXTexFlipRotate.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 //
 // In theory HDR (RGBE) Radiance files can have any of the following data orientations
@@ -175,7 +175,7 @@ namespace
                 char buff[32] = {};
                 strncpy_s(buff, info, std::min<size_t>(31, len));
 
-                float newExposure = static_cast<float>(atof(buff));
+                auto newExposure = static_cast<float>(atof(buff));
                 if ((newExposure >= 1e-12) && (newExposure <= 1e12))
                 {
                     // Note that we ignore strange exposure values (like EXPOSURE=0)
@@ -347,7 +347,7 @@ namespace
         for (size_t pixelCount = 0; pixelCount < width;)
         {
             size_t spanLen = 1;
-            const uint32_t* spanPtr = reinterpret_cast<const uint32_t*>(scanPtr);
+            auto spanPtr = reinterpret_cast<const uint32_t*>(scanPtr);
             while (pixelCount + spanLen < width && spanLen < 32767)
             {
                 if (spanPtr[spanLen] == *spanPtr)
@@ -368,7 +368,7 @@ namespace
                 if (encSize + 8 > rowPitch)
                     return 0;
 
-                uint8_t rleLen = static_cast<uint8_t>(std::min<size_t>(spanLen - 1, 255));
+                auto rleLen = static_cast<uint8_t>(std::min<size_t>(spanLen - 1, 255));
 
                 enc[0] = scanPtr[0];
                 enc[1] = scanPtr[1];
@@ -676,7 +676,7 @@ HRESULT DirectX::LoadFromHDRMemory(const void* pSource, size_t size, TexMetadata
                             return E_FAIL;
                         }
 
-                        float val = static_cast<float>(sourcePtr[1]);
+                        auto val = static_cast<float>(sourcePtr[1]);
                         for (uint8_t j = 0; j < runLen; ++j)
                         {
                             *pixelLoc = val;
@@ -696,7 +696,7 @@ HRESULT DirectX::LoadFromHDRMemory(const void* pSource, size_t size, TexMetadata
                         ++sourcePtr;
                         for (uint8_t j = 0; j < runLen; ++j)
                         {
-                            float val = static_cast<float>(*sourcePtr++);
+                            auto val = static_cast<float>(*sourcePtr++);
                             *pixelLoc = val;
                             pixelLoc += 4;
                         }
@@ -782,7 +782,7 @@ HRESULT DirectX::LoadFromHDRMemory(const void* pSource, size_t size, TexMetadata
 
         for (size_t j = 0; j < image.GetPixelsSize(); j += 16)
         {
-            int exponent = static_cast<int>(fdata[3]);
+            auto exponent = static_cast<int>(fdata[3]);
             fdata[0] = 1.0f / exposure*ldexpf((fdata[0] + 0.5f), exponent - (128 + 8));
             fdata[1] = 1.0f / exposure*ldexpf((fdata[1] + 0.5f), exponent - (128 + 8));
             fdata[2] = 1.0f / exposure*ldexpf((fdata[2] + 0.5f), exponent - (128 + 8));
@@ -909,7 +909,7 @@ HRESULT DirectX::SaveToHDRMemory(const Image& image, Blob& blob)
 
     // Copy header
     auto dPtr = static_cast<uint8_t*>(blob.GetBufferPointer());
-    assert(dPtr != 0);
+    assert(dPtr != nullptr);
     memcpy_s(dPtr, blob.GetBufferSize(), header, headerLen);
     dPtr += headerLen;
 
@@ -1024,7 +1024,7 @@ HRESULT DirectX::SaveToHDRFile(const Image& image, const wchar_t* szFile)
             return hr;
 
         // Write blob
-        const DWORD bytesToWrite = static_cast<DWORD>(blob.GetBufferSize());
+        auto bytesToWrite = static_cast<const DWORD>(blob.GetBufferSize());
         DWORD bytesWritten;
         if (!WriteFile(hFile.get(), blob.GetBufferPointer(), bytesToWrite, &bytesWritten, nullptr))
         {

--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 namespace DirectX
 {

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #include "filters.h"
 
@@ -1214,7 +1214,7 @@ namespace
                         {
                             // Steal and reuse scanline from 'free row' list
                             // (it will always be at least as wide as nwidth due to loop decending order)
-                            assert(rowFree->scanline != 0);
+                            assert(rowFree->scanline != nullptr);
                             rowAcc->scanline.reset(rowFree->scanline.release());
                             rowFree = rowFree->next;
                         }
@@ -2368,7 +2368,7 @@ namespace
                         {
                             // Steal and reuse scanline from 'free slice' list
                             // (it will always be at least as large as nwidth*nheight due to loop decending order)
-                            assert(sliceFree->scanline != 0);
+                            assert(sliceFree->scanline != nullptr);
                             sliceAcc->scanline.reset(sliceFree->scanline.release());
                             sliceFree = sliceFree->next;
                         }
@@ -2609,7 +2609,6 @@ HRESULT DirectX::GenerateMipMaps(
                 return _ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), baseImage.format, mipChain);
             }
         }
-        break;
 
         default:
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
@@ -2815,7 +2814,6 @@ HRESULT DirectX::GenerateMipMaps(
                 return _ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), metadata.format, mipChain);
             }
         }
-        break;
 
         default:
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 using namespace DirectX;
 

--- a/DirectXTex/DirectXTexNormalMaps.cpp
+++ b/DirectXTex/DirectXTexNormalMaps.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 using namespace DirectX;
 
@@ -38,7 +38,6 @@ namespace
             XMStoreFloat4A(&f, v);
             return f.x + f.y + f.z;
         }
-        break;
 
         default:
             assert(false);

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -75,6 +75,8 @@
 #include <d3d11_1.h>
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
+
 #include <directxmath.h>
 #include <directxpackedvector.h>
 #include <assert.h>

--- a/DirectXTex/DirectXTexPMAlpha.cpp
+++ b/DirectXTex/DirectXTexPMAlpha.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 using namespace DirectX;
 

--- a/DirectXTex/DirectXTexResize.cpp
+++ b/DirectXTex/DirectXTexResize.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 #include "filters.h"
 
@@ -678,7 +678,7 @@ namespace
                     if (rowFree)
                     {
                         // Steal and reuse scanline from 'free row' list
-                        assert(rowFree->scanline != 0);
+                        assert(rowFree->scanline != nullptr);
                         rowAcc->scanline.reset(rowFree->scanline.release());
                         rowFree = rowFree->next;
                     }

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 //
 // The implementation here has the following limitations:
@@ -41,8 +41,6 @@ namespace
         TGA_FLAGS_INTERLEAVED_2WAY = 0x40, // Deprecated
         TGA_FLAGS_INTERLEAVED_4WAY = 0x80, // Deprecated
     };
-
-    const char* g_TGA20_Signature = "TRUEVISION-XFILE.";
 
 #pragma pack(push,1)
     struct TGA_HEADER
@@ -373,7 +371,7 @@ namespace
                         if (sPtr + 1 >= endPtr)
                             return E_FAIL;
 
-                        uint16_t t = *sPtr | (*(sPtr + 1) << 8);
+                        auto t = static_cast<uint16_t>(unsigned(*sPtr) | (*(sPtr + 1u) << 8));
                         if (t & 0x8000)
                             nonzeroa = true;
                         sPtr += 2;
@@ -405,7 +403,7 @@ namespace
                             if (x >= image->width)
                                 return E_FAIL;
 
-                            uint16_t t = *sPtr | (*(sPtr + 1) << 8);
+                            auto t = static_cast<uint16_t>(unsigned(*sPtr) | (*(sPtr + 1u) << 8));
                             if (t & 0x8000)
                                 nonzeroa = true;
                             sPtr += 2;
@@ -650,7 +648,7 @@ namespace
                     if (sPtr + 1 >= endPtr)
                         return E_FAIL;
 
-                    uint16_t t = *sPtr | (*(sPtr + 1) << 8);
+                    auto t = static_cast<uint16_t>(unsigned(*sPtr) | (*(sPtr + 1u) << 8));
                     sPtr += 2;
                     *dPtr = t;
 
@@ -860,7 +858,7 @@ HRESULT DirectX::GetMetadataFromTGAMemory(
         return E_INVALIDARG;
 
     size_t offset;
-    return DecodeTGAHeader(pSource, size, metadata, offset, 0);
+    return DecodeTGAHeader(pSource, size, metadata, offset, nullptr);
 }
 
 _Use_decl_annotations_
@@ -908,7 +906,7 @@ HRESULT DirectX::GetMetadataFromTGAFile(const wchar_t* szFile, TexMetadata& meta
     }
 
     size_t offset;
-    return DecodeTGAHeader(header, bytesRead, metadata, offset, 0);
+    return DecodeTGAHeader(header, bytesRead, metadata, offset, nullptr);
 }
 
 
@@ -1029,7 +1027,7 @@ HRESULT DirectX::LoadFromTGAFile(
         return hr;
 
     // Read the pixels
-    DWORD remaining = static_cast<DWORD>(fileInfo.EndOfFile.LowPart - offset);
+    auto remaining = static_cast<DWORD>(fileInfo.EndOfFile.LowPart - offset);
     if (remaining == 0)
         return E_FAIL;
 
@@ -1037,7 +1035,7 @@ HRESULT DirectX::LoadFromTGAFile(
     {
         // Skip past the id string
         LARGE_INTEGER filePos = { { static_cast<DWORD>(offset), 0 } };
-        if (!SetFilePointerEx(hFile.get(), filePos, 0, FILE_BEGIN))
+        if (!SetFilePointerEx(hFile.get(), filePos, nullptr, FILE_BEGIN))
         {
             return HRESULT_FROM_WIN32(GetLastError());
         }
@@ -1091,7 +1089,7 @@ HRESULT DirectX::LoadFromTGAFile(
 
             for (size_t h = 0; h < img->height; ++h)
             {
-                const uint32_t* sPtr = reinterpret_cast<const uint32_t*>(pPixels);
+                auto sPtr = reinterpret_cast<const uint32_t*>(pPixels);
 
                 for (size_t x = 0; x < img->width; ++x)
                 {
@@ -1149,7 +1147,7 @@ HRESULT DirectX::LoadFromTGAFile(
 
             for (size_t h = 0; h < img->height; ++h)
             {
-                const uint16_t* sPtr = reinterpret_cast<const uint16_t*>(pPixels);
+                auto sPtr = reinterpret_cast<const uint16_t*>(pPixels);
 
                 for (size_t x = 0; x < img->width; ++x)
                 {
@@ -1264,7 +1262,7 @@ HRESULT DirectX::SaveToTGAMemory(const Image& image, Blob& blob)
 
     // Copy header
     auto dPtr = static_cast<uint8_t*>(blob.GetBufferPointer());
-    assert(dPtr != 0);
+    assert(dPtr != nullptr);
     memcpy_s(dPtr, blob.GetBufferSize(), &tga_header, sizeof(TGA_HEADER));
     dPtr += sizeof(TGA_HEADER);
 

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "directxtexp.h"
+#include "DirectXTexp.h"
 
 //-------------------------------------------------------------------------------------
 // IStream support for WIC Memory routines
@@ -62,7 +62,7 @@
     #pragma prefast(suppress:6387 28196, "a simple wrapper around an existing annotated function" );
     static inline HRESULT CreateMemoryStream(_Outptr_ IStream** stream)
     {
-        return CreateStreamOnHGlobal(0, TRUE, stream);
+        return CreateStreamOnHGlobal(nullptr, TRUE, stream);
     }
 
 #endif
@@ -1167,7 +1167,7 @@ HRESULT DirectX::SaveToWICMemory(
         return hr;
 
     LARGE_INTEGER li = {};
-    hr = stream->Seek(li, STREAM_SEEK_SET, 0);
+    hr = stream->Seek(li, STREAM_SEEK_SET, nullptr);
     if (FAILED(hr))
         return hr;
 
@@ -1224,7 +1224,7 @@ HRESULT DirectX::SaveToWICMemory(
         return hr;
 
     LARGE_INTEGER li = {};
-    hr = stream->Seek(li, STREAM_SEEK_SET, 0);
+    hr = stream->Seek(li, STREAM_SEEK_SET, nullptr);
     if (FAILED(hr))
         return hr;
 

--- a/DirectXTex/Filters.h
+++ b/DirectXTex/Filters.h
@@ -63,7 +63,7 @@ inline void _CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool 
 {
     assert(source > 0);
     assert(dest > 0);
-    assert(lf != 0);
+    assert(lf != nullptr);
 
     float scale = float(source) / float(dest);
 
@@ -163,7 +163,7 @@ inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool w
 {
     assert(source > 0);
     assert(dest > 0);
-    assert(cf != 0);
+    assert(cf != nullptr);
 
     float scale = float(source) / float(dest);
 
@@ -294,7 +294,7 @@ namespace TriangleFilter
             tf->totalSize = totalSize;
         }
 
-        assert(pFilter != 0);
+        assert(pFilter != nullptr);
         _Analysis_assume_(pFilter != 0);
 
         // Filter setup


### PR DESCRIPTION
Fix for ``InitOnceExecuteOnce`` failing to build with clang x86.

Also various code review cleanup based on clang warnings.
