### PR TITLE
Update TGA codec for TGA 2.0

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -382,8 +382,8 @@ namespace DirectX
         _In_z_ const wchar_t* szFile,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image);
 
-    HRESULT __cdecl SaveToTGAMemory(_In_ const Image& image, _Out_ Blob& blob);
-    HRESULT __cdecl SaveToTGAFile(_In_ const Image& image, _In_z_ const wchar_t* szFile);
+    HRESULT __cdecl SaveToTGAMemory(_In_ const Image& image, _Out_ Blob& blob, _In_opt_ const TexMetadata* metadata = nullptr);
+    HRESULT __cdecl SaveToTGAFile(_In_ const Image& image, _In_z_ const wchar_t* szFile, _In_opt_ const TexMetadata* metadata = nullptr);
 
     // WIC operations
     HRESULT __cdecl LoadFromWICMemory(

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -110,6 +110,7 @@
 
 #include <vector>
 
+#include <time.h>
 #include <stdlib.h>
 #include <search.h>
 

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -1671,7 +1671,7 @@ HRESULT DirectX::SaveToTGAFile(const Image& image, const wchar_t* szFile, const 
                 return HRESULT_FROM_WIN32(GetLastError());
             }
 
-            if (!WriteFile(hFile.get(), temp.get(), sizeof(TGA_EXTENSION), &bytesWritten, nullptr))
+            if (!WriteFile(hFile.get(), &ext, sizeof(TGA_EXTENSION), &bytesWritten, nullptr))
             {
                 return HRESULT_FROM_WIN32(GetLastError());
             }

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -49,7 +49,7 @@ namespace
     {
         TGA_ATTRIBUTE_NONE = 0,             // 0: no alpha data included
         TGA_ATTRIBUTE_IGNORED = 1,          // 1: undefined data, can be ignored
-        TGA_ATTRIBUTE_UNDEFINED = 2,        // 2: uefined data, should be retained
+        TGA_ATTRIBUTE_UNDEFINED = 2,        // 2: uedefined data, should be retained
         TGA_ATTRIBUTE_ALPHA = 3,            // 3: useful alpha channel data
         TGA_ATTRIBUTE_PREMULTIPLIED = 4,    // 4: pre-multiplied alpha
     };
@@ -920,8 +920,8 @@ namespace
 
         if (IsSRGB(metadata.format))
         {
-            ext->wGammaNumerator = 10;
-            ext->wGammaDenominator = 22;
+            ext->wGammaNumerator = 22;
+            ext->wGammaDenominator = 10;
         }
 
         switch (metadata.GetAlphaMode())
@@ -1538,7 +1538,7 @@ HRESULT DirectX::SaveToTGAMemory(const Image& image, Blob& blob, const TexMetada
         auto ext = reinterpret_cast<TGA_EXTENSION*>(dPtr);
         SetExtension(ext, *metadata);
 
-        extOffset = dPtr - destPtr;
+        extOffset = static_cast<uint32_t>(dPtr - destPtr);
         dPtr += sizeof(TGA_EXTENSION);
     }
 

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -72,6 +72,7 @@ enum OPTIONS
     OPT_DDS_DWORD_ALIGN,
     OPT_DDS_BAD_DXTN_TAILS,
     OPT_USE_DX10,
+    OPT_TGA20,
     OPT_NOLOGO,
     OPT_TIMING,
     OPT_SEPALPHA,
@@ -158,6 +159,7 @@ const SValue g_pOptions[] =
     { L"dword",         OPT_DDS_DWORD_ALIGN },
     { L"badtails",      OPT_DDS_BAD_DXTN_TAILS },
     { L"dx10",          OPT_USE_DX10 },
+    { L"tga20",         OPT_TGA20 },
     { L"nologo",        OPT_NOLOGO },
     { L"timing",        OPT_TIMING },
     { L"sepalpha",      OPT_SEPALPHA },
@@ -734,7 +736,8 @@ namespace
         wprintf(L"   -badtails           Fix for older DXTn with bad mipchain tails\n");
         wprintf(L"   -xlum               expand legacy L8, L16, and A8P8 formats\n");
         wprintf(L"\n                       (DDS output only)\n");
-        wprintf(L"   -dx10               Force use of 'DX10' extended header\n");
+        wprintf(L"   -dx10               Force use of 'DX10' extended header for DDS\n");
+        wprintf(L"   -tga20              Write TGA file including TGA 2.0 extension area\n");
         wprintf(L"\n   -nologo             suppress copyright message\n");
         wprintf(L"   -timing             Display elapsed processing time\n\n");
 #ifdef _OPENMP
@@ -2990,7 +2993,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 break;
 
             case CODEC_TGA:
-                hr = SaveToTGAFile(img[0], pConv->szDest);
+                hr = SaveToTGAFile(img[0], pConv->szDest, (dwOptions & (DWORD64(1) << OPT_TGA20)) ? &info : nullptr);
                 break;
 
             case CODEC_HDR:

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -54,6 +54,7 @@ using Microsoft::WRL::ComPtr;
 enum OPTIONS
 {
     OPT_RECURSIVE = 1,
+    OPT_FILELIST,
     OPT_WIDTH,
     OPT_HEIGHT,
     OPT_MIPLEVELS,
@@ -73,6 +74,9 @@ enum OPTIONS
     OPT_DDS_BAD_DXTN_TAILS,
     OPT_USE_DX10,
     OPT_TGA20,
+    OPT_WIC_QUALITY,
+    OPT_WIC_LOSSLESS,
+    OPT_WIC_MULTIFRAME,
     OPT_NOLOGO,
     OPT_TIMING,
     OPT_SEPALPHA,
@@ -96,15 +100,11 @@ enum OPTIONS
     OPT_COMPRESS_MAX,
     OPT_COMPRESS_QUICK,
     OPT_COMPRESS_DITHER,
-    OPT_WIC_QUALITY,
-    OPT_WIC_LOSSLESS,
-    OPT_WIC_MULTIFRAME,
     OPT_COLORKEY,
     OPT_TONEMAP,
     OPT_X2_BIAS,
     OPT_PRESERVE_ALPHA_COVERAGE,
     OPT_INVERT_Y,
-    OPT_FILELIST,
     OPT_ROTATE_COLOR,
     OPT_PAPER_WHITE_NITS,
     OPT_MAX
@@ -141,6 +141,7 @@ struct SValue
 const SValue g_pOptions[] =
 {
     { L"r",             OPT_RECURSIVE },
+    { L"flist",         OPT_FILELIST },
     { L"w",             OPT_WIDTH },
     { L"h",             OPT_HEIGHT },
     { L"m",             OPT_MIPLEVELS },
@@ -160,9 +161,13 @@ const SValue g_pOptions[] =
     { L"badtails",      OPT_DDS_BAD_DXTN_TAILS },
     { L"dx10",          OPT_USE_DX10 },
     { L"tga20",         OPT_TGA20 },
+    { L"wicq",          OPT_WIC_QUALITY },
+    { L"wiclossless",   OPT_WIC_LOSSLESS },
+    { L"wicmulti",      OPT_WIC_MULTIFRAME },
     { L"nologo",        OPT_NOLOGO },
     { L"timing",        OPT_TIMING },
     { L"sepalpha",      OPT_SEPALPHA },
+    { L"keepcoverage",  OPT_PRESERVE_ALPHA_COVERAGE },
     { L"nowic",         OPT_NO_WIC },
     { L"tu",            OPT_TYPELESS_UNORM },
     { L"tf",            OPT_TYPELESS_FLOAT },
@@ -183,15 +188,10 @@ const SValue g_pOptions[] =
     { L"bcmax",         OPT_COMPRESS_MAX },
     { L"bcquick",       OPT_COMPRESS_QUICK },
     { L"bcdither",      OPT_COMPRESS_DITHER },
-    { L"wicq",          OPT_WIC_QUALITY },
-    { L"wiclossless",   OPT_WIC_LOSSLESS },
-    { L"wicmulti",      OPT_WIC_MULTIFRAME },
     { L"c",             OPT_COLORKEY },
     { L"tonemap",       OPT_TONEMAP },
     { L"x2bias",        OPT_X2_BIAS },
-    { L"keepcoverage",  OPT_PRESERVE_ALPHA_COVERAGE },
     { L"inverty",       OPT_INVERT_Y },
-    { L"flist",         OPT_FILELIST },
     { L"rotatecolor",   OPT_ROTATE_COLOR },
     { L"nits",          OPT_PAPER_WHITE_NITS },
     { nullptr,          0 }
@@ -704,40 +704,47 @@ namespace
 
         wprintf(L"Usage: texconv <options> <files>\n\n");
         wprintf(L"   -r                  wildcard filename search is recursive\n");
-        wprintf(L"   -w <n>              width\n");
+        wprintf(L"   -flist <filename>   use text file with a list of input files (one per line)\n");
+        wprintf(L"\n   -w <n>              width\n");
         wprintf(L"   -h <n>              height\n");
         wprintf(L"   -m <n>              miplevels\n");
         wprintf(L"   -f <format>         format\n");
-        wprintf(L"   -if <filter>        image filtering\n");
+        wprintf(L"\n   -if <filter>        image filtering\n");
         wprintf(L"   -srgb{i|o}          sRGB {input, output}\n");
-        wprintf(L"   -px <string>        name prefix\n");
+        wprintf(L"\n   -px <string>        name prefix\n");
         wprintf(L"   -sx <string>        name suffix\n");
         wprintf(L"   -o <directory>      output directory\n");
         wprintf(L"   -y                  overwrite existing output file (if any)\n");
         wprintf(L"   -ft <filetype>      output file type\n");
-        wprintf(L"   -hflip              horizonal flip of source image\n");
+        wprintf(L"\n   -hflip              horizonal flip of source image\n");
         wprintf(L"   -vflip              vertical flip of source image\n");
-        wprintf(L"   -sepalpha           resize/generate mips alpha channel separately\n");
+        wprintf(L"\n   -sepalpha           resize/generate mips alpha channel separately\n");
         wprintf(L"                       from color channels\n");
-        wprintf(L"   -nowic              Force non-WIC filtering\n");
+        wprintf(L"   -keepcoverage <ref> Preserve alpha coverage in mips for alpha test ref\n");
+        wprintf(L"\n   -nowic              Force non-WIC filtering\n");
         wprintf(L"   -wrap, -mirror      texture addressing mode (wrap, mirror, or clamp)\n");
         wprintf(L"   -pmalpha            convert final texture to use premultiplied alpha\n");
         wprintf(L"   -alpha              convert premultiplied alpha to straight alpha\n");
+        wprintf(L"\n   -fl <feature-level> Set maximum feature level target (defaults to 11.0)\n");
         wprintf(L"   -pow2               resize to fit a power-of-2, respecting aspect ratio\n");
         wprintf(
-            L"   -nmap <options>     converts height-map to normal-map\n"
+            L"\n   -nmap <options>     converts height-map to normal-map\n"
             L"                       options must be one or more of\n"
             L"                          r, g, b, a, l, m, u, v, i, o\n");
         wprintf(L"   -nmapamp <weight>   normal map amplitude (defaults to 1.0)\n");
-        wprintf(L"   -fl <feature-level> Set maximum feature level target (defaults to 11.0)\n");
         wprintf(L"\n                       (DDS input only)\n");
         wprintf(L"   -t{u|f}             TYPELESS format is treated as UNORM or FLOAT\n");
         wprintf(L"   -dword              Use DWORD instead of BYTE alignment\n");
         wprintf(L"   -badtails           Fix for older DXTn with bad mipchain tails\n");
         wprintf(L"   -xlum               expand legacy L8, L16, and A8P8 formats\n");
         wprintf(L"\n                       (DDS output only)\n");
-        wprintf(L"   -dx10               Force use of 'DX10' extended header for DDS\n");
-        wprintf(L"   -tga20              Write TGA file including TGA 2.0 extension area\n");
+        wprintf(L"   -dx10               Force use of 'DX10' extended header\n");
+        wprintf(L"\n                       (TGA output only)\n");
+        wprintf(L"   -tga20              Write file including TGA 2.0 extension area\n");
+        wprintf(L"\n                       (BMP, PNG, JPG, TIF, WDP output only)\n");
+        wprintf(L"   -wicq <quality>     When writing images with WIC use quality (0.0 to 1.0)\n");
+        wprintf(L"   -wiclossless        When writing images with WIC use lossless mode\n");
+        wprintf(L"   -wicmulti           When writing images with WIC encode multiframe images\n");
         wprintf(L"\n   -nologo             suppress copyright message\n");
         wprintf(L"   -timing             Display elapsed processing time\n\n");
 #ifdef _OPENMP
@@ -749,20 +756,15 @@ namespace
         wprintf(L"   -bcdither           Use dithering for BC1-3\n");
         wprintf(L"   -bcmax              Use exhaustive compression (BC7 only)\n");
         wprintf(L"   -bcquick            Use quick compression (BC7 only)\n");
-        wprintf(L"   -wicq <quality>     When writing images with WIC use quality (0.0 to 1.0)\n");
-        wprintf(L"   -wiclossless        When writing images with WIC use lossless mode\n");
-        wprintf(L"   -wicmulti           When writing images with WIC encode multiframe images\n");
         wprintf(
             L"   -aw <weight>        BC7 GPU compressor weighting for alpha error metric\n"
             L"                       (defaults to 1.0)\n");
-        wprintf(L"   -c <hex-RGB>        colorkey (a.k.a. chromakey) transparency\n");
+        wprintf(L"\n   -c <hex-RGB>        colorkey (a.k.a. chromakey) transparency\n");
         wprintf(L"   -rotatecolor <rot>  rotates color primaries and/or applies a curve\n");
         wprintf(L"   -nits <value>       paper-white value in nits to use for HDR10 (def: 200.0)\n");
         wprintf(L"   -tonemap            Apply a tonemap operator based on maximum luminance\n");
         wprintf(L"   -x2bias             Enable *2 - 1 conversion cases for unorm/pos-only-float\n");
-        wprintf(L"   -keepcoverage <ref> Preserve alpha coverage in generated mips for alpha test ref\n");
         wprintf(L"   -inverty            Invert Y (i.e. green) channel values\n");
-        wprintf(L"   -flist <filename>   use text file with a list of input files (one per line)\n");
 
         wprintf(L"\n   <format>: ");
         PrintList(13, g_pFormats);


### PR DESCRIPTION
Three distinct changes in this pull request:

First, the TGA writer now includes the official TGA 2.0 footer in all cases. This is recommended in the spec. It does not impact the ability of older codecs to read the content of the file.

Second, when reading a TGA, if there is a TGA 2.0 extension area present I use the AttributeType to set the alpha mode in the returned metadata--unless the reader already set it to OPAQUE due to format.

Third, if the caller provides the new optional metadata parameter to the TGA writer, it will write the TGA 2.0 extension area. This extension area includes AttributeType derived from the metadata alpha mode, the time stamp, a software ID of "DirectXTex", and a software version of ``DIRECTX_TEX_VERSION``.  If the source format was ``DXGI_FORMAT_*_SRGB`` I also set the gamma value to 2.2.

> I added a ``-tga20`` switch to ``texconv`` which enables the TGA 2.0 extension area writing.