### PR TITLE
Added optional forceSRGB parameter to SaveWICTextureToFile

### DIFF
--- a/ScreenGrab/ScreenGrab.cpp
+++ b/ScreenGrab/ScreenGrab.cpp
@@ -936,7 +936,8 @@ HRESULT DirectX::SaveWICTextureToFile(
     REFGUID guidContainerFormat,
     const wchar_t* fileName,
     const GUID* targetFormat,
-    std::function<void(IPropertyBag2*)> setCustomProps )
+    std::function<void(IPropertyBag2*)> setCustomProps,
+    bool forceSRGB)
 {
     if ( !fileName )
         return E_INVALIDARG;
@@ -949,7 +950,7 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     // Determine source format's WIC equivalent
     WICPixelFormatGUID pfGuid;
-    bool sRGB = false;
+    bool sRGB = forceSRGB;
     switch ( desc.Format )
     {
     case DXGI_FORMAT_R32G32B32A32_FLOAT:            pfGuid = GUID_WICPixelFormat128bppRGBAFloat; break;

--- a/ScreenGrab/ScreenGrab.h
+++ b/ScreenGrab/ScreenGrab.h
@@ -20,20 +20,22 @@
 #include <d3d11_1.h>
 
 #include <OCIdl.h>
-#include <stdint.h>
 #include <functional>
 
 
 namespace DirectX
 {
-    HRESULT SaveDDSTextureToFile( _In_ ID3D11DeviceContext* pContext,
-                                  _In_ ID3D11Resource* pSource,
-                                  _In_z_ const wchar_t* fileName );
+    HRESULT __cdecl SaveDDSTextureToFile(
+        _In_ ID3D11DeviceContext* pContext,
+        _In_ ID3D11Resource* pSource,
+        _In_z_ const wchar_t* fileName);
 
-    HRESULT SaveWICTextureToFile( _In_ ID3D11DeviceContext* pContext,
-                                  _In_ ID3D11Resource* pSource,
-                                  _In_ REFGUID guidContainerFormat, 
-                                  _In_z_ const wchar_t* fileName,
-                                  _In_opt_ const GUID* targetFormat = nullptr,
-                                  _In_opt_ std::function<void(IPropertyBag2*)> setCustomProps = nullptr );
+    HRESULT __cdecl SaveWICTextureToFile(
+        _In_ ID3D11DeviceContext* pContext,
+        _In_ ID3D11Resource* pSource,
+        _In_ REFGUID guidContainerFormat,
+        _In_z_ const wchar_t* fileName,
+        _In_opt_ const GUID* targetFormat = nullptr,
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
+        _In_ bool forceSRGB = false);
 }

--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -1050,7 +1050,8 @@ HRESULT DirectX::SaveWICTextureToFile(
     D3D12_RESOURCE_STATES beforeState,
     D3D12_RESOURCE_STATES afterState,
     const GUID* targetFormat,
-    std::function<void(IPropertyBag2*)> setCustomProps )
+    std::function<void(IPropertyBag2*)> setCustomProps,
+    bool forceSRGB)
 {
     if ( !fileName )
         return E_INVALIDARG;
@@ -1091,7 +1092,7 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     // Determine source format's WIC equivalent
     WICPixelFormatGUID pfGuid;
-    bool sRGB = false;
+    bool sRGB = forceSRGB;
     switch ( desc.Format )
     {
     case DXGI_FORMAT_R32G32B32A32_FLOAT:            pfGuid = GUID_WICPixelFormat128bppRGBAFloat; break;

--- a/ScreenGrab/ScreenGrab12.h
+++ b/ScreenGrab/ScreenGrab12.h
@@ -20,7 +20,6 @@
 #include <d3d12.h>
 
 #include <OCIdl.h>
-#include <stdint.h>
 #include <functional>
 
 
@@ -41,5 +40,6 @@ namespace DirectX
         D3D12_RESOURCE_STATES beforeState = D3D12_RESOURCE_STATE_RENDER_TARGET,
         D3D12_RESOURCE_STATES afterState = D3D12_RESOURCE_STATE_RENDER_TARGET,
         _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
+        bool forceSRGB = false);
 }


### PR DESCRIPTION
With the new 'flip' style presentation model for Windows 10 or later, you don't actually use ``*_SRGB`` on the backbuffer format. Therefore, the resulting ``PNG`` screenshot would be washed out.

This adds a new optional paraemeter to allow forcing the sRGB metadata.