### PR TITLE
fix EncodeBC1 floating point exception

### DIFF
--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -569,14 +569,14 @@ namespace
         {
             pSteps = pSteps3;
 
-            HDRColorALerp(&Step[2], &Step[0], &Step[1], 0.5f);
+            HDRColorALerpRGB(&Step[2], &Step[0], &Step[1], 0.5f);
         }
         else
         {
             pSteps = pSteps4;
 
-            HDRColorALerp(&Step[2], &Step[0], &Step[1], 1.0f / 3.0f);
-            HDRColorALerp(&Step[3], &Step[0], &Step[1], 2.0f / 3.0f);
+            HDRColorALerpRGB(&Step[2], &Step[0], &Step[1], 1.0f / 3.0f);
+            HDRColorALerpRGB(&Step[3], &Step[0], &Step[1], 2.0f / 3.0f);
         }
 
         // Calculate color direction

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -141,6 +141,14 @@ inline HDRColorA* HDRColorALerp(_Out_ HDRColorA *pOut, _In_ const HDRColorA *pC1
     return pOut;
 }
 
+inline HDRColorA* HDRColorALerpRGB(_Out_ HDRColorA *pOut, _In_ const HDRColorA *pC1, _In_ const HDRColorA *pC2, _In_ float s)
+{
+	pOut->r = pC1->r + s * (pC2->r - pC1->r);
+	pOut->g = pC1->g + s * (pC2->g - pC1->g);
+	pOut->b = pC1->b + s * (pC2->b - pC1->b);
+	return pOut;
+}
+
 #pragma pack(push,1)
 // BC1/DXT1 compression (4 bits per texel)
 struct D3DX_BC1


### PR DESCRIPTION
Floating point exception sometimes happens when calling HDRColorALerp() in EncodeBC1() which lerp the uninitialized (and unused) alpha value.