### PR TITLE
Direct3D 9 versions of texture loaders

### DIFF
--- a/DDSTextureLoader/DDSTextureLoader11.cpp
+++ b/DDSTextureLoader/DDSTextureLoader11.cpp
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------
-// File: DDSTextureLoader.cpp
+// File: DDSTextureLoader11.cpp
 //
 // Functions for loading a DDS texture and creating a Direct3D runtime resource for it
 //
@@ -14,7 +14,7 @@
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 
-#include "DDSTextureLoader.h"
+#include "DDSTextureLoader11.h"
 
 #include <assert.h>
 #include <algorithm>

--- a/DDSTextureLoader/DDSTextureLoader11.cpp
+++ b/DDSTextureLoader/DDSTextureLoader11.cpp
@@ -639,12 +639,12 @@ namespace
                     return DXGI_FORMAT_B8G8R8A8_UNORM;
                 }
 
-                if (ISBITMASK(0x00ff0000, 0x0000ff00, 0x000000ff, 0x00000000))
+                if (ISBITMASK(0x00ff0000, 0x0000ff00, 0x000000ff, 0))
                 {
                     return DXGI_FORMAT_B8G8R8X8_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x000000ff,0x0000ff00,0x00ff0000,0x00000000) aka D3DFMT_X8B8G8R8
+                // No DXGI format maps to ISBITMASK(0x000000ff,0x0000ff00,0x00ff0000,0) aka D3DFMT_X8B8G8R8
 
                 // Note that many common DDS reader/writers (including D3DX) swap the
                 // the RED/BLUE masks for 10:10:10:2 formats. We assume
@@ -660,12 +660,12 @@ namespace
 
                 // No DXGI format maps to ISBITMASK(0x000003ff,0x000ffc00,0x3ff00000,0xc0000000) aka D3DFMT_A2R10G10B10
 
-                if (ISBITMASK(0x0000ffff, 0xffff0000, 0x00000000, 0x00000000))
+                if (ISBITMASK(0x0000ffff, 0xffff0000, 0, 0))
                 {
                     return DXGI_FORMAT_R16G16_UNORM;
                 }
 
