### PR TITLE
Add CMake project and fix clang warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Release
 x64
 /Tests
 /wiki
+/DirectXTex/out

--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 // Experiemental encoding variants, not enabled by default
 //#define COLOR_WEIGHTS

--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -398,11 +398,11 @@ namespace
                 return;
             }
 
-            uSteps = (uColorKey > 0) ? 3 : 4;
+            uSteps = (uColorKey > 0) ? 3u : 4u;
         }
         else
         {
-            uSteps = 4;
+            uSteps = 4u;
         }
 
         // Quantize block to R56B5, using Floyd Stienberg error diffusion.  This 
@@ -929,12 +929,12 @@ void DirectX::D3DXDecodeBC3(XMVECTOR *pColor, const uint8_t *pBC)
         fAlpha[7] = 1.0f;
     }
 
-    DWORD dw = pBC3->bitmap[0] | (pBC3->bitmap[1] << 8) | (pBC3->bitmap[2] << 16);
+    DWORD dw = uint32_t(pBC3->bitmap[0]) | uint32_t(pBC3->bitmap[1] << 8) | uint32_t(pBC3->bitmap[2] << 16);
 
     for (size_t i = 0; i < 8; ++i, dw >>= 3)
         pColor[i] = XMVectorSetW(pColor[i], fAlpha[dw & 0x7]);
 
-    dw = pBC3->bitmap[3] | (pBC3->bitmap[4] << 8) | (pBC3->bitmap[5] << 16);
+    dw = uint32_t(pBC3->bitmap[3]) | uint32_t(pBC3->bitmap[4] << 8) | uint32_t(pBC3->bitmap[5] << 16);
 
     for (size_t i = 8; i < NUM_PIXELS_PER_BLOCK; ++i, dw >>= 3)
         pColor[i] = XMVectorSetW(pColor[i], fAlpha[dw & 0x7]);
@@ -1027,7 +1027,7 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
     }
 
     // Optimize and Quantize Min and Max values
-    uint32_t uSteps = ((0.0f == fMinAlpha) || (1.0f == fMaxAlpha)) ? 6 : 8;
+    uint32_t uSteps = ((0.0f == fMinAlpha) || (1.0f == fMaxAlpha)) ? 6u : 8u;
 
     float fAlphaA, fAlphaB;
     OptimizeAlpha<false>(&fAlphaA, &fAlphaB, fAlpha, uSteps);
@@ -1106,9 +1106,9 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
 
             uint32_t iStep;
             if (fDot <= 0.0f)
-                iStep = ((6 == uSteps) && (fAlph <= fStep[0] * 0.5f)) ? 6 : 0;
+                iStep = ((6 == uSteps) && (fAlph <= fStep[0] * 0.5f)) ? 6u : 0u;
             else if (fDot >= fSteps)
