### PR TITLE
Fix out-of-bounds read

### DIFF
--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -1318,7 +1318,7 @@ namespace
                 uint32_t iStep;
                 if (fDot <= 0.0f)
                     iStep = 0;
-                if (fDot >= fSteps)
+                else if (fDot >= fSteps)
                     iStep = cSteps - 1;
                 else
                     iStep = uint32_t(fDot + 0.5f);
@@ -1504,7 +1504,7 @@ namespace
                 uint32_t iStep;
                 if (fDot <= 0.0f)
                     iStep = 0;
-                if (fDot >= fSteps)
+                else if (fDot >= fSteps)
                     iStep = cSteps - 1;
                 else
                     iStep = uint32_t(fDot + 0.5f);


### PR DESCRIPTION
Fix OOB memory read.

To reproduce, download this file:
https://github.com/knarkowicz/GPURealTimeBC6H/blob/master/bin/yucca.dds

Then run:
texconv.exe -nogpu -f BC6H_SF16 -m 1 -y yucca.dds

At some points, fDot will be -1.2, causing iStep to underflow, causing a crash.