-                if (ISBITMASK(0xffffffff, 0x00000000, 0x00000000, 0x00000000))
+                if (ISBITMASK(0xffffffff, 0, 0, 0))
                 {
                     // Only 32-bit color channel format in D3D9 was R32F
                     return DXGI_FORMAT_R32_FLOAT; // D3DX writes this out as a FourCC of 114
@@ -681,19 +681,19 @@ namespace
                 {
                     return DXGI_FORMAT_B5G5R5A1_UNORM;
                 }
-                if (ISBITMASK(0xf800, 0x07e0, 0x001f, 0x0000))
+                if (ISBITMASK(0xf800, 0x07e0, 0x001f, 0))
                 {
                     return DXGI_FORMAT_B5G6R5_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x7c00,0x03e0,0x001f,0x0000) aka D3DFMT_X1R5G5B5
+                // No DXGI format maps to ISBITMASK(0x7c00,0x03e0,0x001f,0) aka D3DFMT_X1R5G5B5
 
                 if (ISBITMASK(0x0f00, 0x00f0, 0x000f, 0xf000))
                 {
                     return DXGI_FORMAT_B4G4R4A4_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x0f00,0x00f0,0x000f,0x0000) aka D3DFMT_X4R4G4B4
+                // No DXGI format maps to ISBITMASK(0x0f00,0x00f0,0x000f,0) aka D3DFMT_X4R4G4B4
 
                 // No 3:3:2, 3:3:2:8, or paletted DXGI formats aka D3DFMT_A8R3G3B2, D3DFMT_R3G3B2, D3DFMT_P8, D3DFMT_A8P8, etc.
                 break;
@@ -703,14 +703,14 @@ namespace
         {
             if (8 == ddpf.RGBBitCount)
             {
-                if (ISBITMASK(0x000000ff, 0x00000000, 0x00000000, 0x00000000))
+                if (ISBITMASK(0xff, 0, 0, 0))
                 {
                     return DXGI_FORMAT_R8_UNORM; // D3DX10/11 writes this out as DX10 extension
                 }
 
                 // No DXGI format maps to ISBITMASK(0x0f,0x00,0x00,0xf0) aka D3DFMT_A4L4
 
-                if (ISBITMASK(0x000000ff, 0x00000000, 0x00000000, 0x0000ff00))
+                if (ISBITMASK(0x00ff, 0, 0, 0xff00))
                 {
                     return DXGI_FORMAT_R8G8_UNORM; // Some DDS writers assume the bitcount should be 8 instead of 16
                 }
@@ -718,11 +718,11 @@ namespace
 
             if (16 == ddpf.RGBBitCount)
             {
-                if (ISBITMASK(0x0000ffff, 0x00000000, 0x00000000, 0x00000000))
+                if (ISBITMASK(0xffff, 0, 0, 0))
                 {
                     return DXGI_FORMAT_R16_UNORM; // D3DX10/11 writes this out as DX10 extension
                 }
-                if (ISBITMASK(0x000000ff, 0x00000000, 0x00000000, 0x0000ff00))
+                if (ISBITMASK(0x00ff, 0, 0, 0xff00))
                 {
                     return DXGI_FORMAT_R8G8_UNORM; // D3DX10/11 writes this out as DX10 extension
                 }
@@ -739,7 +739,7 @@ namespace
         {
             if (16 == ddpf.RGBBitCount)
             {
-                if (ISBITMASK(0x00ff, 0xff00, 0x0000, 0x0000))
+                if (ISBITMASK(0x00ff, 0xff00, 0, 0))
                 {
                     return DXGI_FORMAT_R8G8_SNORM; // D3DX10/11 writes this out as DX10 extension
                 }
@@ -751,13 +751,15 @@ namespace
                 {
                     return DXGI_FORMAT_R8G8B8A8_SNORM; // D3DX10/11 writes this out as DX10 extension
                 }
-                if (ISBITMASK(0x0000ffff, 0xffff0000, 0x00000000, 0x00000000))
+                if (ISBITMASK(0x0000ffff, 0xffff0000, 0, 0))
                 {
                     return DXGI_FORMAT_R16G16_SNORM; // D3DX10/11 writes this out as DX10 extension
                 }
 
                 // No DXGI format maps to ISBITMASK(0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000) aka D3DFMT_A2W10V10U10
             }
+
+            // No DXGI format maps to DDPF_BUMPLUMINANCE aka D3DFMT_L6V5U5, D3DFMT_X8L8V8U8
         }
         else if (ddpf.flags & DDS_FOURCC)
         {
@@ -853,6 +855,8 @@ namespace
 
             case 116: // D3DFMT_A32B32G32R32F
                 return DXGI_FORMAT_R32G32B32A32_FLOAT;
+
+            // No DXGI format maps to D3DFMT_CxV8U8
             }
         }
 

--- a/DDSTextureLoader/DDSTextureLoader11.h
+++ b/DDSTextureLoader/DDSTextureLoader11.h
@@ -1,17 +1,10 @@
 //--------------------------------------------------------------------------------------
-// File: WICTextureLoader.h
+// File: DDSTextureLoader11.h
 //
-// Function for loading a WIC image and creating a Direct3D runtime texture for it
-// (auto-generating mipmaps if possible)
+// Functions for loading a DDS texture and creating a Direct3D runtime resource for it
 //
-// Note: Assumes application has already called CoInitializeEx
-//
-// Warning: CreateWICTexture* functions are not thread-safe if given a d3dContext instance for
-//          auto-gen mipmap support.
-//
-// Note these functions are useful for images created as simple 2D textures. For
-// more complex resources, DDSTextureLoader is an excellent light-weight runtime loader.
-// For a full-featured DDS file reader, writer, and texture processing pipeline see
+// Note these functions are useful as a light-weight runtime loader for DDS files. For
+// a full-featured DDS file reader, writer, and texture processing pipeline see
 // the 'Texconv' sample and the 'DirectXTex' library.
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -27,68 +20,75 @@
 
 #include <cstdint>
 
+
 namespace DirectX
 {
-#ifndef WIC_LOADER_FLAGS_DEFINED
-#define WIC_LOADER_FLAGS_DEFINED
-    enum WIC_LOADER_FLAGS : uint32_t
+#ifndef DDS_ALPHA_MODE_DEFINED
+#define DDS_ALPHA_MODE_DEFINED
+    enum DDS_ALPHA_MODE
     {
-        WIC_LOADER_DEFAULT      = 0,
-        WIC_LOADER_FORCE_SRGB   = 0x1,
-        WIC_LOADER_IGNORE_SRGB  = 0x2,
-        WIC_LOADER_FORCE_RGBA32 = 0x10,
+        DDS_ALPHA_MODE_UNKNOWN       = 0,
+        DDS_ALPHA_MODE_STRAIGHT      = 1,
+        DDS_ALPHA_MODE_PREMULTIPLIED = 2,
+        DDS_ALPHA_MODE_OPAQUE        = 3,
+        DDS_ALPHA_MODE_CUSTOM        = 4,
     };
 #endif
 
     // Standard version
-    HRESULT CreateWICTextureFromMemory(
+    HRESULT CreateDDSTextureFromMemory(
         _In_ ID3D11Device* d3dDevice,
-        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
-        _In_ size_t wicDataSize,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0) noexcept;
+        _In_ size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
-    HRESULT CreateWICTextureFromFile(
+    HRESULT CreateDDSTextureFromFile(
         _In_ ID3D11Device* d3dDevice,
         _In_z_ const wchar_t* szFileName,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0) noexcept;
+        _In_ size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
     // Standard version with optional auto-gen mipmap support
-    HRESULT CreateWICTextureFromMemory(
+    HRESULT CreateDDSTextureFromMemory(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
-        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
-        _In_ size_t wicDataSize,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0) noexcept;
+        _In_ size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
-    HRESULT CreateWICTextureFromFile(
+    HRESULT CreateDDSTextureFromFile(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
         _In_z_ const wchar_t* szFileName,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0) noexcept;
+        _In_ size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
     // Extended version
-    HRESULT CreateWICTextureFromMemoryEx(
+    HRESULT CreateDDSTextureFromMemoryEx(
         _In_ ID3D11Device* d3dDevice,
-        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
-        _In_ size_t wicDataSize,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
         _In_ size_t maxsize,
         _In_ D3D11_USAGE usage,
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ unsigned int loadFlags,
+        _In_ bool forceSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
-    HRESULT CreateWICTextureFromFileEx(
+    HRESULT CreateDDSTextureFromFileEx(
         _In_ ID3D11Device* d3dDevice,
         _In_z_ const wchar_t* szFileName,
         _In_ size_t maxsize,
@@ -96,26 +96,28 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ unsigned int loadFlags,
+        _In_ bool forceSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
     // Extended version with optional auto-gen mipmap support
-    HRESULT CreateWICTextureFromMemoryEx(
+    HRESULT CreateDDSTextureFromMemoryEx(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
-        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
-        _In_ size_t wicDataSize,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
         _In_ size_t maxsize,
         _In_ D3D11_USAGE usage,
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ unsigned int loadFlags,
+        _In_ bool forceSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
-    HRESULT CreateWICTextureFromFileEx(
+    HRESULT CreateDDSTextureFromFileEx(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
         _In_z_ const wchar_t* szFileName,
@@ -124,7 +126,8 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ unsigned int loadFlags,
+        _In_ bool forceSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 }

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -1361,7 +1361,8 @@ namespace
             size_t reservedMips = mipCount;
             if (loadFlags & DDS_LOADER_MIP_RESERVE)
             {
-                reservedMips = std::min<size_t>(D3D12_REQ_MIP_LEVELS, CountMips(width, height));
+                reservedMips = std::min<size_t>(D3D12_REQ_MIP_LEVELS,
+                    CountMips(width, height));
             }
 
             hr = CreateTextureResource(d3dDevice, resDim, twidth, theight, tdepth, reservedMips - skipMip, arraySize,

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -27,6 +27,8 @@
 #pragma clang diagnostic ignored "-Wswitch-enum"
 #endif
 
+#pragma warning(disable : 4062)
+
 #define D3DX12_NO_STATE_OBJECT_HELPERS
 #include "d3dx12.h"
 

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -654,12 +654,12 @@ namespace
                     return DXGI_FORMAT_B8G8R8A8_UNORM;
                 }
 
-                if (ISBITMASK(0x00ff0000,0x0000ff00,0x000000ff,0x00000000))
+                if (ISBITMASK(0x00ff0000,0x0000ff00,0x000000ff,0))
                 {
                     return DXGI_FORMAT_B8G8R8X8_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x000000ff,0x0000ff00,0x00ff0000,0x00000000) aka D3DFMT_X8B8G8R8
+                // No DXGI format maps to ISBITMASK(0x000000ff,0x0000ff00,0x00ff0000,0) aka D3DFMT_X8B8G8R8
 
                 // Note that many common DDS reader/writers (including D3DX) swap the
                 // the RED/BLUE masks for 10:10:10:2 formats. We assume
@@ -675,12 +675,12 @@ namespace
 
                 // No DXGI format maps to ISBITMASK(0x000003ff,0x000ffc00,0x3ff00000,0xc0000000) aka D3DFMT_A2R10G10B10
 
-                if (ISBITMASK(0x0000ffff,0xffff0000,0x00000000,0x00000000))
+                if (ISBITMASK(0x0000ffff,0xffff0000,0,0))
                 {
                     return DXGI_FORMAT_R16G16_UNORM;
                 }
 
-                if (ISBITMASK(0xffffffff,0x00000000,0x00000000,0x00000000))
+                if (ISBITMASK(0xffffffff,0,0,0))
                 {
                     // Only 32-bit color channel format in D3D9 was R32F
                     return DXGI_FORMAT_R32_FLOAT; // D3DX writes this out as a FourCC of 114
@@ -696,19 +696,19 @@ namespace
                 {
                     return DXGI_FORMAT_B5G5R5A1_UNORM;
                 }
-                if (ISBITMASK(0xf800,0x07e0,0x001f,0x0000))
+                if (ISBITMASK(0xf800,0x07e0,0x001f,0))
                 {
                     return DXGI_FORMAT_B5G6R5_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x7c00,0x03e0,0x001f,0x0000) aka D3DFMT_X1R5G5B5
+                // No DXGI format maps to ISBITMASK(0x7c00,0x03e0,0x001f,0) aka D3DFMT_X1R5G5B5
 
                 if (ISBITMASK(0x0f00,0x00f0,0x000f,0xf000))
                 {
                     return DXGI_FORMAT_B4G4R4A4_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x0f00,0x00f0,0x000f,0x0000) aka D3DFMT_X4R4G4B4
+                // No DXGI format maps to ISBITMASK(0x0f00,0x00f0,0x000f,0) aka D3DFMT_X4R4G4B4
 
                 // No 3:3:2, 3:3:2:8, or paletted DXGI formats aka D3DFMT_A8R3G3B2, D3DFMT_R3G3B2, D3DFMT_P8, D3DFMT_A8P8, etc.
                 break;
@@ -718,14 +718,14 @@ namespace
         {
             if (8 == ddpf.RGBBitCount)
             {
-                if (ISBITMASK(0x000000ff,0x00000000,0x00000000,0x00000000))
+                if (ISBITMASK(0xff,0,0,0))
                 {
                     return DXGI_FORMAT_R8_UNORM; // D3DX10/11 writes this out as DX10 extension
                 }
 
-                // No DXGI format maps to ISBITMASK(0x0f,0x00,0x00,0xf0) aka D3DFMT_A4L4
+                // No DXGI format maps to ISBITMASK(0x0f,0,0,0xf0) aka D3DFMT_A4L4
 
-                if (ISBITMASK(0x000000ff, 0x00000000, 0x00000000, 0x0000ff00))
+                if (ISBITMASK(0x00ff, 0, 0, 0xff00))
                 {
                     return DXGI_FORMAT_R8G8_UNORM; // Some DDS writers assume the bitcount should be 8 instead of 16
                 }
@@ -733,11 +733,11 @@ namespace
 
             if (16 == ddpf.RGBBitCount)
             {
-                if (ISBITMASK(0x0000ffff,0x00000000,0x00000000,0x00000000))
+                if (ISBITMASK(0xffff,0,0,0))
                 {
                     return DXGI_FORMAT_R16_UNORM; // D3DX10/11 writes this out as DX10 extension
                 }
-                if (ISBITMASK(0x000000ff,0x00000000,0x00000000,0x0000ff00))
+                if (ISBITMASK(0x00ff,0,0,0xff00))
                 {
                     return DXGI_FORMAT_R8G8_UNORM; // D3DX10/11 writes this out as DX10 extension
                 }
@@ -754,7 +754,7 @@ namespace
         {
             if (16 == ddpf.RGBBitCount)
             {
-                if (ISBITMASK(0x00ff, 0xff00, 0x0000, 0x0000))
+                if (ISBITMASK(0x00ff, 0xff00, 0, 0))
                 {
                     return DXGI_FORMAT_R8G8_SNORM; // D3DX10/11 writes this out as DX10 extension
                 }
@@ -766,13 +766,15 @@ namespace
                 {
                     return DXGI_FORMAT_R8G8B8A8_SNORM; // D3DX10/11 writes this out as DX10 extension
                 }
-                if (ISBITMASK(0x0000ffff, 0xffff0000, 0x00000000, 0x00000000))
+                if (ISBITMASK(0x0000ffff, 0xffff0000, 0, 0))
                 {
                     return DXGI_FORMAT_R16G16_SNORM; // D3DX10/11 writes this out as DX10 extension
                 }
 
                 // No DXGI format maps to ISBITMASK(0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000) aka D3DFMT_A2W10V10U10
             }
+
+            // No DXGI format maps to DDPF_BUMPLUMINANCE aka D3DFMT_L6V5U5, D3DFMT_X8L8V8U8
         }
         else if (ddpf.flags & DDS_FOURCC)
         {
@@ -868,6 +870,8 @@ namespace
 
             case 116: // D3DFMT_A32B32G32R32F
                 return DXGI_FORMAT_R32G32B32A32_FLOAT;
+
+            // No DXGI format maps to D3DFMT_CxV8U8
             }
         }
 

--- a/DDSTextureLoader/DDSTextureLoader9.cpp
+++ b/DDSTextureLoader/DDSTextureLoader9.cpp
@@ -1,0 +1,970 @@
+//--------------------------------------------------------------------------------------
+// File: DDSTextureLoader9.cpp
+//
+// Functions for loading a DDS texture and creating a Direct3D runtime resource for it
+//
+// Note these functions are useful as a light-weight runtime loader for DDS files. For
+// a full-featured DDS file reader, writer, and texture processing pipeline see
+// the 'Texconv' sample and the 'DirectXTex' library.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+//--------------------------------------------------------------------------------------
+
+#include "DDSTextureLoader9.h"
+
+#include <d3d9types.h>
+
+#include <assert.h>
+#include <algorithm>
+#include <memory>
+
+#include <wrl/client.h>
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+//--------------------------------------------------------------------------------------
+// Macros
+//--------------------------------------------------------------------------------------
+#ifndef MAKEFOURCC
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
+                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
+                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
+#endif /* defined(MAKEFOURCC) */
+
+//--------------------------------------------------------------------------------------
+// DDS file structure definitions
+//
+// See DDS.h in the 'Texconv' sample and the 'DirectXTex' library
+//--------------------------------------------------------------------------------------
+#pragma pack(push,1)
+
+const uint32_t DDS_MAGIC = 0x20534444; // "DDS "
+
+struct DDS_PIXELFORMAT
+{
+    uint32_t    size;
+    uint32_t    flags;
+    uint32_t    fourCC;
+    uint32_t    RGBBitCount;
+    uint32_t    RBitMask;
+    uint32_t    GBitMask;
+    uint32_t    BBitMask;
+    uint32_t    ABitMask;
+};
+
+#define DDS_FOURCC          0x00000004  // DDPF_FOURCC
+#define DDS_RGB             0x00000040  // DDPF_RGB
+#define DDS_LUMINANCE       0x00020000  // DDPF_LUMINANCE
+#define DDS_ALPHA           0x00000002  // DDPF_ALPHA
+#define DDS_BUMPDUDV        0x00080000  // DDPF_BUMPDUDV
+#define DDS_BUMPLUMINANCE   0x00040000  // DDPF_BUMPLUMINANCE
+
+#define DDS_HEADER_FLAGS_VOLUME         0x00800000  // DDSD_DEPTH
+
+#define DDS_HEIGHT 0x00000002 // DDSD_HEIGHT
+
+#define DDS_CUBEMAP_POSITIVEX 0x00000600 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEX
+#define DDS_CUBEMAP_NEGATIVEX 0x00000a00 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEX
+#define DDS_CUBEMAP_POSITIVEY 0x00001200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEY
+#define DDS_CUBEMAP_NEGATIVEY 0x00002200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEY
+#define DDS_CUBEMAP_POSITIVEZ 0x00004200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEZ
+#define DDS_CUBEMAP_NEGATIVEZ 0x00008200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEZ
+
+#define DDS_CUBEMAP_ALLFACES ( DDS_CUBEMAP_POSITIVEX | DDS_CUBEMAP_NEGATIVEX |\
+                               DDS_CUBEMAP_POSITIVEY | DDS_CUBEMAP_NEGATIVEY |\
+                               DDS_CUBEMAP_POSITIVEZ | DDS_CUBEMAP_NEGATIVEZ )
+
+#define DDS_CUBEMAP 0x00000200 // DDSCAPS2_CUBEMAP
+
+struct DDS_HEADER
+{
+    uint32_t        size;
+    uint32_t        flags;
+    uint32_t        height;
+    uint32_t        width;
+    uint32_t        pitchOrLinearSize;
+    uint32_t        depth; // only if DDS_HEADER_FLAGS_VOLUME is set in flags
+    uint32_t        mipMapCount;
+    uint32_t        reserved1[11];
+    DDS_PIXELFORMAT ddspf;
+    uint32_t        caps;
+    uint32_t        caps2;
+    uint32_t        caps3;
+    uint32_t        caps4;
+    uint32_t        reserved2;
+};
+
+#pragma pack(pop)
+
+//--------------------------------------------------------------------------------------
+namespace
+{
+    struct handle_closer { void operator()(HANDLE h) noexcept { if (h) CloseHandle(h); } };
+
+    using ScopedHandle = std::unique_ptr<void, handle_closer>;
+
+    inline HANDLE safe_handle( HANDLE h ) noexcept { return (h == INVALID_HANDLE_VALUE) ? nullptr : h; }
+
+    //--------------------------------------------------------------------------------------
+    HRESULT LoadTextureDataFromMemory(
+        _In_reads_(ddsDataSize) const uint8_t* ddsData,
+        size_t ddsDataSize,
+        const DDS_HEADER** header,
+        const uint8_t** bitData,
+        size_t* bitSize) noexcept
+    {
+        if (!header || !bitData || !bitSize)
+        {
+            return E_POINTER;
+        }
+
+        if (ddsDataSize > UINT32_MAX)
+        {
+            return E_FAIL;
+        }
+
+        if (ddsDataSize < (sizeof(uint32_t) + sizeof(DDS_HEADER)))
+        {
+            return E_FAIL;
+        }
+
+        // DDS files always start with the same magic number ("DDS ")
+        auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+        if (dwMagicNumber != DDS_MAGIC)
+        {
+            return E_FAIL;
+        }
+
+        auto hdr = reinterpret_cast<const DDS_HEADER*>(ddsData + sizeof(uint32_t));
+
+        // Verify header to validate DDS file
+        if (hdr->size != sizeof(DDS_HEADER) ||
+            hdr->ddspf.size != sizeof(DDS_PIXELFORMAT))
+        {
+            return E_FAIL;
+        }
+
+        // Check for DX10 extension
+        if ((hdr->ddspf.flags & DDS_FOURCC) &&
+            (MAKEFOURCC('D', 'X', '1', '0') == hdr->ddspf.fourCC))
+        {
+            // We don't support the new DX10 header for Direct3D 9
+            return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+        }
+
+        // setup the pointers in the process request
+        *header = hdr;
+        auto offset = sizeof(uint32_t) + sizeof(DDS_HEADER);
+        *bitData = ddsData + offset;
+        *bitSize = ddsDataSize - offset;
+
+        return S_OK;
+    }
+
+
+    //--------------------------------------------------------------------------------------
+    HRESULT LoadTextureDataFromFile(
+        _In_z_ const wchar_t* fileName,
+        std::unique_ptr<uint8_t[]>& ddsData,
+        const DDS_HEADER** header,
+        const uint8_t** bitData,
+        size_t* bitSize) noexcept
+    {
+        if (!header || !bitData || !bitSize)
+        {
+            return E_POINTER;
+        }
+
+        // open the file
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+        ScopedHandle hFile(safe_handle(CreateFile2(fileName,
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            OPEN_EXISTING,
+            nullptr)));
+#else
+        ScopedHandle hFile(safe_handle(CreateFileW(fileName,
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            nullptr)));
+#endif
+
+        if (!hFile)
+        {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        // Get the file size
+        FILE_STANDARD_INFO fileInfo;
+        if (!GetFileInformationByHandleEx(hFile.get(), FileStandardInfo, &fileInfo, sizeof(fileInfo)))
+        {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        // File is too big for 32-bit allocation, so reject read
+        if (fileInfo.EndOfFile.HighPart > 0)
+        {
+            return E_FAIL;
+        }
+
+        // Need at least enough data to fill the header and magic number to be a valid DDS
+        if (fileInfo.EndOfFile.LowPart < (sizeof(uint32_t) + sizeof(DDS_HEADER)))
+        {
+            return E_FAIL;
+        }
+
+        // create enough space for the file data
+        ddsData.reset(new (std::nothrow) uint8_t[fileInfo.EndOfFile.LowPart]);
+        if (!ddsData)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        // read the data in
+        DWORD BytesRead = 0;
+        if (!ReadFile(hFile.get(),
+            ddsData.get(),
+            fileInfo.EndOfFile.LowPart,
+            &BytesRead,
+            nullptr
+        ))
+        {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (BytesRead < fileInfo.EndOfFile.LowPart)
+        {
+            return E_FAIL;
+        }
+
+        // DDS files always start with the same magic number ("DDS ")
+        auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
+        if (dwMagicNumber != DDS_MAGIC)
+        {
+            return E_FAIL;
+        }
+
+        auto hdr = reinterpret_cast<const DDS_HEADER*>(ddsData.get() + sizeof(uint32_t));
+
+        // Verify header to validate DDS file
+        if (hdr->size != sizeof(DDS_HEADER) ||
+            hdr->ddspf.size != sizeof(DDS_PIXELFORMAT))
+        {
+            return E_FAIL;
+        }
+
+        // Check for DX10 extension
+        if ((hdr->ddspf.flags & DDS_FOURCC) &&
+            (MAKEFOURCC('D', 'X', '1', '0') == hdr->ddspf.fourCC))
+        {
+            // We don't support the new DX10 header for Direct3D 9
+            return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+        }
+
+        // setup the pointers in the process request
+        *header = hdr;
+        auto offset = sizeof(uint32_t) + sizeof(DDS_HEADER);
+        *bitData = ddsData.get() + offset;
+        *bitSize = fileInfo.EndOfFile.LowPart - offset;
+
+        return S_OK;
+    }
+
+
+    //--------------------------------------------------------------------------------------
+    // Return the BPP for a particular format
+    //--------------------------------------------------------------------------------------
+    size_t BitsPerPixel(_In_ D3DFORMAT fmt) noexcept
+    {
+        switch (static_cast<int>(fmt))
+        {
+        case D3DFMT_A32B32G32R32F:
+            return 128;
+
+        case D3DFMT_A16B16G16R16:
+        case D3DFMT_Q16W16V16U16:
+        case D3DFMT_A16B16G16R16F:
+        case D3DFMT_G32R32F:
+            return 64;
+
+        case D3DFMT_A8R8G8B8:
+        case D3DFMT_X8R8G8B8:
+        case D3DFMT_A2B10G10R10:
+        case D3DFMT_A8B8G8R8:
+        case D3DFMT_X8B8G8R8:
+        case D3DFMT_G16R16:
+        case D3DFMT_A2R10G10B10:
+        case D3DFMT_Q8W8V8U8:
+        case D3DFMT_V16U16:
+        case D3DFMT_X8L8V8U8:
+        case D3DFMT_A2W10V10U10:
+        case D3DFMT_D32:
+        case D3DFMT_D24S8:
+        case D3DFMT_D24X8:
+        case D3DFMT_D24X4S4:
+        case D3DFMT_D32F_LOCKABLE:
+        case D3DFMT_D24FS8:
+        case D3DFMT_INDEX32:
+        case D3DFMT_G16R16F:
+        case D3DFMT_R32F:
+            return 32;
+
+        case D3DFMT_R8G8B8:
+            return 24;
+
+        case D3DFMT_A4R4G4B4:
+        case D3DFMT_X4R4G4B4:
+        case D3DFMT_R5G6B5:
+        case D3DFMT_L16:
+        case D3DFMT_A8L8:
+        case D3DFMT_X1R5G5B5:
+        case D3DFMT_A1R5G5B5:
+        case D3DFMT_A8R3G3B2:
+        case D3DFMT_V8U8:
+        case D3DFMT_CxV8U8:
+        case D3DFMT_L6V5U5:
+        case D3DFMT_G8R8_G8B8:
+        case D3DFMT_R8G8_B8G8:
+        case D3DFMT_D16_LOCKABLE:
+        case D3DFMT_D15S1:
+        case D3DFMT_D16:
+        case D3DFMT_INDEX16:
+        case D3DFMT_R16F:
+        case D3DFMT_YUY2:
+            return 16;
+
+        case D3DFMT_R3G3B2:
+        case D3DFMT_A8:
+        case D3DFMT_A8P8:
+        case D3DFMT_P8:
+        case D3DFMT_L8:
+        case D3DFMT_A4L4:
+            return 8;
+
+        case D3DFMT_DXT1:
+            return 4;
+
+        case D3DFMT_DXT2:
+        case D3DFMT_DXT3:
+        case D3DFMT_DXT4:
+        case D3DFMT_DXT5:
+            return  8;
+
+            // From DX docs, reference/d3d/enums/d3dformat.asp
+            // (note how it says that D3DFMT_R8G8_B8G8 is "A 16-bit packed RGB format analogous to UYVY (U0Y0, V0Y1, U2Y2, and so on)")
+        case D3DFMT_UYVY:
+            return 16;
+
+            // http://msdn.microsoft.com/library/default.asp?url=/library/en-us/directshow/htm/directxvideoaccelerationdxvavideosubtypes.asp
+        case MAKEFOURCC('A', 'I', '4', '4'):
+        case MAKEFOURCC('I', 'A', '4', '4'):
+            return 8;
+
+        case MAKEFOURCC('Y', 'V', '1', '2'):
+            return 12;
+
+#if !defined(D3D_DISABLE_9EX)
+        case D3DFMT_D32_LOCKABLE:
+            return 32;
+
+        case D3DFMT_S8_LOCKABLE:
+            return 8;
+
+        case D3DFMT_A1:
+            return 1;
+#endif // !D3D_DISABLE_9EX
+
+        default:
+            return 0;
+        }
+    }
+
+
+    //--------------------------------------------------------------------------------------
+    // Get surface information for a particular format
+    //--------------------------------------------------------------------------------------
+    HRESULT GetSurfaceInfo(
+        _In_ size_t width,
+        _In_ size_t height,
+        _In_ D3DFORMAT fmt,
+        size_t* outNumBytes,
+        _Out_opt_ size_t* outRowBytes,
+        _Out_opt_ size_t* outNumRows) noexcept
+    {
+        uint64_t numBytes = 0;
+        uint64_t rowBytes = 0;
+        uint64_t numRows = 0;
+
+        bool bc = false;
+        bool packed = false;
+        size_t bpe = 0;
+        switch (static_cast<int>(fmt))
+        {
+        case D3DFMT_DXT1:
+            bc = true;
+            bpe = 8;
+            break;
+
+        case D3DFMT_DXT2:
+        case D3DFMT_DXT3:
+        case D3DFMT_DXT4:
+        case D3DFMT_DXT5:
+            bc = true;
+            bpe = 16;
+            break;
+
+        case D3DFMT_R8G8_B8G8:
+        case D3DFMT_G8R8_G8B8:
+        case D3DFMT_UYVY:
+        case D3DFMT_YUY2:
+            packed = true;
+            bpe = 4;
+            break;
+
+        default:
+            break;
+        }
+
+        if (bc)
+        {
+            uint64_t numBlocksWide = 0;
+            if (width > 0)
+            {
+                numBlocksWide = std::max<uint64_t>(1u, (uint64_t(width) + 3u) / 4u);
+            }
+            uint64_t numBlocksHigh = 0;
+            if (height > 0)
+            {
+                numBlocksHigh = std::max<uint64_t>(1u, (uint64_t(height) + 3u) / 4u);
+            }
+            rowBytes = numBlocksWide * bpe;
+            numRows = numBlocksHigh;
+            numBytes = rowBytes * numBlocksHigh;
+        }
+        else if (packed)
+        {
+            rowBytes = ((uint64_t(width) + 1u) >> 1) * bpe;
+            numRows = uint64_t(height);
+            numBytes = rowBytes * height;
+        }
+        else
+        {
+            size_t bpp = BitsPerPixel(fmt);
+            if (!bpp)
+                return E_INVALIDARG;
+
+            rowBytes = (uint64_t(width) * bpp + 7u) / 8u; // round up to nearest byte
+            numRows = uint64_t(height);
+            numBytes = rowBytes * height;
+        }
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_HYBRID_X86_ARM64)
+        static_assert(sizeof(size_t) == 4, "Not a 32-bit platform!");
+        if (numBytes > UINT32_MAX || rowBytes > UINT32_MAX || numRows > UINT32_MAX)
+            return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
+#else
+        static_assert(sizeof(size_t) == 8, "Not a 64-bit platform!");
+#endif
+
+        if (outNumBytes)
+        {
+            *outNumBytes = static_cast<size_t>(numBytes);
+        }
+        if (outRowBytes)
+        {
+            *outRowBytes = static_cast<size_t>(rowBytes);
+        }
+        if (outNumRows)
+        {
+            *outNumRows = static_cast<size_t>(numRows);
+        }
+
+        return S_OK;
+    }
+
+
+    //--------------------------------------------------------------------------------------
+    #define ISBITMASK( r,g,b,a ) ( ddpf.RBitMask == r && ddpf.GBitMask == g && ddpf.BBitMask == b && ddpf.ABitMask == a )
+
+    D3DFORMAT GetD3D9Format(const DDS_PIXELFORMAT& ddpf) noexcept
+    {
+        if (ddpf.flags & DDS_RGB)
+        {
+            switch (ddpf.RGBBitCount)
+            {
+            case 32:
+                if (ISBITMASK(0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000))
+                {
+                    return D3DFMT_A8R8G8B8;
+                }
+                if (ISBITMASK(0x00ff0000, 0x0000ff00, 0x000000ff, 0))
+                {
+                    return D3DFMT_X8R8G8B8;
+                }
+                if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000))
+                {
+                    return D3DFMT_A8B8G8R8;
+                }
+                if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0))
+                {
+                    return D3DFMT_X8B8G8R8;
+                }
+
+                // Note that many common DDS reader/writers (including D3DX) swap the
+                // the RED/BLUE masks for 10:10:10:2 formats. We assume
+                // below that the 'backwards' header mask is being used since it is most
+                // likely written by D3DX.
+                
+                // For 'correct' writers this should be 0x3ff00000,0x000ffc00,0x000003ff for BGR data
+                if (ISBITMASK(0x000003ff, 0x000ffc00, 0x3ff00000, 0xc0000000))
+                {
+                    return D3DFMT_A2R10G10B10;
+                }
+
+                // For 'correct' writers this should be 0x000003ff,0x000ffc00,0x3ff00000 for RGB data
+                if (ISBITMASK(0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000))
+                {
+                    return D3DFMT_A2B10G10R10;
+                }
+
+                if (ISBITMASK(0x0000ffff, 0xffff0000, 0x00000000, 0x00000000))
+                {
+                    return D3DFMT_G16R16;
+                }
+                if (ISBITMASK(0xffffffff, 0x00000000, 0x00000000, 0x00000000))
+                {
+                    return D3DFMT_R32F; // D3DX writes this out as a FourCC of 114
+                }
+                break;
+
+            case 24:
+                if (ISBITMASK(0xff0000, 0x00ff00, 0x0000ff, 0))
+                {
+                    return D3DFMT_R8G8B8;
+                }
+                break;
+
+            case 16:
+                if (ISBITMASK(0xf800, 0x07e0, 0x001f, 0x0000))
+                {
+                    return D3DFMT_R5G6B5;
+                }
+                if (ISBITMASK(0x7c00, 0x03e0, 0x001f, 0x8000))
+                {
+                    return D3DFMT_A1R5G5B5;
+                }
+                if (ISBITMASK(0x7c00, 0x03e0, 0x001f, 0))
+                {
+                    return D3DFMT_X1R5G5B5;
+                }
+                if (ISBITMASK(0x0f00, 0x00f0, 0x000f, 0xf000))
+                {
+                    return D3DFMT_A4R4G4B4;
+                }
+                if (ISBITMASK(0x0f00, 0x00f0, 0x000f, 0))
+                {
+                    return D3DFMT_X4R4G4B4;
+                }
+                if (ISBITMASK(0x00e0, 0x001c, 0x0003, 0xff00))
+                {
+                    return D3DFMT_A8R3G3B2;
+                }
+                break;
+
+            case 8:
+                if (ISBITMASK(0xe0, 0x1c, 0x03, 0x00))
+                {
+                    return D3DFMT_R3G3B2;
+                }
+
+                // Paletted texture formats are typically not supported on modern video cards aka D3DFMT_P8, D3DFMT_A8P8
+                break;
+            }
+        }
+        else if (ddpf.flags & DDS_LUMINANCE)
+        {
+            if (8 == ddpf.RGBBitCount)
+            {
+                if (ISBITMASK(0x0f, 0, 0, 0xf0))
+                {
+                    return D3DFMT_A4L4;
+                }
+                if (ISBITMASK(0xff, 0, 0, 0))
+                {
+                    return D3DFMT_L8;
+                }
+            }
+
+            if (16 == ddpf.RGBBitCount)
+            {
+                if (ISBITMASK(0xffff, 0, 0, 0))
+                {
+                    return D3DFMT_L16;
+                }
+                if (ISBITMASK(0x00ff, 0, 0, 0xff00))
+                {
+                    return D3DFMT_A8L8;
+                }
+
+            }
+        }
+        else if (ddpf.flags & DDS_ALPHA)
+        {
+            if (8 == ddpf.RGBBitCount)
+            {
+                return D3DFMT_A8;
+            }
+        }
+        else if (ddpf.flags & DDS_BUMPDUDV)
+        {
+            if (16 == ddpf.RGBBitCount)
+            {
+                if (ISBITMASK(0x00ff, 0xff00, 0, 0))
+                {
+                    return D3DFMT_V8U8;
+                }
+            }
+
+            if (32 == ddpf.RGBBitCount)
+            {
+                if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000))
+                {
+                    return D3DFMT_Q8W8V8U8;
+                }
+                if (ISBITMASK(0x0000ffff, 0xffff0000, 0x00000000, 0x00000000))
+                {
+                    return D3DFMT_V16U16;
+                }
+                if (ISBITMASK(0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000))
+                {
+                    return D3DFMT_A2W10V10U10;
+                }
+            }
+        }
+        else if (ddpf.flags & DDS_BUMPLUMINANCE)
+        {
+            if (16 == ddpf.RGBBitCount)
+            {
+                if (ISBITMASK(0x001f, 0x03e0, 0xfc00, 0))
+                {
+                    return D3DFMT_L6V5U5;
+                }
+            }
+
+            if (32 == ddpf.RGBBitCount)
+            {
+                if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0))
+                {
+                    return D3DFMT_X8L8V8U8;
+                }
+            }
+        }
+        else if (ddpf.flags & DDS_FOURCC)
+        {
+            if (MAKEFOURCC('D', 'X', 'T', '1') == ddpf.fourCC)
+            {
+                return D3DFMT_DXT1;
+            }
+            if (MAKEFOURCC('D', 'X', 'T', '2') == ddpf.fourCC)
+            {
+                return D3DFMT_DXT2;
+            }
+            if (MAKEFOURCC('D', 'X', 'T', '3') == ddpf.fourCC)
+            {
+                return D3DFMT_DXT3;
+            }
+            if (MAKEFOURCC('D', 'X', 'T', '4') == ddpf.fourCC)
+            {
+                return D3DFMT_DXT4;
+            }
+            if (MAKEFOURCC('D', 'X', 'T', '5') == ddpf.fourCC)
+            {
+                return D3DFMT_DXT5;
+            }
+
+            if (MAKEFOURCC('R', 'G', 'B', 'G') == ddpf.fourCC)
+            {
+                return D3DFMT_R8G8_B8G8;
+            }
+            if (MAKEFOURCC('G', 'R', 'G', 'B') == ddpf.fourCC)
+            {
+                return D3DFMT_G8R8_G8B8;
+            }
+
+            if (MAKEFOURCC('U', 'Y', 'V', 'Y') == ddpf.fourCC)
+            {
+                return D3DFMT_UYVY;
+            }
+            if (MAKEFOURCC('Y', 'U', 'Y', '2') == ddpf.fourCC)
+            {
+                return D3DFMT_YUY2;
+            }
+
+            // Check for D3DFORMAT enums being set here
+            switch (ddpf.fourCC)
+            {
+            case D3DFMT_A16B16G16R16:
+            case D3DFMT_Q16W16V16U16:
+            case D3DFMT_R16F:
+            case D3DFMT_G16R16F:
+            case D3DFMT_A16B16G16R16F:
+            case D3DFMT_R32F:
+            case D3DFMT_G32R32F:
+            case D3DFMT_A32B32G32R32F:
+            case D3DFMT_CxV8U8:
+                return static_cast<D3DFORMAT>(ddpf.fourCC);
+            }
+        }
+
+        return D3DFMT_UNKNOWN;
+    }
+} // anonymous namespace
+
+//--------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromMemory(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const uint8_t* ddsData,
+    size_t ddsDataSize,
+    LPDIRECT3DBASETEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+    
+    if (!d3dDevice || !ddsData || !texture)
+    {
+        return E_INVALIDARG;
+    }
+
+    // Validate DDS file in memory
+    const DDS_HEADER* header = nullptr;
+    const uint8_t* bitData = nullptr;
+    size_t bitSize = 0;
+
+    HRESULT hr = LoadTextureDataFromMemory(ddsData, ddsDataSize,
+        &header,
+        &bitData,
+        &bitSize
+    );
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    // TODO -
+    return E_NOTIMPL;
+}
+
+// Type-specific versions
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromMemory(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const uint8_t* ddsData,
+    size_t ddsDataSize,
+    LPDIRECT3DTEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !ddsData || !ddsDataSize || !texture)
+        return E_INVALIDARG;
+
+    ComPtr<IDirect3DBaseTexture9> tex;
+    HRESULT hr = CreateDDSTextureFromMemory(d3dDevice, ddsData, ddsDataSize, tex.GetAddressOf());
+    if (SUCCEEDED(hr))
+    {
+        hr = E_FAIL;
+        if (tex->GetType() == D3DRTYPE_TEXTURE)
+        {
+            *texture = reinterpret_cast<LPDIRECT3DTEXTURE9>(tex.Detach());
+            return S_OK;
+        }
+    }
+
+    return hr;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromMemory(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const uint8_t* ddsData,
+    size_t ddsDataSize,
+    LPDIRECT3DCUBETEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !ddsData || !ddsDataSize || !texture)
+        return E_INVALIDARG;
+
+    ComPtr<IDirect3DBaseTexture9> tex;
+    HRESULT hr = CreateDDSTextureFromMemory(d3dDevice, ddsData, ddsDataSize, tex.GetAddressOf());
+    if (SUCCEEDED(hr))
+    {
+        hr = E_FAIL;
+        if (tex->GetType() == D3DRTYPE_CUBETEXTURE)
+        {
+            *texture = reinterpret_cast<LPDIRECT3DCUBETEXTURE9>(tex.Detach());
+            return S_OK;
+        }
+    }
+
+    return hr;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromMemory(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const uint8_t* ddsData,
+    size_t ddsDataSize,
+    LPDIRECT3DVOLUMETEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !ddsData || !ddsDataSize || !texture)
+        return E_INVALIDARG;
+
+    ComPtr<IDirect3DBaseTexture9> tex;
+    HRESULT hr = CreateDDSTextureFromMemory(d3dDevice, ddsData, ddsDataSize, tex.GetAddressOf());
+    if (SUCCEEDED(hr))
+    {
+        hr = E_FAIL;
+        if (tex->GetType() == D3DRTYPE_VOLUMETEXTURE)
+        {
+            *texture = reinterpret_cast<LPDIRECT3DVOLUMETEXTURE9>(tex.Detach());
+            return S_OK;
+        }
+    }
+
+    return hr;
+}
+
+
+//--------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromFile(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const wchar_t* szFileName,
+    LPDIRECT3DBASETEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !szFileName || !texture)
+        return E_INVALIDARG;
+
+    // TODO -
+    return E_NOTIMPL;
+}
+
+// Type-specific versions
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromFile(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const wchar_t* szFileName,
+    LPDIRECT3DTEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !szFileName || !texture)
+        return E_INVALIDARG;
+
+    ComPtr<IDirect3DBaseTexture9> tex;
+    HRESULT hr = CreateDDSTextureFromFile(d3dDevice, szFileName, tex.GetAddressOf());
+    if (SUCCEEDED(hr))
+    {
+        hr = E_FAIL;
+        if (tex->GetType() == D3DRTYPE_TEXTURE)
+        {
+            *texture = reinterpret_cast<LPDIRECT3DTEXTURE9>(tex.Detach());
+            return S_OK;
+        }
+    }
+
+    return hr;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromFile(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const wchar_t* szFileName,
+    LPDIRECT3DCUBETEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !szFileName || !texture)
+        return E_INVALIDARG;
+
+    ComPtr<IDirect3DBaseTexture9> tex;
+    HRESULT hr = CreateDDSTextureFromFile(d3dDevice, szFileName, tex.GetAddressOf());
+    if (SUCCEEDED(hr))
+    {
+        hr = E_FAIL;
+        if (tex->GetType() == D3DRTYPE_CUBETEXTURE)
+        {
+            *texture = reinterpret_cast<LPDIRECT3DCUBETEXTURE9>(tex.Detach());
+            return S_OK;
+        }
+    }
+
+    return hr;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::CreateDDSTextureFromFile(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const wchar_t* szFileName,
+    LPDIRECT3DVOLUMETEXTURE9* texture) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !szFileName || !texture)
+        return E_INVALIDARG;
+
+    ComPtr<IDirect3DBaseTexture9> tex;
+    HRESULT hr = CreateDDSTextureFromFile(d3dDevice, szFileName, tex.GetAddressOf());
+    if (SUCCEEDED(hr))
+    {
+        hr = E_FAIL;
+        if (tex->GetType() == D3DRTYPE_VOLUMETEXTURE)
+        {
+            *texture = reinterpret_cast<LPDIRECT3DVOLUMETEXTURE9>(tex.Detach());
+            return S_OK;
+        }
+    }
+
+    return hr;
+}

--- a/DDSTextureLoader/DDSTextureLoader9.cpp
+++ b/DDSTextureLoader/DDSTextureLoader9.cpp
@@ -583,7 +583,7 @@ namespace
                 break;
 
             case 8:
-                if (ISBITMASK(0xe0, 0x1c, 0x03, 0x00))
+                if (ISBITMASK(0xe0, 0x1c, 0x03, 0))
                 {
                     return D3DFMT_R3G3B2;
                 }

--- a/DDSTextureLoader/DDSTextureLoader9.cpp
+++ b/DDSTextureLoader/DDSTextureLoader9.cpp
@@ -71,8 +71,6 @@ struct DDS_PIXELFORMAT
 
 #define DDS_HEADER_FLAGS_VOLUME         0x00800000  // DDSD_DEPTH
 
-#define DDS_HEIGHT 0x00000002 // DDSD_HEIGHT
-
 #define DDS_CUBEMAP_POSITIVEX 0x00000600 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEX
 #define DDS_CUBEMAP_NEGATIVEX 0x00000a00 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEX
 #define DDS_CUBEMAP_POSITIVEY 0x00001200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEY
@@ -824,7 +822,7 @@ namespace
                         // Copy stride line by line
                         for (size_t h = 0; h < NumRows; h++)
                         {
-                            memcpy_s(dptr, LockedBox.RowPitch, sptr, RowBytes);
+                            memcpy_s(dptr, static_cast<size_t>(LockedBox.RowPitch), sptr, RowBytes);
                             dptr += LockedBox.RowPitch;
                             sptr += RowBytes;
                         }
@@ -915,7 +913,7 @@ namespace
                         // Copy stride line by line
                         for (size_t r = 0; r < NumRows; r++)
                         {
-                            memcpy_s(pDestBits, LockedRect.Pitch, pSrcBits, RowBytes);
+                            memcpy_s(pDestBits, static_cast<size_t>(LockedRect.Pitch), pSrcBits, RowBytes);
                             pDestBits += LockedRect.Pitch;
                             pSrcBits += RowBytes;
                         }
@@ -988,7 +986,7 @@ namespace
                     // Copy stride line by line
                     for (UINT h = 0; h < NumRows; h++)
                     {
-                        memcpy_s(pDestBits, LockedRect.Pitch, pSrcBits, RowBytes);
+                        memcpy_s(pDestBits, static_cast<size_t>(LockedRect.Pitch), pSrcBits, RowBytes);
                         pDestBits += LockedRect.Pitch;
                         pSrcBits += RowBytes;
                     }
@@ -1080,7 +1078,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         hr = E_FAIL;
         if (tex->GetType() == D3DRTYPE_TEXTURE)
         {
-            *texture = reinterpret_cast<LPDIRECT3DTEXTURE9>(tex.Detach());
+            *texture = static_cast<LPDIRECT3DTEXTURE9>(tex.Detach());
             return S_OK;
         }
     }
@@ -1110,7 +1108,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         hr = E_FAIL;
         if (tex->GetType() == D3DRTYPE_CUBETEXTURE)
         {
-            *texture = reinterpret_cast<LPDIRECT3DCUBETEXTURE9>(tex.Detach());
+            *texture = static_cast<LPDIRECT3DCUBETEXTURE9>(tex.Detach());
             return S_OK;
         }
     }
@@ -1140,7 +1138,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         hr = E_FAIL;
         if (tex->GetType() == D3DRTYPE_VOLUMETEXTURE)
         {
-            *texture = reinterpret_cast<LPDIRECT3DVOLUMETEXTURE9>(tex.Detach());
+            *texture = static_cast<LPDIRECT3DVOLUMETEXTURE9>(tex.Detach());
             return S_OK;
         }
     }
@@ -1213,7 +1211,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         hr = E_FAIL;
         if (tex->GetType() == D3DRTYPE_TEXTURE)
         {
-            *texture = reinterpret_cast<LPDIRECT3DTEXTURE9>(tex.Detach());
+            *texture = static_cast<LPDIRECT3DTEXTURE9>(tex.Detach());
             return S_OK;
         }
     }
@@ -1242,7 +1240,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         hr = E_FAIL;
         if (tex->GetType() == D3DRTYPE_CUBETEXTURE)
         {
-            *texture = reinterpret_cast<LPDIRECT3DCUBETEXTURE9>(tex.Detach());
+            *texture = static_cast<LPDIRECT3DCUBETEXTURE9>(tex.Detach());
             return S_OK;
         }
     }