-                iStep = ((6 == uSteps) && (fAlph >= (fStep[1] + 1.0f) * 0.5f)) ? 7 : 1;
+                iStep = ((6 == uSteps) && (fAlph >= (fStep[1] + 1.0f) * 0.5f)) ? 7u : 1u;
             else
                 iStep = uint32_t(pSteps[uint32_t(fDot + 0.5f)]);
 

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -249,9 +249,9 @@ template <bool bRange> void OptimizeAlpha(float *pX, float *pY, const float *pPo
 
             uint32_t iStep;
             if (fDot <= 0.0f)
-                iStep = ((6 == cSteps) && (pPoints[iPoint] <= fX * 0.5f)) ? 6 : 0;
+                iStep = ((6 == cSteps) && (pPoints[iPoint] <= fX * 0.5f)) ? 6u : 0u;
             else if (fDot >= fSteps)
-                iStep = ((6 == cSteps) && (pPoints[iPoint] >= (fY + 1.0f) * 0.5f)) ? 7 : (cSteps - 1);
+                iStep = ((6 == cSteps) && (pPoints[iPoint] >= (fY + 1.0f) * 0.5f)) ? 7u : (cSteps - 1);
             else
                 iStep = uint32_t(fDot + 0.5f);
 

--- a/DirectXTex/BC4BC5.cpp
+++ b/DirectXTex/BC4BC5.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "BC.h"
 
@@ -159,7 +159,7 @@ namespace
     {
         const uint32_t dwMostNeg = (1 << (8 * sizeof(int8_t) - 1));
 
-        if (_isnan(fVal))
+        if (isnan(fVal))
             fVal = 0;
         else
             if (fVal > 1)

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "BC.h"
 

--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -7,7 +7,7 @@
 // Licensed under the MIT License.
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "BCDirectCompute.h"
 

--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -434,7 +434,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
 
     auto num_total_blocks = static_cast<UINT>(xblocks * yblocks);
     UINT num_blocks = num_total_blocks;
-    int start_block_id = 0;
+    UINT start_block_id = 0;
     while (num_blocks > 0)
     {
         UINT n = std::min<UINT>(num_blocks, MAX_BLOCK_BATCH);

--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -449,7 +449,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
             ConstantsBC6HBC7 param;
             param.tex_width = static_cast<UINT>(srcImage.width);
             param.num_block_x = static_cast<UINT>(xblocks);
-            param.format = m_bcformat;
+            param.format = static_cast<UINT>(m_bcformat);
             param.mode_id = 0;
             param.start_block_id = start_block_id;
             param.num_total_blocks = num_total_blocks;
@@ -487,7 +487,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
                         ConstantsBC6HBC7 param;
                         param.tex_width = static_cast<UINT>(srcImage.width);
                         param.num_block_x = static_cast<UINT>(xblocks);
-                        param.format = m_bcformat;
+                        param.format = static_cast<UINT>(m_bcformat);
                         param.mode_id = modes[i];
                         param.start_block_id = start_block_id;
                         param.num_total_blocks = num_total_blocks;
@@ -522,7 +522,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
                         ConstantsBC6HBC7 param;
                         param.tex_width = static_cast<UINT>(srcImage.width);
                         param.num_block_x = static_cast<UINT>(xblocks);
-                        param.format = m_bcformat;
+                        param.format = static_cast<UINT>(m_bcformat);
                         param.mode_id = modes[i];
                         param.start_block_id = start_block_id;
                         param.num_total_blocks = num_total_blocks;
@@ -562,7 +562,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
                     ConstantsBC6HBC7 param;
                     param.tex_width = static_cast<UINT>(srcImage.width);
                     param.num_block_x = static_cast<UINT>(xblocks);
-                    param.format = m_bcformat;
+                    param.format = static_cast<UINT>(m_bcformat);
                     param.mode_id = i;
                     param.start_block_id = start_block_id;
                     param.num_total_blocks = num_total_blocks;

--- a/DirectXTex/CMakeLists.txt
+++ b/DirectXTex/CMakeLists.txt
@@ -16,7 +16,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 
-# Add source to this project's executable.
 add_library (directxtex STATIC
     BC.h
     BCDirectCompute.h
@@ -56,4 +55,5 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     target_compile_options( directxtex PRIVATE /Wall /fp:fast /permissive- /Zc:__cplusplus )
 endif()
 
+# Windows 10 is used here to build the DirectX 12 code paths as well as 11
 add_compile_definitions(_UNICODE UNICODE _WIN32_WINNT=0x0A00)

--- a/DirectXTex/CMakeLists.txt
+++ b/DirectXTex/CMakeLists.txt
@@ -1,0 +1,59 @@
+﻿# DirectX Texture Library
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+cmake_minimum_required (VERSION 3.8)
+project (DirectXTex_CMake LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
+
+# Add source to this project's executable.
+add_library (directxtex STATIC
+    BC.h
+    BCDirectCompute.h
+    d3dx12.h
+    DDS.h
+    DirectXTex.h
+    DirectXTexP.h
+    filters.h
+    scoped.h
+    BC.cpp
+    BC4BC5.cpp
+    BC6HBC7.cpp
+    BCDirectCompute.cpp
+    DirectXTexCompress.cpp
+    DirectXTexCompressGPU.cpp
+    DirectXTexConvert.cpp
+    DirectXTexD3D11.cpp
+    DirectXTexD3D12.cpp
+    DirectXTexDDS.cpp
+    DirectXTexFlipRotate.cpp
+    DirectXTexHDR.cpp
+    DirectXTexImage.cpp
+    DirectXTexMipmaps.cpp
+    DirectXTexMisc.cpp
+    DirectXTexNormalMaps.cpp
+    DirectXTexPMAlpha.cpp
+    DirectXTexResize.cpp
+    DirectXTexTGA.cpp
+    DirectXTexUtil.cpp
+    DirectXTexWIC.cpp
+)
+
+if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+    target_compile_options( directxtex PRIVATE -Wall -Wpedantic -Wextra )
+endif()
+if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
+    target_compile_options( directxtex PRIVATE /Wall )
+endif()
+
+add_compile_definitions(_UNICODE UNICODE _WIN32_WINNT=0x0A00)

--- a/DirectXTex/CMakeLists.txt
+++ b/DirectXTex/CMakeLists.txt
@@ -48,11 +48,16 @@ add_library (directxtex STATIC
     DirectXTexWIC.cpp
 )
 
+target_compile_options( directxtex PRIVATE /fp:fast )
+
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     target_compile_options( directxtex PRIVATE -Wall -Wpedantic -Wextra )
+    if (${CMAKE_SIZEOF_VOID_P} EQUAL "4")
+        target_compile_options( directxtex PRIVATE /arch:SSE2 )
+    endif()
 endif()
 if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
-    target_compile_options( directxtex PRIVATE /Wall /fp:fast /permissive- /Zc:__cplusplus )
+    target_compile_options( directxtex PRIVATE /Wall /permissive- /Zc:__cplusplus )
 endif()
 
 # Windows 10 is used here to build the DirectX 12 code paths as well as 11

--- a/DirectXTex/CMakeLists.txt
+++ b/DirectXTex/CMakeLists.txt
@@ -53,7 +53,7 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     target_compile_options( directxtex PRIVATE -Wall -Wpedantic -Wextra )
 endif()
 if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
-    target_compile_options( directxtex PRIVATE /Wall )
+    target_compile_options( directxtex PRIVATE /Wall /fp:fast /permissive- /Zc:__cplusplus )
 endif()
 
 add_compile_definitions(_UNICODE UNICODE _WIN32_WINNT=0x0A00)

--- a/DirectXTex/CMakeSettings.json
+++ b/DirectXTex/CMakeSettings.json
@@ -1,0 +1,52 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x86-Clang-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x86" ],
+      "variables": []
+    },
+    {
+      "name": "x86-Clang-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x86" ],
+      "variables": []
+    },
+    {
+      "name": "x64-Clang-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64" ],
+      "variables": []
+    },
+    {
+      "name": "x64-Clang-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -131,7 +131,7 @@ namespace DirectX
             // Helper for miscFlags
 
         bool __cdecl IsPMAlpha() const { return ((miscFlags2 & TEX_MISC2_ALPHA_MODE_MASK) == TEX_ALPHA_MODE_PREMULTIPLIED) != 0; }
-        void __cdecl SetAlphaMode(TEX_ALPHA_MODE mode) { miscFlags2 = (miscFlags2 & ~TEX_MISC2_ALPHA_MODE_MASK) | static_cast<uint32_t>(mode); }
+        void __cdecl SetAlphaMode(TEX_ALPHA_MODE mode) { miscFlags2 = (miscFlags2 & ~static_cast<uint32_t>(TEX_MISC2_ALPHA_MODE_MASK)) | static_cast<uint32_t>(mode); }
         TEX_ALPHA_MODE __cdecl GetAlphaMode() const { return static_cast<TEX_ALPHA_MODE>(miscFlags2 & TEX_MISC2_ALPHA_MODE_MASK); }
             // Helpers for miscFlags2
 

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -120,25 +120,25 @@ namespace
 
                 ptrdiff_t bytesLeft = pEnd - sptr;
                 assert(bytesLeft > 0);
-                size_t bytesToRead = std::min<size_t>(rowPitch, bytesLeft);
+                size_t bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft));
                 if (!_LoadScanline(&temp[0], pw, sptr, bytesToRead, format))
                     return E_FAIL;
 
                 if (ph > 1)
                 {
-                    bytesToRead = std::min<size_t>(rowPitch, bytesLeft - rowPitch);
+                    bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft - rowPitch));
                     if (!_LoadScanline(&temp[4], pw, sptr + rowPitch, bytesToRead, format))
                         return E_FAIL;
 
                     if (ph > 2)
                     {
-                        bytesToRead = std::min<size_t>(rowPitch, bytesLeft - rowPitch * 2);
+                        bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft - rowPitch * 2));
                         if (!_LoadScanline(&temp[8], pw, sptr + rowPitch * 2, bytesToRead, format))
                             return E_FAIL;
 
                         if (ph > 3)
                         {
-                            bytesToRead = std::min<size_t>(rowPitch, bytesLeft - rowPitch * 3);
+                            bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft - rowPitch * 3));
                             if (!_LoadScanline(&temp[12], pw, sptr + rowPitch * 3, bytesToRead, format))
                                 return E_FAIL;
                         }

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -260,7 +260,7 @@ namespace
 
             ptrdiff_t bytesLeft = pEnd - pSrc;
             assert(bytesLeft > 0);
-            size_t bytesToRead = std::min<size_t>(rowPitch, bytesLeft);
+            size_t bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft));
 
             __declspec(align(16)) XMVECTOR temp[16];
             if (!_LoadScanline(&temp[0], pw, pSrc, bytesToRead, format))
