### PR TITLE
Fix version number in VS2019 solution files

### DIFF
--- a/DirectXTex_Desktop_2019.sln
+++ b/DirectXTex_Desktop_2019.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2020
+# Visual Studio 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTex", "DirectXTex\DirectXTex_Desktop_2019.vcxproj", "{371B9FA9-4C90-4AC6-A123-ACED756D6C77}"
 EndProject

--- a/DirectXTex_Desktop_2019_Win10.sln
+++ b/DirectXTex_Desktop_2019_Win10.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2020
+# Visual Studio 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTex", "DirectXTex\DirectXTex_Desktop_2019_Win10.vcxproj", "{371B9FA9-4C90-4AC6-A123-ACED756D6C77}"
 EndProject


### PR DESCRIPTION
Without this change the Visual Studio Version Selector will try to open these solutions with Visual Studio 2017 and fail to find the v142 toolchain. Version number used is from the 16.0.0 release and used in new solutions created with that version of the IDE. No additional changes were required for individual project files.