@@ -1271,7 +1269,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         hr = E_FAIL;
         if (tex->GetType() == D3DRTYPE_VOLUMETEXTURE)
         {
-            *texture = reinterpret_cast<LPDIRECT3DVOLUMETEXTURE9>(tex.Detach());
+            *texture = static_cast<LPDIRECT3DVOLUMETEXTURE9>(tex.Detach());
             return S_OK;
         }
     }

--- a/DDSTextureLoader/DDSTextureLoader9.h
+++ b/DDSTextureLoader/DDSTextureLoader9.h
@@ -1,0 +1,71 @@
+//--------------------------------------------------------------------------------------
+// File: DDSTextureLoader9.h
+//
+// Functions for loading a DDS texture and creating a Direct3D runtime resource for it
+//
+// Note these functions are useful as a light-weight runtime loader for DDS files. For
+// a full-featured DDS file reader, writer, and texture processing pipeline see
+// the 'Texconv' sample and the 'DirectXTex' library.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#define DIRECT3D_VERSION 0x900
+#include <d3d9.h>
+
+#include <cstdint>
+
+
+namespace DirectX
+{
+    // Standard version
+    HRESULT CreateDDSTextureFromMemory(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_ LPDIRECT3DBASETEXTURE9* texture) noexcept;
+
+    HRESULT CreateDDSTextureFromFile(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_z_ const wchar_t* szFileName,
+        _Outptr_ LPDIRECT3DBASETEXTURE9* texture) noexcept;
+
+    // Type-specific versions
+    HRESULT CreateDDSTextureFromMemory(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_ LPDIRECT3DTEXTURE9* texture) noexcept;
+
+    HRESULT CreateDDSTextureFromFile(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_z_ const wchar_t* szFileName,
+        _Outptr_ LPDIRECT3DTEXTURE9* texture) noexcept;
+
+    HRESULT CreateDDSTextureFromMemory(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_ LPDIRECT3DCUBETEXTURE9* texture) noexcept;
+
+    HRESULT CreateDDSTextureFromFile(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_z_ const wchar_t* szFileName,
+        _Outptr_ LPDIRECT3DCUBETEXTURE9* texture) noexcept;
+
+    HRESULT CreateDDSTextureFromMemory(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_ LPDIRECT3DVOLUMETEXTURE9* texture) noexcept;
+
+    HRESULT CreateDDSTextureFromFile(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_z_ const wchar_t* szFileName,
+        _Outptr_ LPDIRECT3DVOLUMETEXTURE9* texture) noexcept;
+}

--- a/DDSTextureLoader/DDSTextureLoader9.h
+++ b/DDSTextureLoader/DDSTextureLoader9.h
@@ -31,24 +31,28 @@ namespace DirectX
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
         _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
         _In_ size_t ddsDataSize,
-        _Outptr_ LPDIRECT3DBASETEXTURE9* texture) noexcept;
+        _Outptr_ LPDIRECT3DBASETEXTURE9* texture,
+        bool generateMipsIfMissing = false) noexcept;
 
     HRESULT CreateDDSTextureFromFile(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
-        _In_z_ const wchar_t* szFileName,
-        _Outptr_ LPDIRECT3DBASETEXTURE9* texture) noexcept;
+        _In_z_ const wchar_t* fileName,
+        _Outptr_ LPDIRECT3DBASETEXTURE9* texture,
+        bool generateMipsIfMissing = false) noexcept;
 
     // Type-specific versions
     HRESULT CreateDDSTextureFromMemory(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
         _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
         _In_ size_t ddsDataSize,
-        _Outptr_ LPDIRECT3DTEXTURE9* texture) noexcept;
+        _Outptr_ LPDIRECT3DTEXTURE9* texture,
+        bool generateMipsIfMissing = false) noexcept;
 
     HRESULT CreateDDSTextureFromFile(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
-        _In_z_ const wchar_t* szFileName,
-        _Outptr_ LPDIRECT3DTEXTURE9* texture) noexcept;
+        _In_z_ const wchar_t* fileName,
+        _Outptr_ LPDIRECT3DTEXTURE9* texture,
+        bool generateMipsIfMissing = false) noexcept;
 
     HRESULT CreateDDSTextureFromMemory(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
@@ -58,7 +62,7 @@ namespace DirectX
 
     HRESULT CreateDDSTextureFromFile(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
-        _In_z_ const wchar_t* szFileName,
+        _In_z_ const wchar_t* fileName,
         _Outptr_ LPDIRECT3DCUBETEXTURE9* texture) noexcept;
 
     HRESULT CreateDDSTextureFromMemory(
@@ -69,6 +73,6 @@ namespace DirectX
 
     HRESULT CreateDDSTextureFromFile(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
-        _In_z_ const wchar_t* szFileName,
+        _In_z_ const wchar_t* fileName,
         _Outptr_ LPDIRECT3DVOLUMETEXTURE9* texture) noexcept;
 }

--- a/DDSTextureLoader/DDSTextureLoader9.h
+++ b/DDSTextureLoader/DDSTextureLoader9.h
@@ -15,7 +15,10 @@
 
 #pragma once
 
+#ifndef DIRECT3D_VERSION
 #define DIRECT3D_VERSION 0x900
+#endif
+
 #include <d3d9.h>
 
 #include <cstdint>

--- a/DirectXTex/DDS.h
+++ b/DirectXTex/DDS.h
@@ -136,7 +136,7 @@ extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_A8R3G3B2 =
 extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_R3G3B2 =
     { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xe0, 0x1c, 0x03, 0 };
 
-extern __declspec(selectany) DDS_PIXELFORMAT DDSPF_A4L4 =
+extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_A4L4 =
     { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 8, 0x0f, 0, 0, 0xf0 };
 
 extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_L8 =

--- a/ScreenGrab/ScreenGrab11.cpp
+++ b/ScreenGrab/ScreenGrab11.cpp
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------
-// File: ScreenGrab.cpp
+// File: ScreenGrab11.cpp
 //
 // Function for capturing a 2D texture and saving it to a file (aka a 'screenshot'
 // when used on a Direct3D 11 Render Target).
@@ -21,7 +21,7 @@
 
 // For 2D array textures and cubemaps, it captures only the first image in the array
 
-#include "ScreenGrab.h"
+#include "ScreenGrab11.h"
 
 #include <dxgiformat.h>
 #include <assert.h>

--- a/ScreenGrab/ScreenGrab11.cpp
+++ b/ScreenGrab/ScreenGrab11.cpp
@@ -33,6 +33,11 @@
 #include <algorithm>
 #include <memory>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
 using Microsoft::WRL::ComPtr;
 
 //--------------------------------------------------------------------------------------
@@ -190,16 +195,16 @@ namespace
         { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','1','0'), 0, 0, 0, 0, 0 };
 
     //-----------------------------------------------------------------------------
-    struct handle_closer { void operator()(HANDLE h) { if (h) CloseHandle(h); } };
+    struct handle_closer { void operator()(HANDLE h) noexcept { if (h) CloseHandle(h); } };
 
     using ScopedHandle = std::unique_ptr<void, handle_closer>;
 
-    inline HANDLE safe_handle( HANDLE h ) { return (h == INVALID_HANDLE_VALUE) ? nullptr : h; }
+    inline HANDLE safe_handle( HANDLE h ) noexcept { return (h == INVALID_HANDLE_VALUE) ? nullptr : h; }
 
     class auto_delete_file
     {
     public:
-        auto_delete_file(HANDLE hFile) : m_handle(hFile) {}
+        auto_delete_file(HANDLE hFile) noexcept : m_handle(hFile) {}
         ~auto_delete_file()
         {
             if (m_handle)
@@ -210,19 +215,22 @@ namespace
             }
         }
 
-        void clear() { m_handle = nullptr; }
+        auto_delete_file(const auto_delete_file&) = delete;
+        auto_delete_file& operator=(const auto_delete_file&) = delete;
+
+        auto_delete_file(const auto_delete_file&&) = delete;
+        auto_delete_file& operator=(const auto_delete_file&&) = delete;
+
+        void clear() noexcept { m_handle = nullptr; }
 
     private:
         HANDLE m_handle;
-
-        auto_delete_file(const auto_delete_file&) = delete;
-        auto_delete_file& operator=(const auto_delete_file&) = delete;
     };
 
     class auto_delete_file_wic
     {
     public:
-        auto_delete_file_wic(ComPtr<IWICStream>& hFile, const wchar_t* szFile) : m_filename(szFile), m_handle(hFile) {}
+        auto_delete_file_wic(ComPtr<IWICStream>& hFile, const wchar_t* szFile) noexcept : m_filename(szFile), m_handle(hFile) {}
         ~auto_delete_file_wic()
         {
             if (m_filename)
@@ -232,14 +240,17 @@ namespace
             }
         }
 
-        void clear() { m_filename = nullptr; }
+        auto_delete_file_wic(const auto_delete_file_wic&) = delete;
+        auto_delete_file_wic& operator=(const auto_delete_file_wic&) = delete;
+
+        auto_delete_file_wic(const auto_delete_file_wic&&) = delete;
+        auto_delete_file_wic& operator=(const auto_delete_file_wic&&) = delete;
+
+        void clear() noexcept { m_filename = nullptr; }
 
     private:
         const wchar_t* m_filename;
         ComPtr<IWICStream>& m_handle;
-
-        auto_delete_file_wic(const auto_delete_file_wic&) = delete;
-        auto_delete_file_wic& operator=(const auto_delete_file_wic&) = delete;
     };
 
     //--------------------------------------------------------------------------------------

--- a/ScreenGrab/ScreenGrab11.h
+++ b/ScreenGrab/ScreenGrab11.h
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------
-// File: ScreenGrab.h
+// File: ScreenGrab11.h
 //
 // Function for capturing a 2D texture and saving it to a file (aka a 'screenshot'
 // when used on a Direct3D 11 Render Target).

--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -198,16 +198,16 @@ namespace
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','1','0'), 0, 0, 0, 0, 0 };
 
     //-----------------------------------------------------------------------------
-    struct handle_closer { void operator()(HANDLE h) { if (h) CloseHandle(h); } };
+    struct handle_closer { void operator()(HANDLE h) noexcept { if (h) CloseHandle(h); } };
 
     using ScopedHandle = std::unique_ptr<void, handle_closer>;
 