@@ -268,19 +268,19 @@ namespace
 
             if (ph > 1)
             {
-                bytesToRead = std::min<size_t>(rowPitch, bytesLeft - rowPitch);
+                bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft - rowPitch));
                 if (!_LoadScanline(&temp[4], pw, pSrc + rowPitch, bytesToRead, format))
                     fail = true;
 
                 if (ph > 2)
                 {
-                    bytesToRead = std::min<size_t>(rowPitch, bytesLeft - rowPitch * 2);
+                    bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft - rowPitch * 2));
                     if (!_LoadScanline(&temp[8], pw, pSrc + rowPitch * 2, bytesToRead, format))
                         fail = true;
 
                     if (ph > 3)
                     {
-                        bytesToRead = std::min<size_t>(rowPitch, bytesLeft - rowPitch * 3);
+                        bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft - rowPitch * 3));
                         if (!_LoadScanline(&temp[12], pw, pSrc + rowPitch * 3, bytesToRead, format))
                             fail = true;
                     }

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -126,19 +126,19 @@ namespace
 
                 if (ph > 1)
                 {
-                    bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft - rowPitch));
+                    bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch);
                     if (!_LoadScanline(&temp[4], pw, sptr + rowPitch, bytesToRead, format))
                         return E_FAIL;
 
                     if (ph > 2)
                     {
-                        bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft - rowPitch * 2));
+                        bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch * 2);
                         if (!_LoadScanline(&temp[8], pw, sptr + rowPitch * 2, bytesToRead, format))
                             return E_FAIL;
 
                         if (ph > 3)
                         {
-                            bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft - rowPitch * 3));
+                            bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch * 3);
                             if (!_LoadScanline(&temp[12], pw, sptr + rowPitch * 3, bytesToRead, format))
                                 return E_FAIL;
                         }

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "BCDirectCompute.h"
 

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 using namespace DirectX;
 using namespace DirectX::PackedVector;
@@ -3255,7 +3255,12 @@ void DirectX::_ConvertScanline(
                         break;
                     }
 
+#ifdef _MSC_VER
                     __fallthrough;
+#endif
+#ifdef __clang__
+                    [[clang::fallthrough]];
+#endif
 
                 case TEX_FILTER_RGB_COPY_RED:
                 {
@@ -3539,7 +3544,12 @@ void DirectX::_ConvertScanline(
                     break;
                 }
 
+#ifdef _MSC_VER
                 __fallthrough;
+#endif
+#ifdef __clang__
+                [[clang::fallthrough]];
+#endif
 
             case TEX_FILTER_RGB_COPY_RED:
             {
@@ -3632,7 +3642,12 @@ void DirectX::_ConvertScanline(
                         break;
                     }
 
+#ifdef _MSC_VER
                     __fallthrough;
+#endif
+#ifdef __clang__
+                    [[clang::fallthrough]];
+#endif
 
                 case TEX_FILTER_RGB_COPY_RED:
                     // Leave data unchanged and the store will handle this...
@@ -4547,7 +4562,7 @@ namespace
         if (FAILED(hr))
             return hr;
 
-        hr = FC->Initialize(source.Get(), targetGUID, _GetWICDither(filter), nullptr, threshold * 100.0, WICBitmapPaletteTypeMedianCut);
+        hr = FC->Initialize(source.Get(), targetGUID, _GetWICDither(filter), nullptr, static_cast<double>(threshold) * 100.0, WICBitmapPaletteTypeMedianCut);
         if (FAILED(hr))
             return hr;
 

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -392,7 +392,7 @@ void DirectX::_CopyScanline(
                     size_t size = std::min<size_t>(outSize, inSize);
                     for (size_t count = 0; count < (size - 1); count += 2)
                     {
-                        *(dPtr++) = *(sPtr++) | 0x8000;
+                        *(dPtr++) = uint16_t(*(sPtr++) | 0x8000);
                     }
                 }
             }
@@ -422,7 +422,7 @@ void DirectX::_CopyScanline(
                     size_t size = std::min<size_t>(outSize, inSize);
                     for (size_t count = 0; count < (size - 1); count += 2)
                     {
-                        *(dPtr++) = *(sPtr++) | 0xF000;
+                        *(dPtr++) = uint16_t(*(sPtr++) | 0xF000);
                     }
                 }
             }
@@ -644,9 +644,9 @@ bool DirectX::_ExpandScanline(
             {
                 uint16_t t = *(sPtr++);
 
-                uint32_t t1 = ((t & 0xf800) >> 8) | ((t & 0xe000) >> 13);
-                uint32_t t2 = ((t & 0x07e0) << 5) | ((t & 0x0600) >> 5);
-                uint32_t t3 = ((t & 0x001f) << 19) | ((t & 0x001c) << 14);
+                uint32_t t1 = uint32_t(((t & 0xf800) >> 8) | ((t & 0xe000) >> 13));
+                uint32_t t2 = uint32_t(((t & 0x07e0) << 5) | ((t & 0x0600) >> 5));
+                uint32_t t3 = uint32_t(((t & 0x001f) << 19) | ((t & 0x001c) << 14));
 
                 *(dPtr++) = t1 | t2 | t3 | 0xff000000;
             }
@@ -668,9 +668,9 @@ bool DirectX::_ExpandScanline(
             {
                 uint16_t t = *(sPtr++);
 
-                uint32_t t1 = ((t & 0x7c00) >> 7) | ((t & 0x7000) >> 12);
-                uint32_t t2 = ((t & 0x03e0) << 6) | ((t & 0x0380) << 1);
-                uint32_t t3 = ((t & 0x001f) << 19) | ((t & 0x001c) << 14);
+                uint32_t t1 = uint32_t(((t & 0x7c00) >> 7) | ((t & 0x7000) >> 12));
+                uint32_t t2 = uint32_t(((t & 0x03e0) << 6) | ((t & 0x0380) << 1));
+                uint32_t t3 = uint32_t(((t & 0x001f) << 19) | ((t & 0x001c) << 14));
                 uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0x8000) ? 0xff000000 : 0);
 
                 *(dPtr++) = t1 | t2 | t3 | ta;
@@ -693,10 +693,10 @@ bool DirectX::_ExpandScanline(
             {
                 uint16_t t = *(sPtr++);
 
-                uint32_t t1 = ((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8);
-                uint32_t t2 = ((t & 0x00f0) << 8) | ((t & 0x00f0) << 4);
-                uint32_t t3 = ((t & 0x000f) << 20) | ((t & 0x000f) << 16);
-                uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf000) << 16) | ((t & 0xf000) << 12));
+                uint32_t t1 = uint32_t(((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8));
+                uint32_t t2 = uint32_t(((t & 0x00f0) << 8) | ((t & 0x00f0) << 4));
+                uint32_t t3 = uint32_t(((t & 0x000f) << 20) | ((t & 0x000f) << 16));
+                uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf000) << 16) | ((t & 0xf000) << 12));
 
                 *(dPtr++) = t1 | t2 | t3 | ta;
             }
@@ -1348,7 +1348,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
                 int64_t u = int64_t(sPtr->x) - 32768;
                 int64_t y = int64_t(sPtr->y) - 4096;
                 int64_t v = int64_t(sPtr->z) - 32768;
-                unsigned int a = sPtr->w;
+                auto a = static_cast<int>(sPtr->w);
                 ++sPtr;
 
                 // http://msdn.microsoft.com/en-us/library/windows/desktop/bb970578.aspx
@@ -2075,7 +2075,7 @@ bool DirectX::_StoreScanline(
                 XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(*sPtr++);
                 v = XMVectorMultiply(v, s_Scale);
                 XMStoreU555(dPtr, v);
-                dPtr->w = (XMVectorGetW(v) > threshold) ? 1 : 0;
+                dPtr->w = (XMVectorGetW(v) > threshold) ? 1u : 0u;
                 ++dPtr;
             }
             return true;
