### PR TITLE
Allow DDSTextureLoader.h and DDSTextureLoader12.h to be included together (same for WICTextureLoader.h/WICTextureLoader12.h)

### DIFF
--- a/DDSTextureLoader/DDSTextureLoader.h
+++ b/DDSTextureLoader/DDSTextureLoader.h
@@ -22,6 +22,8 @@
 
 namespace DirectX
 {
+#ifndef DDS_ALPHA_MODE_DEFINED
+#define DDS_ALPHA_MODE_DEFINED
     enum DDS_ALPHA_MODE
     {
         DDS_ALPHA_MODE_UNKNOWN       = 0,
@@ -30,6 +32,7 @@ namespace DirectX
         DDS_ALPHA_MODE_OPAQUE        = 3,
         DDS_ALPHA_MODE_CUSTOM        = 4,
     };
+#endif
 
     // Standard version
     HRESULT CreateDDSTextureFromMemory(

--- a/DDSTextureLoader/DDSTextureLoader12.h
+++ b/DDSTextureLoader/DDSTextureLoader12.h
@@ -25,6 +25,8 @@
 
 namespace DirectX
 {
+#ifndef DDS_ALPHA_MODE_DEFINED
+#define DDS_ALPHA_MODE_DEFINED
     enum DDS_ALPHA_MODE
     {
         DDS_ALPHA_MODE_UNKNOWN       = 0,
@@ -33,6 +35,7 @@ namespace DirectX
         DDS_ALPHA_MODE_OPAQUE        = 3,
         DDS_ALPHA_MODE_CUSTOM        = 4,
     };
+#endif
 
     enum DDS_LOADER_FLAGS
     {

--- a/WICTextureLoader/WICTextureLoader.h
+++ b/WICTextureLoader/WICTextureLoader.h
@@ -29,12 +29,15 @@
 
 namespace DirectX
 {
+#ifndef WIC_LOADER_FLAGS_DEFINED
+#define WIC_LOADER_FLAGS_DEFINED
     enum WIC_LOADER_FLAGS
     {
         WIC_LOADER_DEFAULT      = 0,
         WIC_LOADER_FORCE_SRGB   = 0x1,
         WIC_LOADER_IGNORE_SRGB  = 0x2,
     };
+#endif
 
     // Standard version
     HRESULT CreateWICTextureFromMemory(

--- a/WICTextureLoader/WICTextureLoader12.h
+++ b/WICTextureLoader/WICTextureLoader12.h
@@ -27,6 +27,8 @@
 
 namespace DirectX
 {
+#ifndef WIC_LOADER_FLAGS_DEFINED
+#define WIC_LOADER_FLAGS_DEFINED
     enum WIC_LOADER_FLAGS
     {
         WIC_LOADER_DEFAULT = 0,
@@ -35,6 +37,7 @@ namespace DirectX
         WIC_LOADER_MIP_AUTOGEN = 0x4,
         WIC_LOADER_MIP_RESERVE = 0x8,
     };
+#endif
 
     // Standard version
     HRESULT __cdecl LoadWICTextureFromMemory(


### PR DESCRIPTION
I've had this in my codebase for a while and though it might be useful: the only thing that prevents DDSTextureLoader.h and DDSTextureLoader12.h being included from the same file is the definition for DDS_ALPHA_MODE enum which can be avoided with a pair of #ifdef-s/#define-s.