-    inline HANDLE safe_handle( HANDLE h ) { return (h == INVALID_HANDLE_VALUE) ? nullptr : h; }
+    inline HANDLE safe_handle( HANDLE h ) noexcept { return (h == INVALID_HANDLE_VALUE) ? nullptr : h; }
 
     class auto_delete_file
     {
     public:
-        auto_delete_file(HANDLE hFile) : m_handle(hFile) {}
+        auto_delete_file(HANDLE hFile) noexcept : m_handle(hFile) {}
         ~auto_delete_file()
         {
             if (m_handle)
@@ -218,19 +218,22 @@ namespace
             }
         }
 
-        void clear() { m_handle = nullptr; }
+        auto_delete_file(const auto_delete_file&) = delete;
+        auto_delete_file& operator=(const auto_delete_file&) = delete;
+
+        auto_delete_file(const auto_delete_file&&) = delete;
+        auto_delete_file& operator=(const auto_delete_file&&) = delete;
+
+        void clear() noexcept { m_handle = nullptr; }
 
     private:
         HANDLE m_handle;
-
-        auto_delete_file(const auto_delete_file&) = delete;
-        auto_delete_file& operator=(const auto_delete_file&) = delete;
     };
 
     class auto_delete_file_wic
     {
     public:
-        auto_delete_file_wic(ComPtr<IWICStream>& hFile, LPCWSTR szFile) : m_filename(szFile), m_handle(hFile) {}
+        auto_delete_file_wic(ComPtr<IWICStream>& hFile, LPCWSTR szFile) noexcept : m_filename(szFile), m_handle(hFile) {}
         ~auto_delete_file_wic()
         {
             if (m_filename)
@@ -240,14 +243,17 @@ namespace
             }
         }
 
-        void clear() { m_filename = nullptr; }
+        auto_delete_file_wic(const auto_delete_file_wic&) = delete;
+        auto_delete_file_wic& operator=(const auto_delete_file_wic&) = delete;
+
+        auto_delete_file_wic(const auto_delete_file_wic&&) = delete;
+        auto_delete_file_wic& operator=(const auto_delete_file_wic&&) = delete;
+
+        void clear() noexcept { m_filename = nullptr; }
 
     private:
         LPCWSTR m_filename;
         ComPtr<IWICStream>& m_handle;
-
-        auto_delete_file_wic(const auto_delete_file_wic&) = delete;
-        auto_delete_file_wic& operator=(const auto_delete_file_wic&) = delete;
     };
 
     //--------------------------------------------------------------------------------------

--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -902,13 +902,12 @@ HRESULT DirectX::SaveDDSTextureToFile(
 
     // Setup header
     const size_t MAX_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
-    uint8_t fileHeader[ MAX_HEADER_SIZE ];
+    uint8_t fileHeader[MAX_HEADER_SIZE] = {};
 
     *reinterpret_cast<uint32_t*>(&fileHeader[0]) = DDS_MAGIC;
 
-    auto header = reinterpret_cast<DDS_HEADER*>( &fileHeader[0] + sizeof(uint32_t) );
+    auto header = reinterpret_cast<DDS_HEADER*>(&fileHeader[0] + sizeof(uint32_t));
     size_t headerSize = sizeof(uint32_t) + sizeof(DDS_HEADER);
-    memset( header, 0, sizeof(DDS_HEADER) );
     header->size = sizeof( DDS_HEADER );
     header->flags = DDS_HEADER_FLAGS_TEXTURE | DDS_HEADER_FLAGS_MIPMAP;
     header->height = desc.Height;
@@ -962,11 +961,10 @@ HRESULT DirectX::SaveDDSTextureToFile(
         return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
 
     default:
-        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_DX10, sizeof(DDS_PIXELFORMAT) );
+        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DX10, sizeof(DDS_PIXELFORMAT));
 
         headerSize += sizeof(DDS_HEADER_DXT10);
-        extHeader = reinterpret_cast<DDS_HEADER_DXT10*>(fileHeader + sizeof(uint32_t) + sizeof(DDS_HEADER) );
-        memset( extHeader, 0, sizeof(DDS_HEADER_DXT10) );
+        extHeader = reinterpret_cast<DDS_HEADER_DXT10*>(fileHeader + sizeof(uint32_t) + sizeof(DDS_HEADER));
         extHeader->dxgiFormat = desc.Format;
         extHeader->resourceDimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
         extHeader->arraySize = 1;

--- a/ScreenGrab/ScreenGrab9.cpp
+++ b/ScreenGrab/ScreenGrab9.cpp
@@ -60,13 +60,14 @@ namespace
         uint32_t    ABitMask;
     };
 
-    #define DDS_FOURCC      0x00000004  // DDPF_FOURCC
-    #define DDS_RGB         0x00000040  // DDPF_RGB
-    #define DDS_RGBA        0x00000041  // DDPF_RGB | DDPF_ALPHAPIXELS
-    #define DDS_LUMINANCE   0x00020000  // DDPF_LUMINANCE
-    #define DDS_LUMINANCEA  0x00020001  // DDPF_LUMINANCE | DDPF_ALPHAPIXELS
-    #define DDS_ALPHA       0x00000002  // DDPF_ALPHA
-    #define DDS_BUMPDUDV    0x00080000  // DDPF_BUMPDUDV
+    #define DDS_FOURCC        0x00000004  // DDPF_FOURCC
+    #define DDS_RGB           0x00000040  // DDPF_RGB
+    #define DDS_RGBA          0x00000041  // DDPF_RGB | DDPF_ALPHAPIXELS
+    #define DDS_LUMINANCE     0x00020000  // DDPF_LUMINANCE
+    #define DDS_LUMINANCEA    0x00020001  // DDPF_LUMINANCE | DDPF_ALPHAPIXELS
+    #define DDS_ALPHA         0x00000002  // DDPF_ALPHA
+    #define DDS_BUMPDUDV      0x00080000  // DDPF_BUMPDUDV
+    #define DDS_BUMPLUMINANCE 0x00040000  // DDPF_BUMPLUMINANCE
 
     #define DDS_HEADER_FLAGS_TEXTURE        0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT 
     #define DDS_HEADER_FLAGS_MIPMAP         0x00020000  // DDSD_MIPMAPCOUNT
@@ -93,37 +94,22 @@ namespace
         uint32_t        reserved2;
     };
 
-    struct DDS_HEADER_DXT10
-    {
-        DXGI_FORMAT     dxgiFormat;
-        uint32_t        resourceDimension;
-        uint32_t        miscFlag; // see D3D11_RESOURCE_MISC_FLAG
-        uint32_t        arraySize;
-        uint32_t        reserved;
-    };
-
     #pragma pack(pop)
 
     const DDS_PIXELFORMAT DDSPF_DXT1 =
         { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','1'), 0, 0, 0, 0, 0 };
 
+    const DDS_PIXELFORMAT DDSPF_DXT2 =
+        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','2'), 0, 0, 0, 0, 0 };
+
     const DDS_PIXELFORMAT DDSPF_DXT3 =
         { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','3'), 0, 0, 0, 0, 0 };
 
+    const DDS_PIXELFORMAT DDSPF_DXT4 =
+        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','4'), 0, 0, 0, 0, 0 };
+
     const DDS_PIXELFORMAT DDSPF_DXT5 =
         { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','5'), 0, 0, 0, 0, 0 };
-
-    const DDS_PIXELFORMAT DDSPF_BC4_UNORM =
-        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','4','U'), 0, 0, 0, 0, 0 };
-
-    const DDS_PIXELFORMAT DDSPF_BC4_SNORM =
-        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','4','S'), 0, 0, 0, 0, 0 };
-
-    const DDS_PIXELFORMAT DDSPF_BC5_UNORM =
-        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','5','U'), 0, 0, 0, 0, 0 };
-
-    const DDS_PIXELFORMAT DDSPF_BC5_SNORM =
-        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','5','S'), 0, 0, 0, 0, 0 };
 
     const DDS_PIXELFORMAT DDSPF_R8G8_B8G8 =
         { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R','G','B','G'), 0, 0, 0, 0, 0 };
@@ -134,26 +120,50 @@ namespace
     const DDS_PIXELFORMAT DDSPF_YUY2 =
         { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('Y','U','Y','2'), 0, 0, 0, 0, 0 };
 
+     const DDS_PIXELFORMAT DDSPF_UYVY =
+        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('U','Y','V','Y'), 0, 0, 0, 0, 0 };
+
     const DDS_PIXELFORMAT DDSPF_A8R8G8B8 =
         { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000 };
 
     const DDS_PIXELFORMAT DDSPF_X8R8G8B8 =
-        { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0x00000000 };
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0 };
 
     const DDS_PIXELFORMAT DDSPF_A8B8G8R8 =
         { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 };
+
+    const DDS_PIXELFORMAT DDSPF_X8B8G8R8 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 };
 
     const DDS_PIXELFORMAT DDSPF_G16R16 =
         { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x0000ffff, 0xffff0000, 0x00000000, 0x00000000 };
 
     const DDS_PIXELFORMAT DDSPF_R5G6B5 =
-        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x0000f800, 0x000007e0, 0x0000001f, 0x00000000 };
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0xf800, 0x07e0, 0x001f, 0 };
 
     const DDS_PIXELFORMAT DDSPF_A1R5G5B5 =
-        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00007c00, 0x000003e0, 0x0000001f, 0x00008000 };
+        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x7c00, 0x03e0, 0x001f, 0x8000 };
+
+    const DDS_PIXELFORMAT DDSPF_X1R5G5B5 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x7c00, 0x03e0, 0x001f, 0 };
 
     const DDS_PIXELFORMAT DDSPF_A4R4G4B4 =
-        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00000f00, 0x000000f0, 0x0000000f, 0x0000f000 };
+        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x0f00, 0x00f0, 0x0000f, 0xf000 };
+
+    const DDS_PIXELFORMAT DDSPF_X4R4G4B4 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x0f00, 0x00f0, 0x000f, 0 };
+
+    const DDS_PIXELFORMAT DDSPF_R8G8B8 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 24, 0xff0000, 0x00ff00, 0x0000ff, 0 };
+
+    const DDS_PIXELFORMAT DDSPF_A8R3G3B2 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x00e0, 0x001c, 0x0003, 0xff00 };
+
+    const DDS_PIXELFORMAT DDSPF_R3G3B2 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xe0, 0x1c, 0x03, 0 };
+
+    const DDS_PIXELFORMAT DDSPF_A4L4 =
+        { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 8, 0x0f, 0, 0, 0xf0 };
 
     const DDS_PIXELFORMAT DDSPF_L8 =
         { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCE, 0,  8, 0xff, 0x00, 0x00, 0x00 };
@@ -176,11 +186,20 @@ namespace
     const DDS_PIXELFORMAT DDSPF_V16U16 = 
         { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x0000ffff, 0xffff0000, 0x00000000, 0x00000000 };
 
-    // DXGI_FORMAT_R10G10B10A2_UNORM should be written using DX10 extension to avoid D3DX 10:10:10:2 reversal issue
+    const DDS_PIXELFORMAT DDSPF_A2W10V10U10 =
+        { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 };
 
-    // This indicates the DDS_HEADER_DXT10 extension is present (the format is in dxgiFormat)
-    const DDS_PIXELFORMAT DDSPF_DX10 =
-        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','1','0'), 0, 0, 0, 0, 0 };
+    const DDS_PIXELFORMAT DDSPF_L6V5U5 =
+        { sizeof(DDS_PIXELFORMAT), DDS_BUMPLUMINANCE, 0, 16, 0x001f, 0x03e0, 0xfc00, 0 };
+
+    const DDS_PIXELFORMAT DDSPF_X8L8V8U8 =
+        { sizeof(DDS_PIXELFORMAT), DDS_BUMPLUMINANCE, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 };
+
+    // Note these 10:10:10:2 format RGB masks are reversed to support a long-standing bug in D3DX
+    const DDS_PIXELFORMAT DDSPF_A2R10G10B10 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x000003ff, 0x000ffc00, 0x3ff00000, 0xc0000000 };
+    const DDS_PIXELFORMAT DDSPF_A2B10G10R10 =
+        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 };
 
     //-----------------------------------------------------------------------------
     struct handle_closer { void operator()(HANDLE h) noexcept { if (h) CloseHandle(h); } };
@@ -475,134 +494,6 @@ namespace
 
 
     //--------------------------------------------------------------------------------------
-    DXGI_FORMAT EnsureNotTypeless( DXGI_FORMAT fmt ) noexcept
-    {
-        // Assumes UNORM or FLOAT; doesn't use UINT or SINT
-        switch( fmt )
-        {
-        case DXGI_FORMAT_R32G32B32A32_TYPELESS: return DXGI_FORMAT_R32G32B32A32_FLOAT;
-        case DXGI_FORMAT_R32G32B32_TYPELESS:    return DXGI_FORMAT_R32G32B32_FLOAT;
-        case DXGI_FORMAT_R16G16B16A16_TYPELESS: return DXGI_FORMAT_R16G16B16A16_UNORM;
-        case DXGI_FORMAT_R32G32_TYPELESS:       return DXGI_FORMAT_R32G32_FLOAT;
-        case DXGI_FORMAT_R10G10B10A2_TYPELESS:  return DXGI_FORMAT_R10G10B10A2_UNORM;
-        case DXGI_FORMAT_R8G8B8A8_TYPELESS:     return DXGI_FORMAT_R8G8B8A8_UNORM;
-        case DXGI_FORMAT_R16G16_TYPELESS:       return DXGI_FORMAT_R16G16_UNORM;
-        case DXGI_FORMAT_R32_TYPELESS:          return DXGI_FORMAT_R32_FLOAT;
-        case DXGI_FORMAT_R8G8_TYPELESS:         return DXGI_FORMAT_R8G8_UNORM;
-        case DXGI_FORMAT_R16_TYPELESS:          return DXGI_FORMAT_R16_UNORM;
-        case DXGI_FORMAT_R8_TYPELESS:           return DXGI_FORMAT_R8_UNORM;
-        case DXGI_FORMAT_BC1_TYPELESS:          return DXGI_FORMAT_BC1_UNORM;
-        case DXGI_FORMAT_BC2_TYPELESS:          return DXGI_FORMAT_BC2_UNORM;
-        case DXGI_FORMAT_BC3_TYPELESS:          return DXGI_FORMAT_BC3_UNORM;
-        case DXGI_FORMAT_BC4_TYPELESS:          return DXGI_FORMAT_BC4_UNORM;
-        case DXGI_FORMAT_BC5_TYPELESS:          return DXGI_FORMAT_BC5_UNORM;
-        case DXGI_FORMAT_B8G8R8A8_TYPELESS:     return DXGI_FORMAT_B8G8R8A8_UNORM;
-        case DXGI_FORMAT_B8G8R8X8_TYPELESS:     return DXGI_FORMAT_B8G8R8X8_UNORM;
-        case DXGI_FORMAT_BC7_TYPELESS:          return DXGI_FORMAT_BC7_UNORM;
-        default:                                return fmt;
-        }
-    }
-
-
-    //--------------------------------------------------------------------------------------
-    HRESULT CaptureTexture(
-        _In_ ID3D11DeviceContext* pContext,
-        _In_ ID3D11Resource* pSource,
-        D3D11_TEXTURE2D_DESC& desc,
-        ComPtr<ID3D11Texture2D>& pStaging ) noexcept
-    {
-        if ( !pContext || !pSource )
-            return E_INVALIDARG;
-
-        D3D11_RESOURCE_DIMENSION resType = D3D11_RESOURCE_DIMENSION_UNKNOWN;
-        pSource->GetType( &resType );
-
-        if ( resType != D3D11_RESOURCE_DIMENSION_TEXTURE2D )
-            return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
-
-        ComPtr<ID3D11Texture2D> pTexture;
-        HRESULT hr = pSource->QueryInterface(IID_ID3D11Texture2D, reinterpret_cast<void**>(pTexture.GetAddressOf()));
-        if ( FAILED(hr) )
-            return hr;
-
-        assert( pTexture );
-
-        pTexture->GetDesc( &desc );
-
-        ComPtr<ID3D11Device> d3dDevice;
-        pContext->GetDevice( d3dDevice.GetAddressOf() );
-
-        if ( desc.SampleDesc.Count > 1 )
-        {
-            // MSAA content must be resolved before being copied to a staging texture
-            desc.SampleDesc.Count = 1;
-            desc.SampleDesc.Quality = 0;
-
-            ComPtr<ID3D11Texture2D> pTemp;
-            hr = d3dDevice->CreateTexture2D( &desc, nullptr, pTemp.GetAddressOf() );
-            if ( FAILED(hr) )
-                return hr;
-
-            assert( pTemp );
-
-            DXGI_FORMAT fmt = EnsureNotTypeless( desc.Format );
-
-            UINT support = 0;
-            hr = d3dDevice->CheckFormatSupport( fmt, &support );
-            if ( FAILED(hr) )
-                return hr;
-
-            if ( !(support & D3D11_FORMAT_SUPPORT_MULTISAMPLE_RESOLVE) )
-                return E_FAIL;
-
-            for( UINT item = 0; item < desc.ArraySize; ++item )
-            {
-                for( UINT level = 0; level < desc.MipLevels; ++level )
-                {
-                    UINT index = D3D11CalcSubresource( level, item, desc.MipLevels );
-                    pContext->ResolveSubresource( pTemp.Get(), index, pSource, index, fmt );
-                }
-            }
-
-            desc.BindFlags = 0;
-            desc.MiscFlags &= D3D11_RESOURCE_MISC_TEXTURECUBE;
-            desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-            desc.Usage = D3D11_USAGE_STAGING;
-
-            hr = d3dDevice->CreateTexture2D(&desc, nullptr, pStaging.ReleaseAndGetAddressOf());
-            if ( FAILED(hr) )
-                return hr;
-
-            assert( pStaging );
-
-            pContext->CopyResource( pStaging.Get(), pTemp.Get() );
-        }
-        else if ( (desc.Usage == D3D11_USAGE_STAGING) && (desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ) )
-        {
-            // Handle case where the source is already a staging texture we can use directly
-            pStaging = pTexture;
-        }
-        else
-        {
-            // Otherwise, create a staging texture from the non-MSAA source
-            desc.BindFlags = 0;
-            desc.MiscFlags &= D3D11_RESOURCE_MISC_TEXTURECUBE;
-            desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-            desc.Usage = D3D11_USAGE_STAGING;
-
-            hr = d3dDevice->CreateTexture2D(&desc, nullptr, pStaging.ReleaseAndGetAddressOf());
-            if ( FAILED(hr) )
-                return hr;
-
-            assert( pStaging );
-
-            pContext->CopyResource( pStaging.Get(), pSource );
-        }
-
-        return S_OK;
-    }
-
-    //--------------------------------------------------------------------------------------
     bool g_WIC2 = false;
 
     BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID* ifactory) noexcept