@@ -3783,10 +3783,10 @@ namespace
                 \
                 auto dPtr = &dest[ index ]; \
                 if (dPtr >= ePtr) break; \
-                dPtr->x = static_cast<itype>(tmp.x) & mask; \
-                dPtr->y = static_cast<itype>(tmp.y) & mask; \
-                dPtr->z = static_cast<itype>(tmp.z) & mask; \
-                dPtr->w = static_cast<itype>(tmp.w) & mask; \
+                dPtr->x = itype(static_cast<itype>(tmp.x) & mask); \
+                dPtr->y = itype(static_cast<itype>(tmp.y) & mask); \
+                dPtr->z = itype(static_cast<itype>(tmp.z) & mask); \
+                dPtr->w = itype(static_cast<itype>(tmp.w) & mask); \
             } \
             return true; \
         } \
@@ -3838,8 +3838,8 @@ namespace
                 \
                 auto dPtr = &dest[ index ]; \
                 if (dPtr >= ePtr) break; \
-                dPtr->x = static_cast<itype>(tmp.x) & mask; \
-                dPtr->y = static_cast<itype>(tmp.y) & mask; \
+                dPtr->x = itype(static_cast<itype>(tmp.x) & mask); \
+                dPtr->y = itype(static_cast<itype>(tmp.y) & mask); \
             } \
             return true; \
         } \
@@ -3888,7 +3888,7 @@ namespace
                 \
                 auto dPtr = &dest[ index ]; \
                 if (dPtr >= ePtr) break; \
-                *dPtr = static_cast<type>((selectw) ? XMVectorGetW(target) : XMVectorGetX(target)) & mask; \
+                *dPtr = type(static_cast<type>((selectw) ? XMVectorGetW(target) : XMVectorGetX(target)) & mask); \
             } \
             return true; \
         } \
@@ -4019,9 +4019,9 @@ bool DirectX::_StoreScanlineDither(
 
                 auto dPtr = &dest[index];
                 if (dPtr >= ePtr) break;
-                dPtr->x = static_cast<uint16_t>(tmp.x) & 0x3FF;
-                dPtr->y = static_cast<uint16_t>(tmp.y) & 0x3FF;
-                dPtr->z = static_cast<uint16_t>(tmp.z) & 0x3FF;
+                dPtr->x = uint16_t(static_cast<uint16_t>(tmp.x) & 0x3FF);
+                dPtr->y = uint16_t(static_cast<uint16_t>(tmp.y) & 0x3FF);
+                dPtr->z = uint16_t(static_cast<uint16_t>(tmp.z) & 0x3FF);
                 dPtr->w = static_cast<uint16_t>(tmp.w);
             }
             return true;
@@ -4185,9 +4185,9 @@ bool DirectX::_StoreScanlineDither(
 
                 auto dPtr = &dest[index];
                 if (dPtr >= ePtr) break;
-                dPtr->x = static_cast<uint16_t>(tmp.x) & 0x1F;
-                dPtr->y = static_cast<uint16_t>(tmp.y) & 0x3F;
-                dPtr->z = static_cast<uint16_t>(tmp.z) & 0x1F;
+                dPtr->x = uint16_t(static_cast<uint16_t>(tmp.x) & 0x1F);
+                dPtr->y = uint16_t(static_cast<uint16_t>(tmp.y) & 0x3F);
+                dPtr->z = uint16_t(static_cast<uint16_t>(tmp.z) & 0x1F);
             }
             return true;
         }
@@ -4234,10 +4234,10 @@ bool DirectX::_StoreScanlineDither(
 
                 auto dPtr = &dest[index];
                 if (dPtr >= ePtr) break;
-                dPtr->x = static_cast<uint16_t>(tmp.x) & 0x1F;
-                dPtr->y = static_cast<uint16_t>(tmp.y) & 0x1F;
-                dPtr->z = static_cast<uint16_t>(tmp.z) & 0x1F;
-                dPtr->w = (XMVectorGetW(target) > threshold) ? 1 : 0;
+                dPtr->x = uint16_t(static_cast<uint16_t>(tmp.x) & 0x1F);
+                dPtr->y = uint16_t(static_cast<uint16_t>(tmp.y) & 0x1F);
+                dPtr->z = uint16_t(static_cast<uint16_t>(tmp.z) & 0x1F);
+                dPtr->w = (XMVectorGetW(target) > threshold) ? 1u : 0u;
             }
             return true;
         }
@@ -4289,9 +4289,9 @@ bool DirectX::_StoreScanlineDither(
 
                 auto dPtr = &dest[index];
                 if (dPtr >= ePtr) break;
-                dPtr->x = static_cast<uint8_t>(tmp.x) & 0xFF;
-                dPtr->y = static_cast<uint8_t>(tmp.y) & 0xFF;
-                dPtr->z = static_cast<uint8_t>(tmp.z) & 0xFF;
+                dPtr->x = uint8_t(static_cast<uint8_t>(tmp.x) & 0xFF);
+                dPtr->y = uint8_t(static_cast<uint8_t>(tmp.y) & 0xFF);
+                dPtr->z = uint8_t(static_cast<uint8_t>(tmp.z) & 0xFF);
                 dPtr->w = 0;
             }
             return true;

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -2774,7 +2774,7 @@ bool DirectX::_StoreScanlineLinear(
 
     default:
         // can't treat A8, XR, Depth, SNORM, UINT, or SINT as sRGB
-        flags &= ~TEX_FILTER_SRGB;
+        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB);
         break;
     }
 
@@ -2849,7 +2849,7 @@ bool DirectX::_LoadScanlineLinear(
 
     default:
         // can't treat A8, XR, Depth, SNORM, UINT, or SINT as sRGB
-        flags &= ~TEX_FILTER_SRGB;
+        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB);
         break;
     }
 
@@ -3060,7 +3060,7 @@ void DirectX::_ConvertScanline(
 
     case DXGI_FORMAT_A8_UNORM:
     case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
-        flags &= ~TEX_FILTER_SRGB_IN;
+        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN);
         break;
 
     default:
@@ -3081,7 +3081,7 @@ void DirectX::_ConvertScanline(
 
     case DXGI_FORMAT_A8_UNORM:
     case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
-        flags &= ~TEX_FILTER_SRGB_OUT;
+        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_OUT);
         break;
 
     default:
