### PR TITLE
Added WIC_FLAGS_FORCE_SRGB / LINEAR flags for WIC writer

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -194,6 +194,9 @@ namespace DirectX
         WIC_FLAGS_IGNORE_SRGB           = 0x20,
             // Ignores sRGB metadata if present in the file
 
+        WIC_FLAGS_FORCE_SRGB            = 0x40,
+            // Writes sRGB metadata into the file reguardless of format
+
         WIC_FLAGS_DITHER                = 0x10000,
             // Use ordered 4x4 dithering for any required conversions
 

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -197,6 +197,9 @@ namespace DirectX
         WIC_FLAGS_FORCE_SRGB            = 0x40,
             // Writes sRGB metadata into the file reguardless of format
 
+        WIC_FLAGS_FORCE_LINEAR          = 0x80,
+            // Writes linear gamma metadata into the file reguardless of format
+
         WIC_FLAGS_DITHER                = 0x10000,
             // Use ordered 4x4 dithering for any required conversions
 

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -570,6 +570,7 @@ namespace
     // Encodes image metadata
     //-------------------------------------------------------------------------------------
     HRESULT EncodeMetadata(
+        DWORD flags,
         _In_ IWICBitmapFrameEncode* frame,
         const GUID& containerFormat,
         DXGI_FORMAT format)
@@ -584,7 +585,7 @@ namespace
             PROPVARIANT value;
             PropVariantInit(&value);
 
-            bool sRGB = IsSRGB(format);
+            bool sRGB = IsSRGB(format) || (flags & WIC_FLAGS_FORCE_SRGB) != 0;
 
             value.vt = VT_LPSTR;
             value.pszVal = const_cast<char*>("DirectXTex");
@@ -715,7 +716,7 @@ namespace
             return E_FAIL;
         }
 
-        hr = EncodeMetadata(frame, containerFormat, image.format);
+        hr = EncodeMetadata(flags, frame, containerFormat, image.format);
         if (FAILED(hr))
             return hr;
 

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -585,7 +585,7 @@ namespace
             PROPVARIANT value;
             PropVariantInit(&value);
 
-            bool sRGB = IsSRGB(format) || (flags & WIC_FLAGS_FORCE_SRGB) != 0;
+            bool sRGB = ((flags & WIC_FLAGS_FORCE_LINEAR) == 0) && ((flags & WIC_FLAGS_FORCE_SRGB) != 0 || IsSRGB(format));
 
             value.vt = VT_LPSTR;
             value.pszVal = const_cast<char*>("DirectXTex");


### PR DESCRIPTION
There was already a ``WIC_FLAGS_IGNORE_SRGB`` to ignore sRGB metadata on the reader, but wasn't any way to force the writing of sRGB metadata on the writer when the input format is *not* 8:8:8:8 which has a ``DXGI_*_SRGB`` equivalent format (i.e. there is no ``_SRGB`` equivalent of say ``DXGI_FORMAT_R10G10B10A2_UNORM``).

This adds ``WIC_FLAGS_FORCE_SRGB`` which forces the writing of the sRGB metadata chunk instead of the gAMA 1.0 chunk. ``WIC_FLAGS_FORCE_LINEAR`` does the opposite.

> This flag only applies to PNG, JPEG, and TIFF WIC container formats.