@@ -664,17 +555,15 @@ namespace
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::SaveDDSTextureToFile(
-    ID3D11DeviceContext* pContext,
-    ID3D11Resource* pSource,
+    LPDIRECT3DSURFACE9 pSource,
     const wchar_t* fileName ) noexcept
 {
-    if ( !fileName )
+    if ( !pSource|| !fileName )
         return E_INVALIDARG;
 
-    D3D11_TEXTURE2D_DESC desc = {};
-    ComPtr<ID3D11Texture2D> pStaging;
-    HRESULT hr = CaptureTexture( pContext, pSource, desc, pStaging );
-    if ( FAILED(hr) )
+    D3DSURFACE_DESC desc = {};
+    HRESULT hr = pSource->GetDesc(&desc);
+    if (FAILED(hr))
         return hr;
 
     // Create file
@@ -689,80 +578,80 @@ HRESULT DirectX::SaveDDSTextureToFile(
     auto_delete_file delonfail(hFile.get());
 
     // Setup header
-    const size_t MAX_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
-    uint8_t fileHeader[ MAX_HEADER_SIZE ];
+    const size_t MAX_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER);
+    uint8_t fileHeader[MAX_HEADER_SIZE] = {};
 
     *reinterpret_cast<uint32_t*>(&fileHeader[0]) = DDS_MAGIC;
 
-    auto header = reinterpret_cast<DDS_HEADER*>( &fileHeader[0] + sizeof(uint32_t) );
+    auto header = reinterpret_cast<DDS_HEADER*>(&fileHeader[0] + sizeof(uint32_t));
     size_t headerSize = sizeof(uint32_t) + sizeof(DDS_HEADER);
-    memset( header, 0, sizeof(DDS_HEADER) );
-    header->size = sizeof( DDS_HEADER );
+    header->size = sizeof(DDS_HEADER);
     header->flags = DDS_HEADER_FLAGS_TEXTURE | DDS_HEADER_FLAGS_MIPMAP;
     header->height = desc.Height;
     header->width = desc.Width;
     header->mipMapCount = 1;
     header->caps = DDS_SURFACE_FLAGS_TEXTURE;
 
-    // Try to use a legacy .DDS pixel format for better tools support, otherwise fallback to 'DX10' header extension
-    DDS_HEADER_DXT10* extHeader = nullptr;
     switch( desc.Format )
+
+
     {
-    case DXGI_FORMAT_R8G8B8A8_UNORM:        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_A8B8G8R8, sizeof(DDS_PIXELFORMAT) );    break;
-    case DXGI_FORMAT_R16G16_UNORM:          memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_G16R16, sizeof(DDS_PIXELFORMAT) );      break;
-    case DXGI_FORMAT_R8G8_UNORM:            memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_A8L8, sizeof(DDS_PIXELFORMAT) );        break;
-    case DXGI_FORMAT_R16_UNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_L16, sizeof(DDS_PIXELFORMAT) );         break;
-    case DXGI_FORMAT_R8_UNORM:              memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_L8, sizeof(DDS_PIXELFORMAT) );          break;
-    case DXGI_FORMAT_A8_UNORM:              memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_A8, sizeof(DDS_PIXELFORMAT) );          break;
-    case DXGI_FORMAT_R8G8_B8G8_UNORM:       memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8_B8G8, sizeof(DDS_PIXELFORMAT) );   break;
-    case DXGI_FORMAT_G8R8_G8B8_UNORM:       memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_G8R8_G8B8, sizeof(DDS_PIXELFORMAT) );   break;
-    case DXGI_FORMAT_BC1_UNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_DXT1, sizeof(DDS_PIXELFORMAT) );        break;
-    case DXGI_FORMAT_BC2_UNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_DXT3, sizeof(DDS_PIXELFORMAT) );        break;
-    case DXGI_FORMAT_BC3_UNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_DXT5, sizeof(DDS_PIXELFORMAT) );        break;
-    case DXGI_FORMAT_BC4_UNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_BC4_UNORM, sizeof(DDS_PIXELFORMAT) );   break;
-    case DXGI_FORMAT_BC4_SNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_BC4_SNORM, sizeof(DDS_PIXELFORMAT) );   break;
-    case DXGI_FORMAT_BC5_UNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_BC5_UNORM, sizeof(DDS_PIXELFORMAT) );   break;
-    case DXGI_FORMAT_BC5_SNORM:             memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_BC5_SNORM, sizeof(DDS_PIXELFORMAT) );   break;
-    case DXGI_FORMAT_B5G6R5_UNORM:          memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_R5G6B5, sizeof(DDS_PIXELFORMAT) );      break;
-    case DXGI_FORMAT_B5G5R5A1_UNORM:        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_A1R5G5B5, sizeof(DDS_PIXELFORMAT) );    break;
-    case DXGI_FORMAT_R8G8_SNORM:            memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_V8U8, sizeof(DDS_PIXELFORMAT) );        break;
-    case DXGI_FORMAT_R8G8B8A8_SNORM:        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_Q8W8V8U8, sizeof(DDS_PIXELFORMAT) );    break;
-    case DXGI_FORMAT_R16G16_SNORM:          memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_V16U16, sizeof(DDS_PIXELFORMAT) );      break;
-    case DXGI_FORMAT_B8G8R8A8_UNORM:        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_A8R8G8B8, sizeof(DDS_PIXELFORMAT) );    break; // DXGI 1.1
-    case DXGI_FORMAT_B8G8R8X8_UNORM:        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_X8R8G8B8, sizeof(DDS_PIXELFORMAT) );    break; // DXGI 1.1
-    case DXGI_FORMAT_YUY2:                  memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_YUY2, sizeof(DDS_PIXELFORMAT) );        break; // DXGI 1.2
-    case DXGI_FORMAT_B4G4R4A4_UNORM:        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_A4R4G4B4, sizeof(DDS_PIXELFORMAT) );    break; // DXGI 1.2
+    case D3DFMT_R8G8B8:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_A8B8G8R8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8B8G8R8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_X8B8G8R8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8B8G8R8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_G16R16:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_G16R16, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_A8L8:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8L8, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_L16:             memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L16, sizeof(DDS_PIXELFORMAT));         break;
+    case D3DFMT_L8:              memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L8, sizeof(DDS_PIXELFORMAT));          break;
+    case D3DFMT_A8:              memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8, sizeof(DDS_PIXELFORMAT));          break;
+    case D3DFMT_R8G8_B8G8:       memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8_B8G8, sizeof(DDS_PIXELFORMAT));   break;
+    case D3DFMT_G8R8_G8B8:       memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_G8R8_G8B8, sizeof(DDS_PIXELFORMAT));   break;
+    case D3DFMT_DXT1:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT1, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_DXT2:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT2, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_DXT3:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT3, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_DXT4:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT4, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_DXT5:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT5, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_R5G6B5:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R5G6B5, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_A1R5G5B5:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A1R5G5B5, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_X1R5G5B5:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X1R5G5B5, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_V8U8:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_V8U8, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_Q8W8V8U8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_Q8W8V8U8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_V16U16:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_V16U16, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_A2W10V10U10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2W10V10U10, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_L6V5U5:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L6V5U5, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_X8L8V8U8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8L8V8U8, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_A8R8G8B8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_X8R8G8B8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_YUY2:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_YUY2, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_UYVY:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_UYVY, sizeof(DDS_PIXELFORMAT));        break;
+
+    case D3DFMT_A4R4G4B4:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A4R4G4B4, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_X4R4G4B4:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X4R4G4B4, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_A2R10G10B10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2R10G10B10, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_A2B10G10R10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2B10G10R10, sizeof(DDS_PIXELFORMAT)); break;
+
+    case D3DFMT_A8R3G3B2:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8R3G3B2, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_R3G3B2:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R3G3B2, sizeof(DDS_PIXELFORMAT)); break;
+
+    case D3DFMT_A4L4:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A4L4, sizeof(DDS_PIXELFORMAT)); break;
 
     // Legacy D3DX formats using D3DFMT enum value as FourCC
-    case DXGI_FORMAT_R32G32B32A32_FLOAT:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 116; break; // D3DFMT_A32B32G32R32F
-    case DXGI_FORMAT_R16G16B16A16_FLOAT:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 113; break; // D3DFMT_A16B16G16R16F
-    case DXGI_FORMAT_R16G16B16A16_UNORM:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 36;  break; // D3DFMT_A16B16G16R16
-    case DXGI_FORMAT_R16G16B16A16_SNORM:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 110; break; // D3DFMT_Q16W16V16U16
-    case DXGI_FORMAT_R32G32_FLOAT:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 115; break; // D3DFMT_G32R32F
-    case DXGI_FORMAT_R16G16_FLOAT:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 112; break; // D3DFMT_G16R16F
-    case DXGI_FORMAT_R32_FLOAT:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 114; break; // D3DFMT_R32F
-    case DXGI_FORMAT_R16_FLOAT:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 111; break; // D3DFMT_R16F
-
-    case DXGI_FORMAT_AI44:
-    case DXGI_FORMAT_IA44:
-    case DXGI_FORMAT_P8:
-    case DXGI_FORMAT_A8P8:
-        return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
+    case D3DFMT_A32B32G32R32F:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 116; break;
+    case D3DFMT_A16B16G16R16F:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 113; break;
+    case D3DFMT_A16B16G16R16:     header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 36;  break;
+    case D3DFMT_Q16W16V16U16:     header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 110; break;
+    case D3DFMT_G32R32F:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 115; break;
+    case D3DFMT_G16R16F:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 112; break;
+    case D3DFMT_R32F:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 114; break;
+    case D3DFMT_R16F:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 111; break;
+    case D3DFMT_CxV8U8:           header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 117; break;
 
     default:
-        memcpy_s( &header->ddspf, sizeof(header->ddspf), &DDSPF_DX10, sizeof(DDS_PIXELFORMAT) );
-
-        headerSize += sizeof(DDS_HEADER_DXT10);
-        extHeader = reinterpret_cast<DDS_HEADER_DXT10*>( fileHeader + sizeof(uint32_t) + sizeof(DDS_HEADER) );
-        memset( extHeader, 0, sizeof(DDS_HEADER_DXT10) );
-        extHeader->dxgiFormat = desc.Format;
-        extHeader->resourceDimension = D3D11_RESOURCE_DIMENSION_TEXTURE2D;
-        extHeader->arraySize = 1;
-        break;
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
     size_t rowPitch, slicePitch, rowCount;
-    hr = GetSurfaceInfo( desc.Width, desc.Height, desc.Format, &slicePitch, &rowPitch, &rowCount );
+    hr = GetSurfaceInfo(desc.Width, desc.Height, desc.Format, &slicePitch, &rowPitch, &rowCount);
     if (FAILED(hr))
         return hr;
 
@@ -828,18 +717,18 @@ HRESULT DirectX::SaveDDSTextureToFile(
     return S_OK;
 }
 
+#if 0
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::SaveWICTextureToFile(
-    ID3D11DeviceContext* pContext,
-    ID3D11Resource* pSource,
+    LPDIRECT3DSURFACE9 pSource,
     REFGUID guidContainerFormat,
     const wchar_t* fileName,
     const GUID* targetFormat,
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB) noexcept
 {
-    if ( !fileName )
+    if ( !pSource|| !fileName )
         return E_INVALIDARG;
 
     D3D11_TEXTURE2D_DESC desc = {};
@@ -1127,3 +1016,4 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     return S_OK;
 }
+#endif

--- a/ScreenGrab/ScreenGrab9.cpp
+++ b/ScreenGrab/ScreenGrab9.cpp
@@ -26,6 +26,11 @@
 #include <algorithm>
 #include <memory>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
 using Microsoft::WRL::ComPtr;
 
 //--------------------------------------------------------------------------------------

--- a/ScreenGrab/ScreenGrab9.cpp
+++ b/ScreenGrab/ScreenGrab9.cpp
@@ -157,7 +157,7 @@ namespace
         { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 24, 0xff0000, 0x00ff00, 0x0000ff, 0 };
 
     const DDS_PIXELFORMAT DDSPF_A8R3G3B2 =
-        { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x00e0, 0x001c, 0x0003, 0xff00 };
+        { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00e0, 0x001c, 0x0003, 0xff00 };
 
     const DDS_PIXELFORMAT DDSPF_R3G3B2 =
         { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xe0, 0x1c, 0x03, 0 };
@@ -566,6 +566,16 @@ HRESULT DirectX::SaveDDSTextureToFile(
     if (FAILED(hr))
         return hr;
 
+    if (desc.Type != D3DRTYPE_SURFACE && desc.Type != D3DRTYPE_TEXTURE)
+    {
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+    }
+
+    if (desc.MultiSampleType != D3DMULTISAMPLE_NONE)
+    {
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+    }
+
     // Create file
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
     ScopedHandle hFile( safe_handle( CreateFile2( fileName, GENERIC_WRITE | DELETE, 0, CREATE_ALWAYS, nullptr ) ) );
@@ -593,60 +603,58 @@ HRESULT DirectX::SaveDDSTextureToFile(
     header->caps = DDS_SURFACE_FLAGS_TEXTURE;
 
     switch( desc.Format )
-
-
     {
-    case D3DFMT_R8G8B8:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_R8G8B8:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8B8, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_A8R8G8B8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_X8R8G8B8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_R5G6B5:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R5G6B5, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_X1R5G5B5:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X1R5G5B5, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_A1R5G5B5:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A1R5G5B5, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_A4R4G4B4:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A4R4G4B4, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_R3G3B2:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R3G3B2, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_A8:              memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8, sizeof(DDS_PIXELFORMAT));          break;
+    case D3DFMT_A8R3G3B2:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8R3G3B2, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_X4R4G4B4:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X4R4G4B4, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_A2B10G10R10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2B10G10R10, sizeof(DDS_PIXELFORMAT)); break;
     case D3DFMT_A8B8G8R8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8B8G8R8, sizeof(DDS_PIXELFORMAT));    break;
     case D3DFMT_X8B8G8R8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8B8G8R8, sizeof(DDS_PIXELFORMAT));    break;
     case D3DFMT_G16R16:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_G16R16, sizeof(DDS_PIXELFORMAT));      break;
-    case D3DFMT_A8L8:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8L8, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_L16:             memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L16, sizeof(DDS_PIXELFORMAT));         break;
+    case D3DFMT_A2R10G10B10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2R10G10B10, sizeof(DDS_PIXELFORMAT)); break;
     case D3DFMT_L8:              memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L8, sizeof(DDS_PIXELFORMAT));          break;
-    case D3DFMT_A8:              memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8, sizeof(DDS_PIXELFORMAT));          break;
-    case D3DFMT_R8G8_B8G8:       memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8_B8G8, sizeof(DDS_PIXELFORMAT));   break;
-    case D3DFMT_G8R8_G8B8:       memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_G8R8_G8B8, sizeof(DDS_PIXELFORMAT));   break;
-    case D3DFMT_DXT1:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT1, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_DXT2:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT2, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_DXT3:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT3, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_DXT4:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT4, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_DXT5:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT5, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_R5G6B5:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R5G6B5, sizeof(DDS_PIXELFORMAT));      break;
-    case D3DFMT_A1R5G5B5:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A1R5G5B5, sizeof(DDS_PIXELFORMAT));    break;
-    case D3DFMT_X1R5G5B5:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X1R5G5B5, sizeof(DDS_PIXELFORMAT));    break;
+    case D3DFMT_A8L8:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8L8, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_A4L4:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A4L4, sizeof(DDS_PIXELFORMAT));        break;
     case D3DFMT_V8U8:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_V8U8, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_L6V5U5:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L6V5U5, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_X8L8V8U8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8L8V8U8, sizeof(DDS_PIXELFORMAT));    break;
     case D3DFMT_Q8W8V8U8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_Q8W8V8U8, sizeof(DDS_PIXELFORMAT));    break;
     case D3DFMT_V16U16:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_V16U16, sizeof(DDS_PIXELFORMAT));      break;
     case D3DFMT_A2W10V10U10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2W10V10U10, sizeof(DDS_PIXELFORMAT)); break;
-    case D3DFMT_L6V5U5:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L6V5U5, sizeof(DDS_PIXELFORMAT)); break;
-    case D3DFMT_X8L8V8U8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8L8V8U8, sizeof(DDS_PIXELFORMAT)); break;
-    case D3DFMT_A8R8G8B8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
-    case D3DFMT_X8R8G8B8:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X8R8G8B8, sizeof(DDS_PIXELFORMAT));    break;
-    case D3DFMT_YUY2:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_YUY2, sizeof(DDS_PIXELFORMAT));        break;
-    case D3DFMT_UYVY:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_UYVY, sizeof(DDS_PIXELFORMAT));        break;
+    case D3DFMT_L16:             memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_L16, sizeof(DDS_PIXELFORMAT));         break;
 
-    case D3DFMT_A4R4G4B4:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A4R4G4B4, sizeof(DDS_PIXELFORMAT));    break;
-    case D3DFMT_X4R4G4B4:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_X4R4G4B4, sizeof(DDS_PIXELFORMAT));    break;
-    case D3DFMT_A2R10G10B10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2R10G10B10, sizeof(DDS_PIXELFORMAT)); break;
-    case D3DFMT_A2B10G10R10:     memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A2B10G10R10, sizeof(DDS_PIXELFORMAT)); break;
-
-    case D3DFMT_A8R3G3B2:        memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A8R3G3B2, sizeof(DDS_PIXELFORMAT)); break;
-    case D3DFMT_R3G3B2:          memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R3G3B2, sizeof(DDS_PIXELFORMAT)); break;
-
-    case D3DFMT_A4L4:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_A4L4, sizeof(DDS_PIXELFORMAT)); break;
+    // FourCC formats
+    case D3DFMT_UYVY:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_UYVY, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_R8G8_B8G8:       memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_R8G8_B8G8, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_YUY2:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_YUY2, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_G8R8_G8B8:       memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_G8R8_G8B8, sizeof(DDS_PIXELFORMAT)); break;
+    case D3DFMT_DXT1:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT1, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_DXT2:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT2, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_DXT3:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT3, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_DXT4:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT4, sizeof(DDS_PIXELFORMAT));      break;
+    case D3DFMT_DXT5:            memcpy_s(&header->ddspf, sizeof(header->ddspf), &DDSPF_DXT5, sizeof(DDS_PIXELFORMAT));      break;
 
     // Legacy D3DX formats using D3DFMT enum value as FourCC
-    case D3DFMT_A32B32G32R32F:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 116; break;
-    case D3DFMT_A16B16G16R16F:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 113; break;
     case D3DFMT_A16B16G16R16:     header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 36;  break;
     case D3DFMT_Q16W16V16U16:     header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 110; break;
-    case D3DFMT_G32R32F:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 115; break;
-    case D3DFMT_G16R16F:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 112; break;
-    case D3DFMT_R32F:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 114; break;
     case D3DFMT_R16F:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 111; break;
+    case D3DFMT_G16R16F:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 112; break;
+    case D3DFMT_A16B16G16R16F:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 113; break;
+    case D3DFMT_R32F:             header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 114; break;
+    case D3DFMT_G32R32F:          header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 115; break;
+    case D3DFMT_A32B32G32R32F:    header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 116; break;
     case D3DFMT_CxV8U8:           header->ddspf.size = sizeof(DDS_PIXELFORMAT); header->ddspf.flags = DDS_FOURCC; header->ddspf.fourCC = 117; break;
 
     default:
