### PR TITLE
  Ex texture loaders updated with additional parameter validation

### DIFF
--- a/DDSTextureLoader/DDSTextureLoader.cpp
+++ b/DDSTextureLoader/DDSTextureLoader.cpp
@@ -1776,6 +1776,11 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         return E_INVALIDARG;
     }
 
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
+
     // Validate DDS file in memory
     const DDS_HEADER* header = nullptr;
     const uint8_t* bitData = nullptr;
@@ -1902,6 +1907,11 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
     }
 
     if (!d3dDevice || !fileName || (!texture && !textureView))
+    {
+        return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
     {
         return E_INVALIDARG;
     }

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -638,6 +638,9 @@ HRESULT DirectX::CreateShaderResourceViewEx(
 
     *ppSRV = nullptr;
 
+    if (!(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+        return E_INVALIDARG;
+
     ComPtr<ID3D11Resource> resource;
     HRESULT hr = CreateTextureEx(pDevice, srcImages, nimages, metadata,
         usage, bindFlags, cpuAccessFlags, miscFlags, forceSRGB,

--- a/WICTextureLoader/WICTextureLoader.cpp
+++ b/WICTextureLoader/WICTextureLoader.cpp
@@ -818,7 +818,14 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
     }
 
     if (!d3dDevice || !wicData || (!texture && !textureView))
+    {
         return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
 
     if (!wicDataSize)
         return E_FAIL;
@@ -951,7 +958,14 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
     }
 
     if (!d3dDevice || !fileName || (!texture && !textureView))
+    {
         return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
 
     auto pWIC = _GetWIC();
     if (!pWIC)


### PR DESCRIPTION
If you pass a 'non-null' value to the DDS or WIC texture loaders, but when calling the ``Ex`` version you provide a ``bindFlags`` without the ``D3D11_BIND_SHADER_RESOURCE`` then it will fail when it calls ``CreateShaderResourceView``.

This PR adds validation early in the function to catch this rather than failing later on...