@@ -3090,7 +3090,7 @@ void DirectX::_ConvertScanline(
 
     if ((flags & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
     {
-        flags &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
     }
 
     // sRGB input processing (sRGB -> Linear RGB)
@@ -4502,7 +4502,7 @@ namespace
 
         if ((filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
         {
-            filter &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+            filter &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
         }
 
         DWORD wicsrgb = _CheckWICColorSpace(pfGUID, targetGUID);

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #if !defined(_XBOX_ONE) || !defined(_TITLE)
 #include <d3d10.h>

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -553,7 +553,7 @@ HRESULT DirectX::CreateTextureEx(
         desc.Usage = usage;
         desc.BindFlags = bindFlags;
         desc.CPUAccessFlags = cpuAccessFlags;
-        desc.MiscFlags = miscFlags & ~D3D11_RESOURCE_MISC_TEXTURECUBE;
+        desc.MiscFlags = miscFlags & ~static_cast<uint32_t>(D3D11_RESOURCE_MISC_TEXTURECUBE);
 
         hr = pDevice->CreateTexture1D(&desc, initData.get(), reinterpret_cast<ID3D11Texture1D**>(ppResource));
     }
@@ -575,7 +575,7 @@ HRESULT DirectX::CreateTextureEx(
         if (metadata.IsCubemap())
             desc.MiscFlags = miscFlags | D3D11_RESOURCE_MISC_TEXTURECUBE;
         else
-            desc.MiscFlags = miscFlags & ~D3D11_RESOURCE_MISC_TEXTURECUBE;
+            desc.MiscFlags = miscFlags & ~static_cast<uint32_t>(D3D11_RESOURCE_MISC_TEXTURECUBE);
 
         hr = pDevice->CreateTexture2D(&desc, initData.get(), reinterpret_cast<ID3D11Texture2D**>(ppResource));
     }
@@ -592,7 +592,7 @@ HRESULT DirectX::CreateTextureEx(
         desc.Usage = usage;
         desc.BindFlags = bindFlags;
         desc.CPUAccessFlags = cpuAccessFlags;
-        desc.MiscFlags = miscFlags & ~D3D11_RESOURCE_MISC_TEXTURECUBE;
+        desc.MiscFlags = miscFlags & ~static_cast<uint32_t>(D3D11_RESOURCE_MISC_TEXTURECUBE);
 
         hr = pDevice->CreateTexture3D(&desc, initData.get(), reinterpret_cast<ID3D11Texture3D**>(ppResource));
     }

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -883,7 +883,7 @@ HRESULT DirectX::CaptureTexture(
         mdata.depth = 1;
         mdata.arraySize = desc.ArraySize;
         mdata.mipLevels = desc.MipLevels;
-        mdata.miscFlags = (desc.MiscFlags & D3D11_RESOURCE_MISC_TEXTURECUBE) ? TEX_MISC_TEXTURECUBE : 0;
+        mdata.miscFlags = (desc.MiscFlags & D3D11_RESOURCE_MISC_TEXTURECUBE) ? TEX_MISC_TEXTURECUBE : 0u;
         mdata.miscFlags2 = 0;
         mdata.format = desc.Format;
         mdata.dimension = TEX_DIMENSION_TEXTURE2D;

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -58,13 +58,13 @@ namespace
             if (!slicePlane)
             {
                 // Plane 0
-                res.SlicePitch = res.RowPitch * height;
+                res.SlicePitch = res.RowPitch * static_cast<LONG>(height);
             }
             else
             {
                 // Plane 1
                 res.pData = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(res.pData) + res.RowPitch * height);
-                res.SlicePitch = res.RowPitch * ((height + 1) >> 1);
+                res.SlicePitch = res.RowPitch * static_cast<LONG>((height + 1) >> 1);
             }
             break;
 
@@ -72,14 +72,14 @@ namespace
             if (!slicePlane)
             {
                 // Plane 0
-                res.SlicePitch = res.RowPitch * height;
+                res.SlicePitch = res.RowPitch * static_cast<LONG>(height);
             }
             else
             {
                 // Plane 1
                 res.pData = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(res.pData) + res.RowPitch * height);
                 res.RowPitch = (res.RowPitch >> 1);
-                res.SlicePitch = res.RowPitch * height;
+                res.SlicePitch = res.RowPitch * static_cast<LONG>(height);
             }
             break;
         }
@@ -142,7 +142,7 @@ namespace
             return hr;
 
         numberOfResources = (desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D)
-                            ? 1 : desc.DepthOrArraySize;
+                            ? 1u : desc.DepthOrArraySize;
         numberOfResources *= desc.MipLevels;
         numberOfResources *= numberOfPlanes;
 
@@ -706,7 +706,7 @@ HRESULT DirectX::CaptureTexture(
             mdata.depth = 1;
             mdata.arraySize = desc.DepthOrArraySize;
             mdata.mipLevels = desc.MipLevels;
-            mdata.miscFlags = isCubeMap ? TEX_MISC_TEXTURECUBE : 0;
+            mdata.miscFlags = isCubeMap ? TEX_MISC_TEXTURECUBE : 0u;
             mdata.miscFlags2 = 0;
             mdata.format = desc.Format;
             mdata.dimension = TEX_DIMENSION_TEXTURE2D;

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -14,7 +14,6 @@
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-conversion"
-#pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
 #endif
 
 #if defined(_XBOX_ONE) && defined(_TITLE)

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -41,7 +41,7 @@ static_assert(static_cast<int>(TEX_DIMENSION_TEXTURE3D) == static_cast<int>(D3D1
 
 namespace
 {
-    template<typename T> void AdjustPlaneResource(
+    template<typename T, typename PT> void AdjustPlaneResource(
         _In_ DXGI_FORMAT fmt,
         _In_ size_t height,
         _In_ size_t slicePlane,
@@ -58,13 +58,13 @@ namespace
             if (!slicePlane)
             {
                 // Plane 0
-                res.SlicePitch = res.RowPitch * static_cast<LONG>(height);
+                res.SlicePitch = res.RowPitch * static_cast<PT>(height);
             }
             else
             {
                 // Plane 1
-                res.pData = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(res.pData) + res.RowPitch * height);
-                res.SlicePitch = res.RowPitch * static_cast<LONG>((height + 1) >> 1);
+                res.pData = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(res.pData) + res.RowPitch * PT(height));
+                res.SlicePitch = res.RowPitch * static_cast<PT>((height + 1) >> 1);
             }
             break;
 
@@ -72,14 +72,14 @@ namespace
             if (!slicePlane)
             {
                 // Plane 0
-                res.SlicePitch = res.RowPitch * static_cast<LONG>(height);
+                res.SlicePitch = res.RowPitch * static_cast<PT>(height);
             }
             else
             {
                 // Plane 1
-                res.pData = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(res.pData) + res.RowPitch * height);
+                res.pData = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(res.pData) + res.RowPitch * PT(height));
                 res.RowPitch = (res.RowPitch >> 1);
-                res.SlicePitch = res.RowPitch * static_cast<LONG>(height);
+                res.SlicePitch = res.RowPitch * static_cast<PT>(height);
             }
             break;
         }
@@ -586,7 +586,7 @@ HRESULT DirectX::PrepareUpload(
                     static_cast<LONG_PTR>(img.slicePitch)
                 };
 
-                AdjustPlaneResource(metadata.format, img.height, plane, res);
+                AdjustPlaneResource<D3D12_SUBRESOURCE_DATA, intptr_t>(metadata.format, img.height, plane, res);
 
                 subresources.emplace_back(res);
 
@@ -623,7 +623,7 @@ HRESULT DirectX::PrepareUpload(
                         static_cast<LONG_PTR>(img.slicePitch)
                     };
 
-                    AdjustPlaneResource(metadata.format, img.height, plane, res);
+                    AdjustPlaneResource<D3D12_SUBRESOURCE_DATA, intptr_t>(metadata.format, img.height, plane, res);
 
                     subresources.emplace_back(res);
                 }
@@ -786,7 +786,7 @@ HRESULT DirectX::CaptureTexture(
 
                 D3D12_MEMCPY_DEST destData = { img->pixels, img->rowPitch, img->slicePitch };
 
-                AdjustPlaneResource(img->format, img->height, plane, destData);
+                AdjustPlaneResource<D3D12_MEMCPY_DEST, uintptr_t>(img->format, img->height, plane, destData);
 
                 D3D12_SUBRESOURCE_DATA srcData =
                 {

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -9,13 +9,23 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
+#endif
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
 #include "d3dx12_x.h"
 #else
 #define D3DX12_NO_STATE_OBJECT_HELPERS
 #include "d3dx12.h"
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 
 #ifndef IID_GRAPHICS_PPV_ARGS

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "DDS.h"
 

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -328,7 +328,7 @@ namespace
 
             static_assert(static_cast<int>(TEX_MISC_TEXTURECUBE) == static_cast<int>(DDS_RESOURCE_MISC_TEXTURECUBE), "DDS header mismatch");
 
-            metadata.miscFlags = d3d10ext->miscFlag & ~TEX_MISC_TEXTURECUBE;
+            metadata.miscFlags = d3d10ext->miscFlag & ~static_cast<uint32_t>(TEX_MISC_TEXTURECUBE);
 
             switch (d3d10ext->resourceDimension)
             {
@@ -722,7 +722,7 @@ HRESULT DirectX::_EncodeDDSHeader(
 
         static_assert(static_cast<int>(TEX_MISC_TEXTURECUBE) == static_cast<int>(DDS_RESOURCE_MISC_TEXTURECUBE), "DDS header mismatch");
 
-        ext->miscFlag = metadata.miscFlags & ~TEX_MISC_TEXTURECUBE;
+        ext->miscFlag = metadata.miscFlags & ~static_cast<uint32_t>(TEX_MISC_TEXTURECUBE);
 
         if (metadata.miscFlags & TEX_MISC_TEXTURECUBE)
         {
@@ -914,7 +914,7 @@ namespace
                     uint32_t t1 = uint32_t((t & 0x00e0) | ((t & 0x00e0) >> 3) | ((t & 0x00c0) >> 6));
                     uint32_t t2 = uint32_t(((t & 0x001c) << 11) | ((t & 0x001c) << 8) | ((t & 0x0018) << 5));
                     uint32_t t3 = uint32_t(((t & 0x0003) << 22) | ((t & 0x0003) << 20) | ((t & 0x0003) << 18) | ((t & 0x0003) << 16));
-                    uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16));
+                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -957,7 +957,7 @@ namespace
                     uint16_t t = *(sPtr++);
 
                     uint32_t t1 = pal8[t & 0xff];
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16);
+                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
 
                     *(dPtr++) = t1 | ta;
                 }
@@ -1000,7 +1000,7 @@ namespace
                         uint8_t t = *(sPtr++);
 
                         uint32_t t1 = uint32_t(((t & 0x0f) << 4) | (t & 0x0f));
-                        uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf0) << 24) | ((t & 0xf0) << 20)));
+                        uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf0) << 24) | ((t & 0xf0) << 20));
 
                         *(dPtr++) = t1 | (t1 << 8) | (t1 << 16) | ta;
                     }
