### PR TITLE
texconv: added -fixbc4x4 switch

### DIFF
--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -1857,9 +1857,9 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             image.swap(timage);
         }
 
-        // --- Decompress --------------------------------------------------------------
         DXGI_FORMAT tformat = (format == DXGI_FORMAT_UNKNOWN) ? info.format : format;
 
+        // --- Decompress --------------------------------------------------------------
         std::unique_ptr<ScratchImage> cimage;
         if (IsCompressed(info.format))
         {

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -1919,7 +1919,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     info.mipLevels = mdata.mipLevels;
                     image.swap(timage);
                 }
-                else
+                else if (IsCompressed(tformat))
                 {
                     non4bc = true;
                 }


### PR DESCRIPTION
DirectXTex has generalized support for BC image sizes so it can support non-multiple-of-4 image sizes and properly BC them. However, Direct3D itself can only create a BC resource if the top-most miplevel is a multiple-of-4 in both width and height.

As such, some DDS files have been written that can't actually be loaded as textures. For example, a 1x1 BC compressed DDS.  With the new ``-fixbc4x4`` switch, such BC compressed images are rounded up to fix, although this process invalidates any existing mipchain.