### PR TITLE
Remove BOM from two files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# DirectX Texture Library
+# DirectX Texture Library
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "configurations": [
     {
       "name": "x86-Clang-Debug",


### PR DESCRIPTION
UTF-8 without a BOM is recommended for file formatting. This is the most compatible with various tools and also takes up the least amount of space (though in this case it only saves 4 bytes).