@@ -1024,7 +1024,7 @@ namespace
 
                 for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
                 {
-                    uint16_t t = *(sPtr++);
+                    uint32_t t = *(sPtr++);
 
                     uint32_t t1 = uint32_t((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8);
                     uint32_t t2 = uint32_t((t & 0x00f0) << 8) | ((t & 0x00f0) << 4);
@@ -1100,7 +1100,7 @@ namespace
                     uint32_t t1 = uint32_t(t & 0xff);
                     uint32_t t2 = uint32_t(t1 << 8);
                     uint32_t t3 = uint32_t(t1 << 16);
-                    uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16));
+                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -837,9 +837,9 @@ namespace
                 for (size_t ocount = 0, icount = 0; ((icount < (inSize - 2)) && (ocount < (outSize - 3))); icount += 3, ocount += 4)
                 {
                     // 24bpp Direct3D 9 files are actually BGR, so need to swizzle as well
-                    uint32_t t1 = (*(sPtr) << 16);
-                    uint32_t t2 = (*(sPtr + 1) << 8);
-                    uint32_t t3 = *(sPtr + 2);
+                    uint32_t t1 = uint32_t(*(sPtr) << 16);
+                    uint32_t t2 = uint32_t(*(sPtr + 1) << 8);
+                    uint32_t t3 = uint32_t(*(sPtr + 2));
 
                     *(dPtr++) = t1 | t2 | t3 | 0xff000000;
                     sPtr += 3;
@@ -862,9 +862,9 @@ namespace
                     {
                         uint8_t t = *(sPtr++);
 
-                        uint32_t t1 = (t & 0xe0) | ((t & 0xe0) >> 3) | ((t & 0xc0) >> 6);
-                        uint32_t t2 = ((t & 0x1c) << 11) | ((t & 0x1c) << 8) | ((t & 0x18) << 5);
-                        uint32_t t3 = ((t & 0x03) << 22) | ((t & 0x03) << 20) | ((t & 0x03) << 18) | ((t & 0x03) << 16);
+                        uint32_t t1 = uint32_t((t & 0xe0) | ((t & 0xe0) >> 3) | ((t & 0xc0) >> 6));
+                        uint32_t t2 = uint32_t(((t & 0x1c) << 11) | ((t & 0x1c) << 8) | ((t & 0x18) << 5));
+                        uint32_t t3 = uint32_t(((t & 0x03) << 22) | ((t & 0x03) << 20) | ((t & 0x03) << 18) | ((t & 0x03) << 16));
 
                         *(dPtr++) = t1 | t2 | t3 | 0xff000000;
                     }
@@ -911,10 +911,10 @@ namespace
                 {
                     uint16_t t = *(sPtr++);
 
-                    uint32_t t1 = (t & 0x00e0) | ((t & 0x00e0) >> 3) | ((t & 0x00c0) >> 6);
-                    uint32_t t2 = ((t & 0x001c) << 11) | ((t & 0x001c) << 8) | ((t & 0x0018) << 5);
-                    uint32_t t3 = ((t & 0x0003) << 22) | ((t & 0x0003) << 20) | ((t & 0x0003) << 18) | ((t & 0x0003) << 16);
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16);
+                    uint32_t t1 = uint32_t((t & 0x00e0) | ((t & 0x00e0) >> 3) | ((t & 0x00c0) >> 6));
+                    uint32_t t2 = uint32_t(((t & 0x001c) << 11) | ((t & 0x001c) << 8) | ((t & 0x0018) << 5));
+                    uint32_t t3 = uint32_t(((t & 0x0003) << 22) | ((t & 0x0003) << 20) | ((t & 0x0003) << 18) | ((t & 0x0003) << 16));
+                    uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16));
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -999,8 +999,8 @@ namespace
                     {
                         uint8_t t = *(sPtr++);
 
-                        uint32_t t1 = ((t & 0x0f) << 4) | (t & 0x0f);
-                        uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf0) << 24) | ((t & 0xf0) << 20));
+                        uint32_t t1 = uint32_t(((t & 0x0f) << 4) | (t & 0x0f));
+                        uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf0) << 24) | ((t & 0xf0) << 20)));
 
                         *(dPtr++) = t1 | (t1 << 8) | (t1 << 16) | ta;
                     }
