### PR TITLE
Prevent shift overflow in FloatTo7e3/FloatTo6e4 denormal conversion

### DIFF
--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -37,7 +37,7 @@ namespace
             {
                 // The number is too small to be represented as a normalized 7e3.
                 // Convert it to a denormalized value.
-                uint32_t Shift = 125U - (IValue >> 23U);
+                uint32_t Shift = std::min<uint32_t>(125U - (IValue >> 23U), 24U);
                 IValue = (0x800000U | (IValue & 0x7FFFFFU)) >> Shift;
             }
             else
@@ -103,7 +103,7 @@ namespace
             {
                 // The number is too small to be represented as a normalized 6e4.
                 // Convert it to a denormalized value.
-                uint32_t Shift = 121U - (IValue >> 23U);
+                uint32_t Shift = std::min<uint32_t>(121U - (IValue >> 23U), 24U);
                 IValue = (0x800000U | (IValue & 0x7FFFFFU)) >> Shift;
             }
             else


### PR DESCRIPTION
Shifting uint32_t by an amount larger than 31 has undefined behavior across different platforms, and while AMD64 returns 0 when there's overflow, some platforms — including Direct3D shaders and PowerPC — only use the lower 5 bits.

This may cause floats with exponent smaller than -33 to be converted to 7e3 incorrectly, resulting in non-zero values when the number is totally too small to be represented as 7e3, and for 6e4 this may happen when the exponent is smaller than -37.

I've noticed this issue when I was testing similar code for 20e4 in a shader — when the float32 value was zero, the shift amount was 113 — which has a remainder of 17 when divided by 32 — so the 0x800000 part was kept, and I got 8 instead of 0 in the result.

This fix limits the shift amount to 24, which is the maximum possible number of bits in the shifted value.