+        // No support for paletted formats D3DFMT_P8, D3DFMT_A8P8
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
@@ -658,45 +666,45 @@ HRESULT DirectX::SaveDDSTextureToFile(
     if (rowPitch > UINT32_MAX || slicePitch > UINT32_MAX)
         return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
 
-    if ( IsCompressed( desc.Format ) )
+    if (IsCompressed(desc.Format))
     {
         header->flags |= DDS_HEADER_FLAGS_LINEARSIZE;
-        header->pitchOrLinearSize = static_cast<uint32_t>( slicePitch );
+        header->pitchOrLinearSize = static_cast<uint32_t>(slicePitch);
     }
     else
     {
         header->flags |= DDS_HEADER_FLAGS_PITCH;
-        header->pitchOrLinearSize = static_cast<uint32_t>( rowPitch );
+        header->pitchOrLinearSize = static_cast<uint32_t>(rowPitch);
     }
 
     // Setup pixels
-    std::unique_ptr<uint8_t[]> pixels( new (std::nothrow) uint8_t[ slicePitch ] );
+    std::unique_ptr<uint8_t[]> pixels(new (std::nothrow) uint8_t[slicePitch]);
     if (!pixels)
         return E_OUTOFMEMORY;
 
-    D3D11_MAPPED_SUBRESOURCE mapped;
-    hr = pContext->Map( pStaging.Get(), 0, D3D11_MAP_READ, 0, &mapped );
-    if ( FAILED(hr) )
+    D3DLOCKED_RECT lockedRect = {};
+    hr = pSource->LockRect(&lockedRect, nullptr, D3DLOCK_READONLY);
+    if (FAILED(hr))
         return hr;
 
-    auto sptr = static_cast<const uint8_t*>( mapped.pData );
-    if ( !sptr )
+    auto sptr = static_cast<const uint8_t*>(lockedRect.pBits);
+    if (!sptr)
     {
-        pContext->Unmap( pStaging.Get(), 0 );
+        pSource->UnlockRect();
         return E_POINTER;
     }
 
     uint8_t* dptr = pixels.get();
 
-    size_t msize = std::min<size_t>( rowPitch, mapped.RowPitch );
+    size_t msize = std::min<size_t>(rowPitch, static_cast<size_t>(lockedRect.Pitch));
     for( size_t h = 0; h < rowCount; ++h )
     {
         memcpy_s( dptr, rowPitch, sptr, msize );
-        sptr += mapped.RowPitch;
+        sptr += lockedRect.Pitch;
         dptr += rowPitch;
     }
 
-    pContext->Unmap( pStaging.Get(), 0 );
+    pSource->UnlockRect();
 
     // Write header & pixels
     DWORD bytesWritten;
@@ -717,7 +725,7 @@ HRESULT DirectX::SaveDDSTextureToFile(
     return S_OK;
 }
 
-#if 0
+
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::SaveWICTextureToFile(
@@ -728,67 +736,61 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB) noexcept
 {
-    if ( !pSource|| !fileName )
+    if (!pSource || !fileName)
         return E_INVALIDARG;
 
-    D3D11_TEXTURE2D_DESC desc = {};
-    ComPtr<ID3D11Texture2D> pStaging;
-    HRESULT hr = CaptureTexture( pContext, pSource, desc, pStaging );
-    if ( FAILED(hr) )
+    D3DSURFACE_DESC desc = {};
+    HRESULT hr = pSource->GetDesc(&desc);
+    if (FAILED(hr))
         return hr;
+
+    if (desc.Type != D3DRTYPE_SURFACE && desc.Type != D3DRTYPE_TEXTURE)
+    {
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+    }
+
+    if (desc.MultiSampleType != D3DMULTISAMPLE_NONE)
+    {
+        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+    }
+
+    auto pWIC = _GetWIC();
+    if (!pWIC)
+        return E_NOINTERFACE;
 
     // Determine source format's WIC equivalent
     WICPixelFormatGUID pfGuid = {};
-    bool sRGB = forceSRGB;
     switch ( desc.Format )
     {
-    case DXGI_FORMAT_R32G32B32A32_FLOAT:            pfGuid = GUID_WICPixelFormat128bppRGBAFloat; break;
-    case DXGI_FORMAT_R16G16B16A16_FLOAT:            pfGuid = GUID_WICPixelFormat64bppRGBAHalf; break;
-    case DXGI_FORMAT_R16G16B16A16_UNORM:            pfGuid = GUID_WICPixelFormat64bppRGBA; break;
-    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:    pfGuid = GUID_WICPixelFormat32bppRGBA1010102XR; break; // DXGI 1.1
-    case DXGI_FORMAT_R10G10B10A2_UNORM:             pfGuid = GUID_WICPixelFormat32bppRGBA1010102; break;
-    case DXGI_FORMAT_B5G5R5A1_UNORM:                pfGuid = GUID_WICPixelFormat16bppBGRA5551; break;
-    case DXGI_FORMAT_B5G6R5_UNORM:                  pfGuid = GUID_WICPixelFormat16bppBGR565; break;
-    case DXGI_FORMAT_R32_FLOAT:                     pfGuid = GUID_WICPixelFormat32bppGrayFloat; break;
-    case DXGI_FORMAT_R16_FLOAT:                     pfGuid = GUID_WICPixelFormat16bppGrayHalf; break;
-    case DXGI_FORMAT_R16_UNORM:                     pfGuid = GUID_WICPixelFormat16bppGray; break;
-    case DXGI_FORMAT_R8_UNORM:                      pfGuid = GUID_WICPixelFormat8bppGray; break;
-    case DXGI_FORMAT_A8_UNORM:                      pfGuid = GUID_WICPixelFormat8bppAlpha; break;
+    case D3DFMT_R8G8B8:         pfGuid = GUID_WICPixelFormat24bppBGR; break;
+    case D3DFMT_A8R8G8B8:       pfGuid = GUID_WICPixelFormat32bppBGRA; break;
+    case D3DFMT_X8R8G8B8:       pfGuid = GUID_WICPixelFormat32bppBGR; break;
+    case D3DFMT_R5G6B5:         pfGuid = GUID_WICPixelFormat16bppBGR565; break;
+    case D3DFMT_X1R5G5B5:       pfGuid = GUID_WICPixelFormat16bppBGR555; break;
+    case D3DFMT_A1R5G5B5:       pfGuid = GUID_WICPixelFormat16bppBGRA5551; break;
+    case D3DFMT_A8:             pfGuid = GUID_WICPixelFormat8bppAlpha; break;
+    case D3DFMT_A2B10G10R10:    pfGuid = GUID_WICPixelFormat32bppRGBA1010102; break;
+    case D3DFMT_A8B8G8R8:       pfGuid = GUID_WICPixelFormat32bppRGBA; break;
+    case D3DFMT_A16B16G16R16:   pfGuid = GUID_WICPixelFormat64bppRGBA; break;
+    case D3DFMT_L8:             pfGuid = GUID_WICPixelFormat8bppGray; break;
+    case D3DFMT_L16:            pfGuid = GUID_WICPixelFormat16bppGray; break;
+    case D3DFMT_R16F:           pfGuid = GUID_WICPixelFormat16bppGrayHalf; break;
+    case D3DFMT_A16B16G16R16F:  pfGuid = GUID_WICPixelFormat64bppRGBAHalf; break;
+    case D3DFMT_R32F:           pfGuid = GUID_WICPixelFormat32bppGrayFloat; break;
+    case D3DFMT_A32B32G32R32F:  pfGuid = GUID_WICPixelFormat128bppRGBAFloat; break;
 
-    case DXGI_FORMAT_R8G8B8A8_UNORM:
-        pfGuid = GUID_WICPixelFormat32bppRGBA;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+    case D3DFMT_X8B8G8R8:
+        if (g_WIC2)
+            pfGuid = GUID_WICPixelFormat32bppRGB;
+        else
+            HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
         break;
-
-    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
-        pfGuid = GUID_WICPixelFormat32bppRGBA;
-        sRGB = true;
-        break;
-
-    case DXGI_FORMAT_B8G8R8A8_UNORM: // DXGI 1.1
-        pfGuid = GUID_WICPixelFormat32bppBGRA;
-        break;
-
-    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB: // DXGI 1.1
-        pfGuid = GUID_WICPixelFormat32bppBGRA;
-        sRGB = true;
-        break;
-
-    case DXGI_FORMAT_B8G8R8X8_UNORM: // DXGI 1.1
-        pfGuid = GUID_WICPixelFormat32bppBGR;
-        break; 
-
-    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB: // DXGI 1.1
-        pfGuid = GUID_WICPixelFormat32bppBGR;
-        sRGB = true;
-        break; 
+#endif
 
     default:
         return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
     }
-
-    auto pWIC = _GetWIC();
-    if ( !pWIC )
-        return E_NOINTERFACE;
 
     ComPtr<IWICStream> stream;
     hr = pWIC->CreateStream( stream.GetAddressOf() );
@@ -857,8 +859,8 @@ HRESULT DirectX::SaveWICTextureToFile(
         switch ( desc.Format )
         {
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
-        case DXGI_FORMAT_R32G32B32A32_FLOAT:            
-        case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        case D3DFMT_A32B32G32R32F:
+        case D3DFMT_A16B16G16R16F:
             if (g_WIC2)
             {
                 targetGuid = GUID_WICPixelFormat96bppRGBFloat;
@@ -870,15 +872,21 @@ HRESULT DirectX::SaveWICTextureToFile(
             break;
 #endif
 
-        case DXGI_FORMAT_R16G16B16A16_UNORM: targetGuid = GUID_WICPixelFormat48bppBGR; break;
-        case DXGI_FORMAT_B5G5R5A1_UNORM:     targetGuid = GUID_WICPixelFormat16bppBGR555; break;
-        case DXGI_FORMAT_B5G6R5_UNORM:       targetGuid = GUID_WICPixelFormat16bppBGR565; break;
+        case D3DFMT_A16B16G16R16: targetGuid = GUID_WICPixelFormat48bppBGR; break;
+        case D3DFMT_R5G6B5:       targetGuid = GUID_WICPixelFormat16bppBGR565; break;
 
-        case DXGI_FORMAT_R32_FLOAT:
-        case DXGI_FORMAT_R16_FLOAT:
-        case DXGI_FORMAT_R16_UNORM:
-        case DXGI_FORMAT_R8_UNORM:
-        case DXGI_FORMAT_A8_UNORM:
+        case D3DFMT_A1R5G5B5:
+        case D3DFMT_X1R5G5B5:
+            targetGuid = GUID_WICPixelFormat16bppBGR555;
+            break;
+
+        case D3DFMT_L16:
+            targetGuid = GUID_WICPixelFormat16bppGray;
+            break;
+
+        case D3DFMT_R32F:
+        case D3DFMT_R16F:
+        case D3DFMT_L8:
             targetGuid = GUID_WICPixelFormat8bppGray;
             break;
 
@@ -912,52 +920,26 @@ HRESULT DirectX::SaveWICTextureToFile(
         {
             // Set Software name
             (void)metawriter->SetMetadataByName( L"/tEXt/{str=Software}", &value );
-
-            // Set sRGB chunk
-            if (sRGB)
-            {
-                value.vt = VT_UI1;
-                value.bVal = 0;
-                (void)metawriter->SetMetadataByName(L"/sRGB/RenderingIntent", &value);
-            }
-            else
-            {
-                // add gAMA chunk with gamma 1.0
-                value.vt = VT_UI4;
-                value.uintVal = 100000; // gama value * 100,000 -- i.e. gamma 1.0
-                (void)metawriter->SetMetadataByName(L"/gAMA/ImageGamma", &value);
-
-                // remove sRGB chunk which is added by default.
-                (void)metawriter->RemoveMetadataByName(L"/sRGB/RenderingIntent");
-            }
         }
         else
         {
             // Set Software name
             (void)metawriter->SetMetadataByName( L"System.ApplicationName", &value );
-
-            if ( sRGB )
-            {
-                // Set EXIF Colorspace of sRGB
-                value.vt = VT_UI2;
-                value.uiVal = 1;
-                (void)metawriter->SetMetadataByName( L"System.Image.ColorSpace", &value );
-            }
         }
     }
 
-    D3D11_MAPPED_SUBRESOURCE mapped;
-    hr = pContext->Map( pStaging.Get(), 0, D3D11_MAP_READ, 0, &mapped );
-    if ( FAILED(hr) )
+    D3DLOCKED_RECT lockedRect = {};
+    hr = pSource->LockRect(&lockedRect, nullptr, D3DLOCK_READONLY);
+    if (FAILED(hr))
         return hr;
 
     if ( memcmp( &targetGuid, &pfGuid, sizeof(WICPixelFormatGUID) ) != 0 )
     {
         // Conversion required to write
         ComPtr<IWICBitmap> source;
-        hr = pWIC->CreateBitmapFromMemory( desc.Width, desc.Height, pfGuid,
-                                           mapped.RowPitch, mapped.RowPitch * desc.Height,
-                                           static_cast<BYTE*>( mapped.pData ), source.GetAddressOf() );
+        hr = pWIC->CreateBitmapFromMemory(desc.Width, desc.Height, pfGuid,
+            lockedRect.Pitch, mapped.RowPitch * desc.Height,
+            static_cast<BYTE*>(mapped.pData), source.GetAddressOf());
         if ( FAILED(hr) )
         {
             pContext->Unmap( pStaging.Get(), 0 );
@@ -1016,4 +998,3 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     return S_OK;
 }
-#endif

--- a/ScreenGrab/ScreenGrab9.h
+++ b/ScreenGrab/ScreenGrab9.h
@@ -38,6 +38,5 @@ namespace DirectX
         _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* fileName,
         _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
-        _In_ bool forceSRGB = false) noexcept;
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr) noexcept;
 }

--- a/ScreenGrab/ScreenGrab9.h
+++ b/ScreenGrab/ScreenGrab9.h
@@ -1,0 +1,43 @@
+//--------------------------------------------------------------------------------------
+// File: ScreenGrab9.h
+//
+// Function for saving 2D surface to a file (aka a 'screenshot'
+// when used on a Direct3D 9's GetFrontBufferData).
+//
+// Note these functions are useful as a light-weight runtime screen grabber. For
+// full-featured texture capture, DDS writer, and texture processing pipeline,
+// see the 'Texconv' sample and the 'DirectXTex' library.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#ifndef DIRECT3D_VERSION
+#define DIRECT3D_VERSION 0x900
+#endif
+
+#include <d3d9.h>
+
+#include <OCIdl.h>
+#include <functional>
+
+
+namespace DirectX
+{
+    HRESULT __cdecl SaveDDSTextureToFile(
+        _In_ LPDIRECT3DSURFACE9 pSource,
+        _In_z_ const wchar_t* fileName) noexcept;
+
+    HRESULT __cdecl SaveWICTextureToFile(
+        _In_ LPDIRECT3DSURFACE9 pSource,
+        _In_ REFGUID guidContainerFormat,
+        _In_z_ const wchar_t* fileName,
+        _In_opt_ const GUID* targetFormat = nullptr,
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
+        _In_ bool forceSRGB = false) noexcept;
+}

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -923,7 +923,7 @@ namespace
             float bestScore = FLT_MAX;
             for (size_t y = maxsize; y > 0; y >>= 1)
             {
-                float score = fabs((float(x) / float(y)) - origAR);
+                float score = fabsf((float(x) / float(y)) - origAR);
                 if (score < bestScore)
                 {
                     bestScore = score;
@@ -940,7 +940,7 @@ namespace
             float bestScore = FLT_MAX;
             for (size_t x = maxsize; x > 0; x >>= 1)
             {
-                float score = fabs((float(x) / float(y)) - origAR);
+                float score = fabsf((float(x) / float(y)) - origAR);
                 if (score < bestScore)
                 {
                     bestScore = score;

--- a/WICTextureLoader/WICTextureLoader11.cpp
+++ b/WICTextureLoader/WICTextureLoader11.cpp
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------------
-// File: WICTextureLoader.cpp
+// File: WICTextureLoader11.cpp
 //
 // Function for loading a WIC image and creating a Direct3D runtime texture for it
 // (auto-generating mipmaps if possible)
@@ -24,7 +24,7 @@
 // We could load multi-frame images (TIFF/GIF) into a texture array.
 // For now, we just load the first frame (note: DirectXTex supports multi-frame images)
 
-#include "WICTextureLoader.h"
+#include "WICTextureLoader11.h"
 
 #include <dxgiformat.h>
 #include <assert.h>

--- a/WICTextureLoader/WICTextureLoader11.cpp
+++ b/WICTextureLoader/WICTextureLoader11.cpp
@@ -164,7 +164,6 @@ namespace
 
     bool g_WIC2 = false;
 
-    //--------------------------------------------------------------------------------------
     BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID* ifactory) noexcept
     {
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)

--- a/WICTextureLoader/WICTextureLoader11.h
+++ b/WICTextureLoader/WICTextureLoader11.h
@@ -37,6 +37,8 @@ namespace DirectX
         WIC_LOADER_FORCE_SRGB   = 0x1,
         WIC_LOADER_IGNORE_SRGB  = 0x2,
         WIC_LOADER_FORCE_RGBA32 = 0x10,
+        WIC_LOADER_FIT_POW2     = 0x20,
+        WIC_LOADER_MAKE_SQUARE  = 0x40,
     };
 #endif
 

--- a/WICTextureLoader/WICTextureLoader11.h
+++ b/WICTextureLoader/WICTextureLoader11.h
@@ -1,10 +1,17 @@
 //--------------------------------------------------------------------------------------
-// File: DDSTextureLoader.h
+// File: WICTextureLoader11.h
 //
-// Functions for loading a DDS texture and creating a Direct3D runtime resource for it
+// Function for loading a WIC image and creating a Direct3D runtime texture for it
+// (auto-generating mipmaps if possible)
 //
-// Note these functions are useful as a light-weight runtime loader for DDS files. For
-// a full-featured DDS file reader, writer, and texture processing pipeline see
+// Note: Assumes application has already called CoInitializeEx
+//
+// Warning: CreateWICTexture* functions are not thread-safe if given a d3dContext instance for
+//          auto-gen mipmap support.
+//
+// Note these functions are useful for images created as simple 2D textures. For
+// more complex resources, DDSTextureLoader is an excellent light-weight runtime loader.
+// For a full-featured DDS file reader, writer, and texture processing pipeline see
 // the 'Texconv' sample and the 'DirectXTex' library.
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -20,75 +27,68 @@
 
 #include <cstdint>
 
-
 namespace DirectX
 {
-#ifndef DDS_ALPHA_MODE_DEFINED
-#define DDS_ALPHA_MODE_DEFINED
-    enum DDS_ALPHA_MODE
+#ifndef WIC_LOADER_FLAGS_DEFINED
+#define WIC_LOADER_FLAGS_DEFINED
+    enum WIC_LOADER_FLAGS : uint32_t
     {
-        DDS_ALPHA_MODE_UNKNOWN       = 0,
-        DDS_ALPHA_MODE_STRAIGHT      = 1,
-        DDS_ALPHA_MODE_PREMULTIPLIED = 2,
-        DDS_ALPHA_MODE_OPAQUE        = 3,
-        DDS_ALPHA_MODE_CUSTOM        = 4,
+        WIC_LOADER_DEFAULT      = 0,
+        WIC_LOADER_FORCE_SRGB   = 0x1,
+        WIC_LOADER_IGNORE_SRGB  = 0x2,
+        WIC_LOADER_FORCE_RGBA32 = 0x10,
     };
 #endif
 
     // Standard version
-    HRESULT CreateDDSTextureFromMemory(
+    HRESULT CreateWICTextureFromMemory(
         _In_ ID3D11Device* d3dDevice,
-        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
-        _In_ size_t ddsDataSize,
+        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
+        _In_ size_t wicDataSize,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _In_ size_t maxsize = 0) noexcept;
 
-    HRESULT CreateDDSTextureFromFile(
+    HRESULT CreateWICTextureFromFile(
         _In_ ID3D11Device* d3dDevice,
         _In_z_ const wchar_t* szFileName,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _In_ size_t maxsize = 0) noexcept;
 
     // Standard version with optional auto-gen mipmap support
-    HRESULT CreateDDSTextureFromMemory(
+    HRESULT CreateWICTextureFromMemory(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
-        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
-        _In_ size_t ddsDataSize,
+        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
+        _In_ size_t wicDataSize,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _In_ size_t maxsize = 0) noexcept;
 
-    HRESULT CreateDDSTextureFromFile(
+    HRESULT CreateWICTextureFromFile(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
         _In_z_ const wchar_t* szFileName,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _In_ size_t maxsize = 0,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _In_ size_t maxsize = 0) noexcept;
 
     // Extended version
-    HRESULT CreateDDSTextureFromMemoryEx(
+    HRESULT CreateWICTextureFromMemoryEx(
         _In_ ID3D11Device* d3dDevice,
-        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
-        _In_ size_t ddsDataSize,
+        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
+        _In_ size_t wicDataSize,
         _In_ size_t maxsize,
         _In_ D3D11_USAGE usage,
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
+        _In_ unsigned int loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
 
-    HRESULT CreateDDSTextureFromFileEx(
+    HRESULT CreateWICTextureFromFileEx(
         _In_ ID3D11Device* d3dDevice,
         _In_z_ const wchar_t* szFileName,
         _In_ size_t maxsize,
@@ -96,28 +96,26 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
+        _In_ unsigned int loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
 
     // Extended version with optional auto-gen mipmap support
-    HRESULT CreateDDSTextureFromMemoryEx(
+    HRESULT CreateWICTextureFromMemoryEx(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
-        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
-        _In_ size_t ddsDataSize,
+        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
+        _In_ size_t wicDataSize,
         _In_ size_t maxsize,
         _In_ D3D11_USAGE usage,
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
+        _In_ unsigned int loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
 
-    HRESULT CreateDDSTextureFromFileEx(
+    HRESULT CreateWICTextureFromFileEx(
         _In_ ID3D11Device* d3dDevice,
         _In_opt_ ID3D11DeviceContext* d3dContext,
         _In_z_ const wchar_t* szFileName,
@@ -126,8 +124,7 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
+        _In_ unsigned int loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
-        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
 }

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -1,7 +1,7 @@
 //--------------------------------------------------------------------------------------
 // File: WICTextureLoader12.cpp
 //
-// Function for loading a WIC image and creating a Direct3D 12 runtime texture for it
+// Function for loading a WIC image and creating a Direct3D runtime texture for it
 // (auto-generating mipmaps if possible)
 //
 // Note: Assumes application has already called CoInitializeEx
@@ -166,7 +166,8 @@ namespace
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
         IWICImagingFactory2* factory = nullptr;
-        if (!InitOnceExecuteOnce(&s_initOnce,
+        if (!InitOnceExecuteOnce(
+            &s_initOnce,
             InitializeWICFactory,
             nullptr,
             reinterpret_cast<LPVOID*>(&factory)))
@@ -339,7 +340,7 @@ namespace
 
         if (!maxsize)
         {
-            maxsize = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
+            maxsize = size_t(D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
         }
 
         UINT twidth = width;
@@ -559,7 +560,8 @@ namespace
         }
 
         // Count the number of mips
-        uint32_t mipCount = (loadFlags & (WIC_LOADER_MIP_AUTOGEN|WIC_LOADER_MIP_RESERVE)) ? CountMips(twidth, theight) : 1;
+        uint32_t mipCount = (loadFlags & (WIC_LOADER_MIP_AUTOGEN | WIC_LOADER_MIP_RESERVE))
+            ? CountMips(twidth, theight) : 1u;
 
         // Create texture
         D3D12_RESOURCE_DESC desc = {};
@@ -606,7 +608,7 @@ namespace
         _In_ ID3D12Resource** texture) noexcept
     {
 #if !defined(NO_D3D12_DEBUG_NAME) && ( defined(_DEBUG) || defined(PROFILE) )
-        if (texture)
+        if (texture && *texture)
         {
             const wchar_t* pstrName = wcsrchr(fileName, '\\');
             if (!pstrName)
@@ -618,10 +620,7 @@ namespace
                 pstrName++;
             }
 
-            if (texture && *texture)
-            {
-                (*texture)->SetName(pstrName);
-            }
+            (*texture)->SetName(pstrName);
         }
 #else
         UNREFERENCED_PARAMETER(fileName);
@@ -769,7 +768,11 @@ HRESULT DirectX::LoadWICTextureFromFileEx(
 
     // Initialize WIC
     ComPtr<IWICBitmapDecoder> decoder;
-    HRESULT hr = pWIC->CreateDecoderFromFilename(fileName, nullptr, GENERIC_READ, WICDecodeMetadataCacheOnDemand, decoder.GetAddressOf());
+    HRESULT hr = pWIC->CreateDecoderFromFilename(fileName,
+        nullptr,
+        GENERIC_READ,
+        WICDecodeMetadataCacheOnDemand,
+        decoder.GetAddressOf());
     if (FAILED(hr))
         return hr;
 

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -277,6 +277,47 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
+    void FitPowerOf2(UINT origx, UINT origy, UINT& targetx, UINT& targety, size_t maxsize)
+    {
+        float origAR = float(origx) / float(origy);
+
+        if (origx > origy)
+        {
+            size_t x;
+            for (x = maxsize; x > 1; x >>= 1) { if (x <= targetx) break; }
+            targetx = UINT(x);
+
+            float bestScore = FLT_MAX;
+            for (size_t y = maxsize; y > 0; y >>= 1)
+            {
+                float score = fabsf((float(x) / float(y)) - origAR);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    targety = UINT(y);
+                }
+            }
+        }
+        else
+        {
+            size_t y;
+            for (y = maxsize; y > 1; y >>= 1) { if (y <= targety) break; }
+            targety = UINT(y);
+
+            float bestScore = FLT_MAX;
+            for (size_t x = maxsize; x > 0; x >>= 1)
+            {
+                float score = fabsf((float(x) / float(y)) - origAR);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    targetx = UINT(x);
+                }
+            }
+        }
+    }
+
+    //---------------------------------------------------------------------------------
     HRESULT CreateTextureFromWIC(_In_ ID3D12Device* d3dDevice,
         _In_ IWICBitmapFrameDecode *frame,
         size_t maxsize,
@@ -301,8 +342,13 @@ namespace
             maxsize = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
         }
 
-        UINT twidth, theight;
-        if (width > maxsize || height > maxsize)
+        UINT twidth = width;
+        UINT theight = height;
+        if (loadFlags & WIC_LOADER_FIT_POW2)
+        {
+            FitPowerOf2(width, height, twidth, theight, maxsize);
+        }
+        else if (width > maxsize || height > maxsize)
         {
             float ar = static_cast<float>(height) / static_cast<float>(width);
             if (width > height)
@@ -317,10 +363,11 @@ namespace
             }
             assert(twidth <= maxsize && theight <= maxsize);
         }
-        else
+
+        if (loadFlags & WIC_LOADER_MAKE_SQUARE)
         {
-            twidth = width;
-            theight = height;
+            twidth = std::max<UINT>(twidth, theight);
+            theight = twidth;
         }
 
         // Determine format

--- a/WICTextureLoader/WICTextureLoader12.h
+++ b/WICTextureLoader/WICTextureLoader12.h
@@ -32,12 +32,14 @@ namespace DirectX
 #define WIC_LOADER_FLAGS_DEFINED
     enum WIC_LOADER_FLAGS : uint32_t
     {
-        WIC_LOADER_DEFAULT = 0,
-        WIC_LOADER_FORCE_SRGB = 0x1,
-        WIC_LOADER_IGNORE_SRGB = 0x2,
-        WIC_LOADER_MIP_AUTOGEN = 0x4,
-        WIC_LOADER_MIP_RESERVE = 0x8,
+        WIC_LOADER_DEFAULT      = 0,
+        WIC_LOADER_FORCE_SRGB   = 0x1,
+        WIC_LOADER_IGNORE_SRGB  = 0x2,
+        WIC_LOADER_MIP_AUTOGEN  = 0x4,
+        WIC_LOADER_MIP_RESERVE  = 0x8,
         WIC_LOADER_FORCE_RGBA32 = 0x10,
+        WIC_LOADER_FIT_POW2     = 0x20,
+        WIC_LOADER_MAKE_SQUARE  = 0x40,
     };
 #endif
 

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -1,0 +1,696 @@
+//--------------------------------------------------------------------------------------
+// File: WICTextureLoader9.cpp
+//
+// Function for loading a WIC image and creating a Direct3D runtime texture for it
+// (auto-generating mipmaps if possible)
+//
+// Note: Assumes application has already called CoInitializeEx
+//
+// Warning: CreateWICTexture* functions are not thread-safe if given a d3dContext instance for
+//          auto-gen mipmap support.
+//
+// Note these functions are useful for images created as simple 2D textures. For
+// more complex resources, DDSTextureLoader is an excellent light-weight runtime loader.
+// For a full-featured DDS file reader, writer, and texture processing pipeline see
+// the 'Texconv' sample and the 'DirectXTex' library.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+//--------------------------------------------------------------------------------------
+
+// We could load multi-frame images (TIFF/GIF) into a texture array.
+// For now, we just load the first frame (note: DirectXTex supports multi-frame images)
+
+#include "WICTextureLoader9.h"
+
+#include <d3d9types.h>
+
+#include <assert.h>
+#include <algorithm>
+#include <memory>
+
+#include <wincodec.h>
+
+#include <wrl\client.h>
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    //-------------------------------------------------------------------------------------
+    // WIC Pixel Format Translation Data
+    //-------------------------------------------------------------------------------------
+    struct WICTranslate
+    {
+        GUID                wic;
+        D3DFORMAT           format;
+    };
+
+    const WICTranslate g_WICFormats[] =
+    {
+        { GUID_WICPixelFormat128bppRGBAFloat,       D3DFMT_A32B32G32R32F },
+
+        { GUID_WICPixelFormat64bppRGBAHalf,         D3DFMT_A16B16G16R16F },
+        { GUID_WICPixelFormat64bppRGBA,             D3DFMT_A16B16G16R16 },
+
+        { GUID_WICPixelFormat24bppBGR,              D3DFMT_R8G8B8 },
+
+        { GUID_WICPixelFormat32bppRGBA,             D3DFMT_A8B8G8R8 },
+        { GUID_WICPixelFormat32bppBGRA,             D3DFMT_A8R8G8B8 },
+        { GUID_WICPixelFormat32bppBGR,              D3DFMT_X8R8G8B8 },
+
+        { GUID_WICPixelFormat32bppRGBA1010102,      D3DFMT_A2B10G10R10 },
+
+        { GUID_WICPixelFormat16bppBGRA5551,         D3DFMT_A1R5G5B5 },
+        { GUID_WICPixelFormat16bppBGR565,           D3DFMT_R5G6B5 },
+
+        { GUID_WICPixelFormat32bppGrayFloat,        D3DFMT_R32F },
+        { GUID_WICPixelFormat16bppGrayHalf,         D3DFMT_R16F },
+        { GUID_WICPixelFormat16bppGray,             D3DFMT_L16 },
+        { GUID_WICPixelFormat8bppGray,              D3DFMT_L8 },
+
+        { GUID_WICPixelFormat8bppAlpha,             D3DFMT_A8 },
+    };
+
+    //-------------------------------------------------------------------------------------
+    // WIC Pixel Format nearest conversion table
+    //-------------------------------------------------------------------------------------
+
+    struct WICConvert
+    {
+        GUID        source;
+        GUID        target;
+    };
+
+    const WICConvert g_WICConvert[] =
+    {
+        // Note target GUID in this conversion table must be one of those directly supported formats (above).
+
+        { GUID_WICPixelFormatBlackWhite,            GUID_WICPixelFormat8bppGray }, // D3DFMT_L8
+
+        { GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+        { GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+        { GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+        { GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+
+        { GUID_WICPixelFormat2bppGray,              GUID_WICPixelFormat8bppGray }, // D3DFMT_L8 
+        { GUID_WICPixelFormat4bppGray,              GUID_WICPixelFormat8bppGray }, // D3DFMT_L8 
+
+        { GUID_WICPixelFormat16bppGrayFixedPoint,   GUID_WICPixelFormat16bppGrayHalf }, // D3DFMT_R16F 
+        { GUID_WICPixelFormat32bppGrayFixedPoint,   GUID_WICPixelFormat32bppGrayFloat }, // D3DFMT_R32F 
+
+        { GUID_WICPixelFormat16bppBGR555,           GUID_WICPixelFormat16bppBGRA5551 }, // D3DFMT_A1R5G5B5
+
+        { GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // D3DFMT_A2B10G10R10
+
+        { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat24bppBGR }, // D3DFMT_R8G8B8
+
+        { GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+        { GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+
+        { GUID_WICPixelFormat48bppRGB,              GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+        { GUID_WICPixelFormat48bppBGR,              GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+        { GUID_WICPixelFormat64bppBGRA,             GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+        { GUID_WICPixelFormat64bppPRGBA,            GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+        { GUID_WICPixelFormat64bppPBGRA,            GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+
+        { GUID_WICPixelFormat48bppRGBFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat48bppBGRFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat64bppRGBAFixedPoint,   GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat64bppBGRAFixedPoint,   GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat64bppRGBFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat64bppRGBHalf,          GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat48bppRGBHalf,          GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+
+        { GUID_WICPixelFormat128bppPRGBAFloat,      GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
+        { GUID_WICPixelFormat128bppRGBFloat,        GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
+        { GUID_WICPixelFormat128bppRGBAFixedPoint,  GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
+        { GUID_WICPixelFormat128bppRGBFixedPoint,   GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
+        { GUID_WICPixelFormat32bppRGBE,             GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F
+
+        { GUID_WICPixelFormat32bppCMYK,             GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8
+        { GUID_WICPixelFormat64bppCMYK,             GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+        { GUID_WICPixelFormat40bppCMYKAlpha,        GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8
+        { GUID_WICPixelFormat80bppCMYKAlpha,        GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+
+    #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+        { GUID_WICPixelFormat32bppRGB,              GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8
+        { GUID_WICPixelFormat64bppRGB,              GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
+        { GUID_WICPixelFormat64bppPRGBAHalf,        GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
+        { GUID_WICPixelFormat96bppRGBFloat,         GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
+    #endif
+
+        // We don't support n-channel formats
+    };
+
+    bool g_WIC2 = false;
+
+    //--------------------------------------------------------------------------------------
+    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID* ifactory) noexcept
+    {
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+        HRESULT hr = CoCreateInstance(
+            CLSID_WICImagingFactory2,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory2),
+            ifactory
+        );
+
+        if (SUCCEEDED(hr))
+        {
+            // WIC2 is available on Windows 10, Windows 8.x, and Windows 7 SP1 with KB 2670838 installed
+            g_WIC2 = true;
+            return TRUE;
+        }
+        else
+        {
+            hr = CoCreateInstance(
+                CLSID_WICImagingFactory1,
+                nullptr,
+                CLSCTX_INPROC_SERVER,
+                __uuidof(IWICImagingFactory),
+                ifactory
+            );
+            return SUCCEEDED(hr) ? TRUE : FALSE;
+        }
+#else
+        return SUCCEEDED(CoCreateInstance(
+            CLSID_WICImagingFactory,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory),
+            ifactory)) ? TRUE : FALSE;
+#endif
+    }
+
+    IWICImagingFactory* _GetWIC() noexcept
+    {
+        static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
+
+        IWICImagingFactory* factory = nullptr;
+        if (!InitOnceExecuteOnce(
+            &s_initOnce,
+            InitializeWICFactory,
+            nullptr,
+            reinterpret_cast<LPVOID*>(&factory)))
+        {
+            return nullptr;
+        }
+
+        return factory;
+    }
+
+    //---------------------------------------------------------------------------------
+    D3DFORMAT _WICToD3D9(const GUID& guid) noexcept
+    {
+        for (size_t i = 0; i < _countof(g_WICFormats); ++i)
+        {
+            if (memcmp(&g_WICFormats[i].wic, &guid, sizeof(GUID)) == 0)
+                return g_WICFormats[i].format;
+        }
+
+        return D3DFMT_UNKNOWN;
+    }
+
+    //---------------------------------------------------------------------------------
+    size_t _WICBitsPerPixel(REFGUID targetGuid) noexcept
+    {
+        auto pWIC = _GetWIC();
+        if (!pWIC)
+            return 0;
+
+        ComPtr<IWICComponentInfo> cinfo;
+        if (FAILED(pWIC->CreateComponentInfo(targetGuid, cinfo.GetAddressOf())))
+            return 0;
+
+        WICComponentType type;
+        if (FAILED(cinfo->GetComponentType(&type)))
+            return 0;
+
+        if (type != WICPixelFormat)
+            return 0;
+
+        ComPtr<IWICPixelFormatInfo> pfinfo;
+        if (FAILED(cinfo.As(&pfinfo)))
+            return 0;
+
+        UINT bpp;
+        if (FAILED(pfinfo->GetBitsPerPixel(&bpp)))
+            return 0;
+
+        return bpp;
+    }
+
+#if 0
+    //---------------------------------------------------------------------------------
+    HRESULT CreateTextureFromWIC(_In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+        _In_ IWICBitmapFrameDecode *frame,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ unsigned int loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
+    {
+        UINT width, height;
+        HRESULT hr = frame->GetSize(&width, &height);
+        if (FAILED(hr))
+            return hr;
+
+        if (maxsize > UINT32_MAX)
+            return E_INVALIDARG;
+
+        assert(width > 0 && height > 0);
+
+        if (!maxsize)
+        {
+            // This is a bit conservative because the hardware could support larger textures than
+            // the Feature Level defined minimums, but doing it this way is much easier and more
+            // performant for WIC than the 'fail and retry' model used by DDSTextureLoader
+
+            switch (d3dDevice->GetFeatureLevel())
+            {
+            case D3D_FEATURE_LEVEL_9_1:
+            case D3D_FEATURE_LEVEL_9_2:
+                maxsize = 2048u /*D3D_FL9_1_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+                break;
+
+            case D3D_FEATURE_LEVEL_9_3:
+                maxsize = 4096u /*D3D_FL9_3_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+                break;
+
+            case D3D_FEATURE_LEVEL_10_0:
+            case D3D_FEATURE_LEVEL_10_1:
+                maxsize = 8192u /*D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+                break;
+
+            default:
+                maxsize = size_t(D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
+                break;
+            }
+        }
+
+        assert(maxsize > 0);
+
+        UINT twidth, theight;
+        if (width > maxsize || height > maxsize)
+        {
+            float ar = static_cast<float>(height) / static_cast<float>(width);
+            if (width > height)
+            {
+                twidth = static_cast<UINT>(maxsize);
+                theight = std::max<UINT>(1, static_cast<UINT>(static_cast<float>(maxsize) * ar));
+            }
+            else
+            {
+                theight = static_cast<UINT>(maxsize);
+                twidth = std::max<UINT>(1, static_cast<UINT>(static_cast<float>(maxsize) / ar));
+            }
+            assert(twidth <= maxsize && theight <= maxsize);
+        }
+        else
+        {
+            twidth = width;
+            theight = height;
+        }
+
+        // Determine format
+        WICPixelFormatGUID pixelFormat;
+        hr = frame->GetPixelFormat(&pixelFormat);
+        if (FAILED(hr))
+            return hr;
+
+        WICPixelFormatGUID convertGUID;
+        memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &pixelFormat, sizeof(GUID));
+
+        size_t bpp = 0;
+
+        DXGI_FORMAT format = _WICToDXGI(pixelFormat);
+        if (format == D3DFMT_UNKNOWN)
+        {
+            for (size_t i = 0; i < _countof(g_WICConvert); ++i)
+            {
+                if (memcmp(&g_WICConvert[i].source, &pixelFormat, sizeof(WICPixelFormatGUID)) == 0)
+                {
+                    memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &g_WICConvert[i].target, sizeof(GUID));
+
+                    format = _WICToDXGI(g_WICConvert[i].target);
+                    assert(format != D3DFMT_UNKNOWN);
+                    bpp = _WICBitsPerPixel(convertGUID);
+                    break;
+                }
+            }
+
+            if (format == D3DFMT_UNKNOWN)
+                return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+        }
+        else
+        {
+            bpp = _WICBitsPerPixel(pixelFormat);
+        }
+
+        if (loadFlags & WIC_LOADER_FORCE_RGBA32)
+        {
+            memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &GUID_WICPixelFormat32bppRGBA, sizeof(GUID));
+            format = D3DFMT_A8B8G8R8;
+            bpp = 32;
+        }
+
+        if (!bpp)
+            return E_FAIL;
+
+        // Handle sRGB formats
+        if (loadFlags & WIC_LOADER_FORCE_SRGB)
+        {
+            format = MakeSRGB(format);
+        }
+        else if (!(loadFlags & WIC_LOADER_IGNORE_SRGB))
+        {
+            ComPtr<IWICMetadataQueryReader> metareader;
+            if (SUCCEEDED(frame->GetMetadataQueryReader(metareader.GetAddressOf())))
+            {
+                GUID containerFormat;
+                if (SUCCEEDED(metareader->GetContainerFormat(&containerFormat)))
+                {
+                    // Check for sRGB colorspace metadata
+                    bool sRGB = false;
+
+                    PROPVARIANT value;
+                    PropVariantInit(&value);
+
+                    if (memcmp(&containerFormat, &GUID_ContainerFormatPng, sizeof(GUID)) == 0)
+                    {
+                        // Check for sRGB chunk
+                        if (SUCCEEDED(metareader->GetMetadataByName(L"/sRGB/RenderingIntent", &value)) && value.vt == VT_UI1)
+                        {
+                            sRGB = true;
+                        }
+                    }
+                    else if (SUCCEEDED(metareader->GetMetadataByName(L"System.Image.ColorSpace", &value)) && value.vt == VT_UI2 && value.uiVal == 1)
+                    {
+                        sRGB = true;
+                    }
+
+                    (void)PropVariantClear(&value);
+
+                    if (sRGB)
+                        format = MakeSRGB(format);
+                }
+            }
+        }
+
+        // Verify our target format is supported by the current device
+        // (handles WDDM 1.0 or WDDM 1.1 device driver cases as well as DirectX 11.0 Runtime without 16bpp format support)
+        UINT support = 0;
+        hr = d3dDevice->CheckFormatSupport(format, &support);
+        if (FAILED(hr) || !(support & D3D11_FORMAT_SUPPORT_TEXTURE2D))
+        {
+            // Fallback to RGBA 32-bit format which is supported by all devices
+            memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &GUID_WICPixelFormat32bppRGBA, sizeof(GUID));
+            format = D3DFMT_A8B8G8R8;
+            bpp = 32;
+        }
+
+        // Allocate temporary memory for image
+        uint64_t rowBytes = (uint64_t(twidth) * uint64_t(bpp) + 7u) / 8u;
+        uint64_t numBytes = rowBytes * uint64_t(height);
+
+        if (rowBytes > UINT32_MAX || numBytes > UINT32_MAX)
+            return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
+
+        auto rowPitch = static_cast<size_t>(rowBytes);
+        auto imageSize = static_cast<size_t>(numBytes);
+
+        std::unique_ptr<uint8_t[]> temp(new (std::nothrow) uint8_t[imageSize]);
+        if (!temp)
+            return E_OUTOFMEMORY;
+
+        // Load image data
+        if (memcmp(&convertGUID, &pixelFormat, sizeof(GUID)) == 0
+            && twidth == width
+            && theight == height)
+        {
+            // No format conversion or resize needed
+            hr = frame->CopyPixels(nullptr, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+            if (FAILED(hr))
+                return hr;
+        }
+        else if (twidth != width || theight != height)
+        {
+            // Resize
+            auto pWIC = _GetWIC();
+            if (!pWIC)
+                return E_NOINTERFACE;
+
+            ComPtr<IWICBitmapScaler> scaler;
+            hr = pWIC->CreateBitmapScaler(scaler.GetAddressOf());
+            if (FAILED(hr))
+                return hr;
+
+            hr = scaler->Initialize(frame, twidth, theight, WICBitmapInterpolationModeFant);
+            if (FAILED(hr))
+                return hr;
+
+            WICPixelFormatGUID pfScaler;
+            hr = scaler->GetPixelFormat(&pfScaler);
+            if (FAILED(hr))
+                return hr;
+
+            if (memcmp(&convertGUID, &pfScaler, sizeof(GUID)) == 0)
+            {
+                // No format conversion needed
+                hr = scaler->CopyPixels(nullptr, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+                if (FAILED(hr))
+                    return hr;
+            }
+            else
+            {
+                ComPtr<IWICFormatConverter> FC;
+                hr = pWIC->CreateFormatConverter(FC.GetAddressOf());
+                if (FAILED(hr))
+                    return hr;
+
+                BOOL canConvert = FALSE;
+                hr = FC->CanConvert(pfScaler, convertGUID, &canConvert);
+                if (FAILED(hr) || !canConvert)
+                {
+                    return E_UNEXPECTED;
+                }
+
+                hr = FC->Initialize(scaler.Get(), convertGUID, WICBitmapDitherTypeErrorDiffusion, nullptr, 0, WICBitmapPaletteTypeMedianCut);
+                if (FAILED(hr))
+                    return hr;
+
+                hr = FC->CopyPixels(nullptr, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+                if (FAILED(hr))
+                    return hr;
+            }
+        }
+        else
+        {
+            // Format conversion but no resize
+            auto pWIC = _GetWIC();
+            if (!pWIC)
+                return E_NOINTERFACE;
+
+            ComPtr<IWICFormatConverter> FC;
+            hr = pWIC->CreateFormatConverter(FC.GetAddressOf());
+            if (FAILED(hr))
+                return hr;
+
+            BOOL canConvert = FALSE;
+            hr = FC->CanConvert(pixelFormat, convertGUID, &canConvert);
+            if (FAILED(hr) || !canConvert)
+            {
+                return E_UNEXPECTED;
+            }
+
+            hr = FC->Initialize(frame, convertGUID, WICBitmapDitherTypeErrorDiffusion, nullptr, 0, WICBitmapPaletteTypeMedianCut);
+            if (FAILED(hr))
+                return hr;
+
+            hr = FC->CopyPixels(nullptr, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+            if (FAILED(hr))
+                return hr;
+        }
+
+        // D3DUSAGE_AUTOGENMIPMAP
+
+        // Create texture
+        D3D11_TEXTURE2D_DESC desc = {};
+        desc.Width = twidth;
+        desc.Height = theight;
+        desc.MipLevels = (autogen) ? 0u : 1u;
+        desc.ArraySize = 1;
+        desc.Format = format;
+        desc.SampleDesc.Count = 1;
+        desc.SampleDesc.Quality = 0;
+        desc.Usage = usage;
+        desc.CPUAccessFlags = cpuAccessFlags;
+
+        if (autogen)
+        {
+            desc.BindFlags = bindFlags | D3D11_BIND_RENDER_TARGET;
+            desc.MiscFlags = miscFlags | D3D11_RESOURCE_MISC_GENERATE_MIPS;
+        }
+        else
+        {
+            desc.BindFlags = bindFlags;
+            desc.MiscFlags = miscFlags;
+        }
+
+        D3D11_SUBRESOURCE_DATA initData;
+        initData.pSysMem = temp.get();
+        initData.SysMemPitch = static_cast<UINT>(rowPitch);
+        initData.SysMemSlicePitch = static_cast<UINT>(imageSize);
+
+        ID3D11Texture2D* tex = nullptr;
+        hr = d3dDevice->CreateTexture2D(&desc, (autogen) ? nullptr : &initData, &tex);
+        if (SUCCEEDED(hr) && tex)
+        {
+            if (textureView)
+            {
+                D3D11_SHADER_RESOURCE_VIEW_DESC SRVDesc = {};
+                SRVDesc.Format = desc.Format;
+
+                SRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+                SRVDesc.Texture2D.MipLevels = (autogen) ? unsigned(-1) : 1u;
+
+                hr = d3dDevice->CreateShaderResourceView(tex, &SRVDesc, textureView);
+                if (FAILED(hr))
+                {
+                    tex->Release();
+                    return hr;
+                }
+
+                if (autogen)
+                {
+                    assert(d3dContext != nullptr);
+                    d3dContext->UpdateSubresource(tex, 0, nullptr, temp.get(), static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize));
+                    d3dContext->GenerateMips(*textureView);
+                }
+            }
+
+            if (texture)
+            {
+                *texture = tex;
+            }
+            else
+            {
+                SetDebugObjectName(tex, "WICTextureLoader");
+                tex->Release();
+            }
+        }
+
+        return hr;
+    }
+#endif
+} // anonymous namespace
+
+//--------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::CreateWICTextureFromMemory(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const uint8_t* wicData,
+    size_t wicDataSize,
+    LPDIRECT3DTEXTURE9* texture,
+    unsigned int loadFlags) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !wicData || !wicDataSize || !texture)
+        return E_INVALIDARG;
+
+    if (!wicDataSize)
+        return E_FAIL;
+
+    if (wicDataSize > UINT32_MAX)
+        return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
+
+    auto pWIC = _GetWIC();
+    if (!pWIC)
+        return E_NOINTERFACE;
+
+    // Create input stream for memory
+    ComPtr<IWICStream> stream;
+    HRESULT hr = pWIC->CreateStream(stream.GetAddressOf());
+    if (FAILED(hr))
+        return hr;
+
+    hr = stream->InitializeFromMemory(const_cast<uint8_t*>(wicData), static_cast<DWORD>(wicDataSize));
+    if (FAILED(hr))
+        return hr;
+
+    // Initialize WIC
+    ComPtr<IWICBitmapDecoder> decoder;
+    hr = pWIC->CreateDecoderFromStream(stream.Get(), nullptr, WICDecodeMetadataCacheOnDemand, decoder.GetAddressOf());
+    if (FAILED(hr))
+        return hr;
+
+    ComPtr<IWICBitmapFrameDecode> frame;
+    hr = decoder->GetFrame(0, frame.GetAddressOf());
+    if (FAILED(hr))
+        return hr;
+
+    // TODO -
+    hr = E_NOTIMPL;
+
+    return hr;
+}
+
+//--------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::CreateWICTextureFromFile(
+    LPDIRECT3DDEVICE9 d3dDevice,
+    const wchar_t* szFileName,
+    LPDIRECT3DTEXTURE9* texture,
+    unsigned int loadFlags) noexcept
+{
+    if (texture)
+    {
+        *texture = nullptr;
+    }
+
+    if (!d3dDevice || !szFileName || !texture)
+        return E_INVALIDARG;
+
+    auto pWIC = _GetWIC();
+    if (!pWIC)
+        return E_NOINTERFACE;
+
+    // Initialize WIC
+    ComPtr<IWICBitmapDecoder> decoder;
+    HRESULT hr = pWIC->CreateDecoderFromFilename(szFileName,
+        nullptr,
+        GENERIC_READ,
+        WICDecodeMetadataCacheOnDemand,
+        decoder.GetAddressOf());
+    if (FAILED(hr))
+        return hr;
+
+    ComPtr<IWICBitmapFrameDecode> frame;
+    hr = decoder->GetFrame(0, frame.GetAddressOf());
+    if (FAILED(hr))
+        return hr;
+
+    // TODO -
+    hr = E_NOTIMPL;
+
+    return hr;
+}

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -64,6 +64,7 @@ namespace
         { GUID_WICPixelFormat32bppRGBA1010102,      D3DFMT_A2B10G10R10 },
 
         { GUID_WICPixelFormat16bppBGRA5551,         D3DFMT_A1R5G5B5 },
+        { GUID_WICPixelFormat16bppBGR555,           D3DFMT_X1R5G5B5 },
         { GUID_WICPixelFormat16bppBGR565,           D3DFMT_R5G6B5 },
 
         { GUID_WICPixelFormat32bppGrayFloat,        D3DFMT_R32F },
@@ -100,8 +101,6 @@ namespace
 
         { GUID_WICPixelFormat16bppGrayFixedPoint,   GUID_WICPixelFormat16bppGrayHalf }, // D3DFMT_R16F 
         { GUID_WICPixelFormat32bppGrayFixedPoint,   GUID_WICPixelFormat32bppGrayFloat }, // D3DFMT_R32F 
-
-        { GUID_WICPixelFormat16bppBGR555,           GUID_WICPixelFormat16bppBGRA5551 }, // D3DFMT_A1R5G5B5
 
         { GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // D3DFMT_A2B10G10R10
 

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -219,6 +219,47 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
+    void FitPowerOf2(UINT origx, UINT origy, UINT& targetx, UINT& targety, size_t maxsize)
+    {
+        float origAR = float(origx) / float(origy);
+
+        if (origx > origy)
+        {
+            size_t x;
+            for (x = maxsize; x > 1; x >>= 1) { if (x <= targetx) break; }
+            targetx = UINT(x);
+
+            float bestScore = FLT_MAX;
+            for (size_t y = maxsize; y > 0; y >>= 1)
+            {
+                float score = fabsf((float(x) / float(y)) - origAR);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    targety = UINT(y);
+                }
+            }
+        }
+        else
+        {
+            size_t y;
+            for (y = maxsize; y > 1; y >>= 1) { if (y <= targety) break; }
+            targety = UINT(y);
+
+            float bestScore = FLT_MAX;
+            for (size_t x = maxsize; x > 0; x >>= 1)
+            {
+                float score = fabsf((float(x) / float(y)) - origAR);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    targetx = UINT(x);
+                }
+            }
+        }
+    }
+
+    //---------------------------------------------------------------------------------
     HRESULT CreateTextureFromWIC(
         _In_ LPDIRECT3DDEVICE9 device,
         _In_ IWICBitmapFrameDecode *frame,
@@ -243,8 +284,13 @@ namespace
 
         assert(maxsize > 0);
 
-        UINT twidth, theight;
-        if (width > maxsize || height > maxsize)
+        UINT twidth = width;
+        UINT theight = height;
+        if (loadFlags & WIC_LOADER_FIT_POW2)
+        {
+            FitPowerOf2(width, height, twidth, theight, maxsize);
+        }
+        else if (width > maxsize || height > maxsize)
         {
             float ar = static_cast<float>(height) / static_cast<float>(width);
             if (width > height)
@@ -259,10 +305,11 @@ namespace
             }
             assert(twidth <= maxsize && theight <= maxsize);
         }
-        else
+
+        if (loadFlags & WIC_LOADER_MAKE_SQUARE)
         {
-            twidth = width;
-            theight = height;
+            twidth = std::max<UINT>(twidth, theight);
+            theight = twidth;
         }
 
         // Determine format
@@ -299,10 +346,20 @@ namespace
             format = D3DFMT_A8B8G8R8;
         }
 
+        // Create texture
+        ComPtr<IDirect3DTexture9> pTexture;
+        hr = device->CreateTexture(twidth, theight, 1u,
+            (loadFlags & WIC_LOADER_MIP_AUTOGEN) ? D3DUSAGE_AUTOGENMIPMAP : 0u,
+            format, D3DPOOL_DEFAULT,
+            pTexture.GetAddressOf(), nullptr);
+        if (FAILED(hr))
+            return hr;
+
         // Create staging texture memory
         ComPtr<IDirect3DTexture9> pStagingTexture;
         hr = device->CreateTexture(twidth, theight, 1u,
-            0, format, D3DPOOL_SYSTEMMEM, pStagingTexture.GetAddressOf(), nullptr);
+            0u, format, D3DPOOL_SYSTEMMEM,
+            pStagingTexture.GetAddressOf(), nullptr);
         if (FAILED(hr))
             return hr;
 
@@ -440,15 +497,6 @@ namespace
             if (FAILED(hr))
                 return hr;
         }
-
-        // Create texture
-        ComPtr<IDirect3DTexture9> pTexture;
-        hr = device->CreateTexture(twidth, theight, 1u,
-            (loadFlags & WIC_LOADER_MIP_AUTOGEN) ? D3DUSAGE_AUTOGENMIPMAP : 0u,
-            format, D3DPOOL_DEFAULT,
-            pTexture.GetAddressOf(), nullptr);
-        if (FAILED(hr))
-            return hr;
 
         hr = device->UpdateTexture(pStagingTexture.Get(), pTexture.Get());
         if (FAILED(hr))

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -58,9 +58,6 @@ namespace
         { GUID_WICPixelFormat64bppRGBAHalf,         D3DFMT_A16B16G16R16F },
         { GUID_WICPixelFormat64bppRGBA,             D3DFMT_A16B16G16R16 },
 
-        { GUID_WICPixelFormat24bppBGR,              D3DFMT_R8G8B8 },
-
-        { GUID_WICPixelFormat32bppRGBA,             D3DFMT_A8B8G8R8 },
         { GUID_WICPixelFormat32bppBGRA,             D3DFMT_A8R8G8B8 },
         { GUID_WICPixelFormat32bppBGR,              D3DFMT_X8R8G8B8 },
 
@@ -93,10 +90,10 @@ namespace
 
         { GUID_WICPixelFormatBlackWhite,            GUID_WICPixelFormat8bppGray }, // D3DFMT_L8
 
-        { GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
-        { GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
-        { GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
-        { GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+        { GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
 
         { GUID_WICPixelFormat2bppGray,              GUID_WICPixelFormat8bppGray }, // D3DFMT_L8 
         { GUID_WICPixelFormat4bppGray,              GUID_WICPixelFormat8bppGray }, // D3DFMT_L8 
@@ -108,10 +105,13 @@ namespace
 
         { GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // D3DFMT_A2B10G10R10
 
-        { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat24bppBGR }, // D3DFMT_R8G8B8
+        { GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat32bppBGR }, // D3DFMT_X8R8G8B8
+        { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat32bppBGR }, // D3DFMT_X8R8G8B8
 
-        { GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
-        { GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8 
+        { GUID_WICPixelFormat32bppRGBA,             GUID_WICPixelFormat32bppBGRA }, // D3DFMT_X8R8G8B8
+
+        { GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
 
         { GUID_WICPixelFormat48bppRGB,              GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
         { GUID_WICPixelFormat48bppBGR,              GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
@@ -133,13 +133,13 @@ namespace
         { GUID_WICPixelFormat128bppRGBFixedPoint,   GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
         { GUID_WICPixelFormat32bppRGBE,             GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F
 
-        { GUID_WICPixelFormat32bppCMYK,             GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8
+        { GUID_WICPixelFormat32bppCMYK,             GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
         { GUID_WICPixelFormat64bppCMYK,             GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
-        { GUID_WICPixelFormat40bppCMYKAlpha,        GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8
+        { GUID_WICPixelFormat40bppCMYKAlpha,        GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
         { GUID_WICPixelFormat80bppCMYKAlpha,        GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
 
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
-        { GUID_WICPixelFormat32bppRGB,              GUID_WICPixelFormat32bppRGBA }, // D3DFMT_A8B8G8R8
+        { GUID_WICPixelFormat32bppRGB,              GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
         { GUID_WICPixelFormat64bppRGB,              GUID_WICPixelFormat64bppRGBA }, // D3DFMT_A16B16G16R16
         { GUID_WICPixelFormat64bppPRGBAHalf,        GUID_WICPixelFormat64bppRGBAHalf }, // D3DFMT_A16B16G16R16F 
         { GUID_WICPixelFormat96bppRGBFloat,         GUID_WICPixelFormat128bppRGBAFloat }, // D3DFMT_A32B32G32R32F 
@@ -342,8 +342,8 @@ namespace
 
         if (loadFlags & WIC_LOADER_FORCE_RGBA32)
         {
-            memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &GUID_WICPixelFormat32bppRGBA, sizeof(GUID));
-            format = D3DFMT_A8B8G8R8;
+            memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &GUID_WICPixelFormat32bppBGRA, sizeof(GUID));
+            format = D3DFMT_A8R8G8B8;
         }
 
         // Create texture

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -59,7 +59,6 @@ namespace
         { GUID_WICPixelFormat64bppRGBA,             D3DFMT_A16B16G16R16 },
 
         { GUID_WICPixelFormat32bppBGRA,             D3DFMT_A8R8G8B8 },
-        { GUID_WICPixelFormat32bppBGR,              D3DFMT_X8R8G8B8 },
 
         { GUID_WICPixelFormat32bppRGBA1010102,      D3DFMT_A2B10G10R10 },
 
@@ -104,11 +103,10 @@ namespace
 
         { GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // D3DFMT_A2B10G10R10
 
-        { GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat32bppBGR }, // D3DFMT_X8R8G8B8
-        { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat32bppBGR }, // D3DFMT_X8R8G8B8
-
-        { GUID_WICPixelFormat32bppRGBA,             GUID_WICPixelFormat32bppBGRA }, // D3DFMT_X8R8G8B8
-
+        { GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat32bppBGR,              GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
+        { GUID_WICPixelFormat32bppRGBA,             GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
         { GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
         { GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppBGRA }, // D3DFMT_A8R8G8B8
 

--- a/WICTextureLoader/WICTextureLoader9.h
+++ b/WICTextureLoader/WICTextureLoader9.h
@@ -1,0 +1,52 @@
+//--------------------------------------------------------------------------------------
+// File: WICTextureLoader9.h
+//
+// Function for loading a WIC image and creating a Direct3D runtime texture for it
+// (auto-generating mipmaps if possible)
+//
+// Note: Assumes application has already called CoInitializeEx
+//
+// Note these functions are useful for images created as simple 2D textures. For
+// more complex resources, DDSTextureLoader is an excellent light-weight runtime loader.
+// For a full-featured DDS file reader, writer, and texture processing pipeline see
+// the 'Texconv' sample and the 'DirectXTex' library.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#define DIRECT3D_VERSION 0x900
+#include <d3d9.h>
+
+#include <cstdint>
+
+namespace DirectX
+{
+#ifndef WIC_LOADER_FLAGS_DEFINED
+#define WIC_LOADER_FLAGS_DEFINED
+    enum WIC_LOADER_FLAGS : uint32_t
+    {
+        WIC_LOADER_DEFAULT = 0,
+        WIC_LOADER_MIP_AUTOGEN = 0x4,
+        WIC_LOADER_FORCE_RGBA32 = 0x10,
+    };
+#endif
+
+    // Standard version
+    HRESULT CreateWICTextureFromMemory(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
+        _In_ size_t wicDataSize,
+        _Outptr_ LPDIRECT3DTEXTURE9* texture,
+        _In_ unsigned int loadFlags = 0) noexcept;
+
+    HRESULT CreateWICTextureFromFile(
+        _In_ LPDIRECT3DDEVICE9 d3dDevice,
+        _In_z_ const wchar_t* szFileName,
+        _Outptr_ LPDIRECT3DTEXTURE9* texture,
+        _In_ unsigned int loadFlags = 0) noexcept;
+}

--- a/WICTextureLoader/WICTextureLoader9.h
+++ b/WICTextureLoader/WICTextureLoader9.h
@@ -19,7 +19,9 @@
 
 #pragma once
 
+#ifndef DIRECT3D_VERSION
 #define DIRECT3D_VERSION 0x900
+#endif
 #include <d3d9.h>
 
 #include <cstdint>
@@ -31,7 +33,6 @@ namespace DirectX
     enum WIC_LOADER_FLAGS : uint32_t
     {
         WIC_LOADER_DEFAULT = 0,
-        WIC_LOADER_MIP_AUTOGEN = 0x4,
         WIC_LOADER_FORCE_RGBA32 = 0x10,
     };
 #endif

--- a/WICTextureLoader/WICTextureLoader9.h
+++ b/WICTextureLoader/WICTextureLoader9.h
@@ -33,6 +33,7 @@ namespace DirectX
     enum WIC_LOADER_FLAGS : uint32_t
     {
         WIC_LOADER_DEFAULT = 0,
+        WIC_LOADER_MIP_AUTOGEN = 0x4,
         WIC_LOADER_FORCE_RGBA32 = 0x10,
     };
 #endif
@@ -43,11 +44,13 @@ namespace DirectX
         _In_reads_bytes_(wicDataSize) const uint8_t* wicData,
         _In_ size_t wicDataSize,
         _Outptr_ LPDIRECT3DTEXTURE9* texture,
+        _In_ size_t maxsize = 0,
         _In_ unsigned int loadFlags = 0) noexcept;
 
     HRESULT CreateWICTextureFromFile(
         _In_ LPDIRECT3DDEVICE9 d3dDevice,
-        _In_z_ const wchar_t* szFileName,
+        _In_z_ const wchar_t* fileName,
         _Outptr_ LPDIRECT3DTEXTURE9* texture,
+        _In_ size_t maxsize = 0,
         _In_ unsigned int loadFlags = 0) noexcept;
 }

--- a/WICTextureLoader/WICTextureLoader9.h
+++ b/WICTextureLoader/WICTextureLoader9.h
@@ -32,9 +32,11 @@ namespace DirectX
 #define WIC_LOADER_FLAGS_DEFINED
     enum WIC_LOADER_FLAGS : uint32_t
     {
-        WIC_LOADER_DEFAULT = 0,
-        WIC_LOADER_MIP_AUTOGEN = 0x4,
+        WIC_LOADER_DEFAULT      = 0,
+        WIC_LOADER_MIP_AUTOGEN  = 0x4,
         WIC_LOADER_FORCE_RGBA32 = 0x10,
+        WIC_LOADER_FIT_POW2     = 0x20,
+        WIC_LOADER_MAKE_SQUARE  = 0x40,
     };
 #endif
 


### PR DESCRIPTION
DDSTextureLoader9 & WICTextureLoader9 added to DirectXTex

Added ``WIC_LOADER_FIT_POW2`` and ``WIC_LOADER_MAKE_SQUARE`` to WICTextureLoader (also in DirectX Tool Kits)

> DDSTextureLoader renamed to DDSTextureLoader11
> ScreenGrab renamed to ScreenGrab11
> WICTextureLoader renamed to WICTextureLoader11