@@ -1026,10 +1026,10 @@ namespace
                 {
                     uint16_t t = *(sPtr++);
 
-                    uint32_t t1 = ((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8);
-                    uint32_t t2 = ((t & 0x00f0) << 8) | ((t & 0x00f0) << 4);
-                    uint32_t t3 = ((t & 0x000f) << 20) | ((t & 0x000f) << 16);
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf000) << 16) | ((t & 0xf000) << 12));
+                    uint32_t t1 = uint32_t((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8);
+                    uint32_t t2 = uint32_t((t & 0x00f0) << 8) | ((t & 0x00f0) << 4);
+                    uint32_t t3 = uint32_t((t & 0x000f) << 20) | ((t & 0x000f) << 16);
+                    uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf000) << 16) | ((t & 0xf000) << 12)));
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -1097,10 +1097,10 @@ namespace
                 {
                     uint16_t t = *(sPtr++);
 
-                    uint32_t t1 = (t & 0xff);
-                    uint32_t t2 = (t1 << 8);
-                    uint32_t t3 = (t1 << 16);
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16);
+                    uint32_t t1 = uint32_t(t & 0xff);
+                    uint32_t t2 = uint32_t(t1 << 8);
+                    uint32_t t3 = uint32_t(t1 << 16);
+                    uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0xff00) << 16));
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -1184,7 +1184,7 @@ namespace
             return E_FAIL;
         }
 
-        DWORD tflags = (convFlags & CONV_FLAGS_NOALPHA) ? TEXP_SCANLINE_SETALPHA : 0;
+        DWORD tflags = (convFlags & CONV_FLAGS_NOALPHA) ? TEXP_SCANLINE_SETALPHA : 0u;
         if (convFlags & CONV_FLAGS_SWIZZLE)
             tflags |= TEXP_SCANLINE_LEGACY;
 
@@ -1406,7 +1406,7 @@ namespace
         if (IsPlanar(metadata.format))
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
-        DWORD tflags = (convFlags & CONV_FLAGS_NOALPHA) ? TEXP_SCANLINE_SETALPHA : 0;
+        DWORD tflags = (convFlags & CONV_FLAGS_NOALPHA) ? TEXP_SCANLINE_SETALPHA : 0u;
         if (convFlags & CONV_FLAGS_SWIZZLE)
             tflags |= TEXP_SCANLINE_LEGACY;
 

--- a/DirectXTex/DirectXTexFlipRotate.cpp
+++ b/DirectXTex/DirectXTexFlipRotate.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 //
 // In theory HDR (RGBE) Radiance files can have any of the following data orientations
@@ -176,7 +176,7 @@ namespace
                 strncpy_s(buff, info, std::min<size_t>(31, len));
 
                 auto newExposure = static_cast<float>(atof(buff));
-                if ((newExposure >= 1e-12) && (newExposure <= 1e12))
+                if ((newExposure >= 1e-12f) && (newExposure <= 1e12f))
                 {
                     // Note that we ignore strange exposure values (like EXPOSURE=0)
                     exposure *= newExposure;
@@ -304,7 +304,7 @@ namespace
             const float max_xy = (r > g) ? r : g;
             float max_xyz = (max_xy > b) ? max_xy : b;
 
-            if (max_xyz > 1e-32)
+            if (max_xyz > 1e-32f)
             {
                 int e;
                 max_xyz = frexpf(max_xyz, &e) * 256.f / max_xyz;

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -219,8 +219,8 @@ namespace
         {
             // We only support the -Y +X orientation (see top of file)
             return HRESULT_FROM_WIN32(
-                ((orientation[0] == '+' || orientation[0] == '-') && (orientation[1] == 'X' || orientation[1] == 'Y'))
-                ? ERROR_NOT_SUPPORTED : ERROR_INVALID_DATA
+                static_cast<unsigned long>(((orientation[0] == '+' || orientation[0] == '-') && (orientation[1] == 'X' || orientation[1] == 'Y'))
+                ? ERROR_NOT_SUPPORTED : ERROR_INVALID_DATA)
             );
         }
 
@@ -275,7 +275,7 @@ namespace
             return E_FAIL;
         }
 
-        offset = info - static_cast<const char*>(pSource);
+        offset = size_t(info - static_cast<const char*>(pSource));
 
         metadata.width = width;
         metadata.height = height;
@@ -317,7 +317,7 @@ namespace
                 pDestination[0] = red;
                 pDestination[1] = green;
                 pDestination[2] = blue;
-                pDestination[3] = (red || green || blue) ? uint8_t(e & 0xff) : 0;
+                pDestination[3] = (red || green || blue) ? uint8_t(e & 0xff) : 0u;
             }
             else
             {
@@ -473,7 +473,7 @@ namespace
                     if (encSize + 2 > rowPitch)
                         return 0;
 
-                    enc[0] = 128 + spanLen;
+                    enc[0] = 128u + spanLen;
                     enc[1] = *spanPtr;
                     enc += 2;
                     encSize += 2;
@@ -953,7 +953,7 @@ HRESULT DirectX::SaveToHDRMemory(const Image& image, Blob& blob)
     }
 #endif
 
-    hr = blob.Trim(dPtr - static_cast<uint8_t*>(blob.GetBufferPointer()));
+    hr = blob.Trim(size_t(dPtr - static_cast<uint8_t*>(blob.GetBufferPointer())));
     if (FAILED(hr))
     {
         blob.Release();

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -291,7 +291,7 @@ namespace
     //-------------------------------------------------------------------------------------
     inline void FloatToRGBE(_Out_writes_(width*4) uint8_t* pDestination, _In_reads_(width*fpp) const float* pSource, size_t width, _In_range_(3, 4) int fpp)
     {
-        auto ePtr = pSource + width * fpp;
+        auto ePtr = pSource + width * size_t(fpp);
 
         for (size_t j = 0; j < width; ++j)
         {

--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 namespace DirectX
 {

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "filters.h"
 

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 using namespace DirectX;
 

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -322,7 +322,7 @@ HRESULT DirectX::CopyRectangle(
             if (((pSrc + copyW) > pEndSrc) || (pDest > pEndDest))
                 return E_FAIL;
 
-            memcpy_s(pDest, pEndDest - pDest, pSrc, copyW);
+            memcpy_s(pDest, size_t(pEndDest - pDest), pSrc, copyW);
 
             pSrc += srcImage.rowPitch;
             pDest += dstImage.rowPitch;

--- a/DirectXTex/DirectXTexNormalMaps.cpp
+++ b/DirectXTex/DirectXTexNormalMaps.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 using namespace DirectX;
 

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -51,6 +51,23 @@
 // warning #161: unrecognized #pragma
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wc++98-compat"
+#pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#pragma clang diagnostic ignored "-Wc++98-compat-local-type-template-args"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wmissing-variable-declarations"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#endif
+
 #pragma warning(push)
 #pragma warning(disable : 4005)
 #define WIN32_LEAN_AND_MEAN

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -65,6 +65,7 @@
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #endif
 

--- a/DirectXTex/DirectXTexPMAlpha.cpp
+++ b/DirectXTex/DirectXTexPMAlpha.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 using namespace DirectX;
 

--- a/DirectXTex/DirectXTexResize.cpp
+++ b/DirectXTex/DirectXTexResize.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 #include "filters.h"
 

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 //
 // The implementation here has the following limitations:

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -373,7 +373,7 @@ namespace
                         if (sPtr + 1 >= endPtr)
                             return E_FAIL;
 
-                        auto t = static_cast<uint16_t>(unsigned(*sPtr) | (*(sPtr + 1u) << 8));
+                        auto t = static_cast<uint16_t>(uint32_t(*sPtr) | uint32_t(*(sPtr + 1u) << 8));
                         if (t & 0x8000)
                             nonzeroa = true;
                         sPtr += 2;
@@ -405,7 +405,7 @@ namespace
                             if (x >= image->width)
                                 return E_FAIL;
 
-                            auto t = static_cast<uint16_t>(unsigned(*sPtr) | (*(sPtr + 1u) << 8));
+                            auto t = static_cast<uint16_t>(uint32_t(*sPtr) | uint32_t(*(sPtr + 1u) << 8));
                             if (t & 0x8000)
                                 nonzeroa = true;
                             sPtr += 2;
@@ -462,7 +462,7 @@ namespace
                                 return E_FAIL;
 
                             // BGR -> RGBA
-                            t = (*sPtr << 16) | (*(sPtr + 1) << 8) | (*(sPtr + 2)) | 0xFF000000;
+                            t = uint32_t(*sPtr << 16) | uint32_t(*(sPtr + 1) << 8) | uint32_t(*(sPtr + 2)) | 0xFF000000;
                             sPtr += 3;
 
                             nonzeroa = true;
@@ -526,7 +526,7 @@ namespace
                                     return E_FAIL;
 
                                 // BGR -> RGBA
-                                *dPtr = (*sPtr << 16) | (*(sPtr + 1) << 8) | (*(sPtr + 2)) | 0xFF000000;
+                                *dPtr = uint32_t(*sPtr << 16) | uint32_t(*(sPtr + 1) << 8) | uint32_t(*(sPtr + 2)) | 0xFF000000;
                                 sPtr += 3;
 
                                 nonzeroa = true;
@@ -652,7 +652,7 @@ namespace
                     if (sPtr + 1 >= endPtr)
                         return E_FAIL;
 
-                    auto t = static_cast<uint16_t>(unsigned(*sPtr) | (*(sPtr + 1u) << 8));
+                    auto t = static_cast<uint16_t>(uint32_t(*sPtr) | uint32_t(*(sPtr + 1u) << 8));
                     sPtr += 2;
                     *dPtr = t;
 
@@ -698,7 +698,7 @@ namespace
                             return E_FAIL;
 
                         // BGR -> RGBA
-                        *dPtr = (*sPtr << 16) | (*(sPtr + 1) << 8) | (*(sPtr + 2)) | 0xFF000000;
+                        *dPtr = uint32_t(*sPtr << 16) | uint32_t(*(sPtr + 1) << 8) | uint32_t(*(sPtr + 2)) | 0xFF000000;
                         sPtr += 3;
 
                         nonzeroa = true;

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -475,7 +475,7 @@ namespace
                                 return E_FAIL;
 
                             // BGRA -> RGBA
-                            t = (*sPtr << 16) | (*(sPtr + 1) << 8) | (*(sPtr + 2)) | (*(sPtr + 3) << 24);
+                            t = uint32_t(*sPtr << 16) | uint32_t(*(sPtr + 1) << 8) | uint32_t(*(sPtr + 2)) | uint32_t(*(sPtr + 3) << 24);
 
                             if (*(sPtr + 3) > 0)
                                 nonzeroa = true;
@@ -539,7 +539,7 @@ namespace
                                     return E_FAIL;
 
                                 // BGRA -> RGBA
-                                *dPtr = (*sPtr << 16) | (*(sPtr + 1) << 8) | (*(sPtr + 2)) | (*(sPtr + 3) << 24);
+                                *dPtr = uint32_t(*sPtr << 16) | uint32_t(*(sPtr + 1) << 8) | uint32_t(*(sPtr + 2)) | uint32_t(*(sPtr + 3) << 24);
 
                                 if (*(sPtr + 3) > 0)
                                     nonzeroa = true;
@@ -711,7 +711,7 @@ namespace
                             return E_FAIL;
 
                         // BGRA -> RGBA
-                        *dPtr = (*sPtr << 16) | (*(sPtr + 1) << 8) | (*(sPtr + 2)) | (*(sPtr + 3) << 24);
+                        *dPtr = uint32_t(*sPtr << 16) | uint32_t(*(sPtr + 1) << 8) | uint32_t(*(sPtr + 2)) | uint32_t(*(sPtr + 3) << 24);
 
                         if (*(sPtr + 3) > 0)
                             nonzeroa = true;

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -222,7 +222,7 @@ DWORD DirectX::_CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID&
 
     if ((srgb & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
     {
-        srgb &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+        srgb &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
     }
 
     return srgb;

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -9,7 +9,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
-#include "DirectXTexp.h"
+#include "DirectXTexP.h"
 
 //-------------------------------------------------------------------------------------
 // IStream support for WIC Memory routines

--- a/DirectXTex/filters.h
+++ b/DirectXTex/filters.h
@@ -78,12 +78,12 @@ inline void _CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool 
 
         if (isrcA < 0)
         {
-            isrcA = (wrap) ? (source - 1) : 0;
+            isrcA = (wrap) ? (ptrdiff_t(source) - 1) : 0;
         }
 
         if (size_t(isrcB) >= source)
         {
-            isrcB = (wrap) ? 0 : (source - 1);
+            isrcB = (wrap) ? 0 : (ptrdiff_t(source) - 1);
         }
 
         float weight = 1.0f + float(isrcB) - srcB;
@@ -171,10 +171,10 @@ inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool w
     {
         float srcB = (float(u) + 0.5f) * scale - 0.5f;
 
-        ptrdiff_t isrcB = bounduvw(ptrdiff_t(srcB), source - 1, wrap, mirror);
-        ptrdiff_t isrcA = bounduvw(isrcB - 1, source - 1, wrap, mirror);
-        ptrdiff_t isrcC = bounduvw(isrcB + 1, source - 1, wrap, mirror);
-        ptrdiff_t isrcD = bounduvw(isrcB + 2, source - 1, wrap, mirror);
+        ptrdiff_t isrcB = bounduvw(ptrdiff_t(srcB), ptrdiff_t(source) - 1, wrap, mirror);
+        ptrdiff_t isrcA = bounduvw(isrcB - 1, ptrdiff_t(source) - 1, wrap, mirror);
+        ptrdiff_t isrcC = bounduvw(isrcB + 1, ptrdiff_t(source) - 1, wrap, mirror);
+        ptrdiff_t isrcD = bounduvw(isrcB + 2, ptrdiff_t(source) - 1, wrap, mirror);
 
         auto& entry = cf[u];
         entry.u0 = size_t(isrcA);


### PR DESCRIPTION
With VS 2019 Update 1 supporting the clang/LLVM toolset, I've formally added CMake files as well as addressed a number of clang warnings.