### PR TITLE
Switched to using strongly typed flags

### DIFF
--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -67,7 +67,7 @@ namespace
         _Out_ HDRColorA *pY,
         _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA *pPoints,
         uint32_t cSteps,
-        DWORD flags) noexcept
+        uint32_t flags) noexcept
     {
         static const float fEpsilon = (0.25f / 64.0f) * (0.25f / 64.0f);
         static const float pC3[] = { 2.0f / 2.0f, 1.0f / 2.0f, 0.0f / 2.0f };
@@ -372,7 +372,7 @@ namespace
         _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA *pColor,
         bool bColorKey,
         float threshold,
-        DWORD flags) noexcept
+        uint32_t flags) noexcept
     {
         assert(pBC && pColor);
         static_assert(sizeof(D3DX_BC1) == 8, "D3DX_BC1 should be 8 bytes");
@@ -735,7 +735,7 @@ void DirectX::D3DXDecodeBC1(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC1(uint8_t *pBC, const XMVECTOR *pColor, float threshold, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC1(uint8_t *pBC, const XMVECTOR *pColor, float threshold, uint32_t flags) noexcept
 {
     assert(pBC && pColor);
 
@@ -810,7 +810,7 @@ void DirectX::D3DXDecodeBC2(XMVECTOR *pColor, const uint8_t *pBC) noexcept
     DecodeBC1(pColor, &pBC2->bc1, false);
 
     // 4-bit alpha part
-    DWORD dw = pBC2->bitmap[0];
+    uint32_t dw = pBC2->bitmap[0];
 
     for (size_t i = 0; i < 8; ++i, dw >>= 4)
     {
@@ -825,7 +825,7 @@ void DirectX::D3DXDecodeBC2(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC2(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC2(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     assert(pBC && pColor);
     static_assert(sizeof(D3DX_BC2) == 16, "D3DX_BC2 should be 16 bytes");
@@ -929,7 +929,7 @@ void DirectX::D3DXDecodeBC3(XMVECTOR *pColor, const uint8_t *pBC) noexcept
         fAlpha[7] = 1.0f;
     }
 
-    DWORD dw = uint32_t(pBC3->bitmap[0]) | uint32_t(pBC3->bitmap[1] << 8) | uint32_t(pBC3->bitmap[2] << 16);
+    uint32_t dw = uint32_t(pBC3->bitmap[0]) | uint32_t(pBC3->bitmap[1] << 8) | uint32_t(pBC3->bitmap[2] << 16);
 
     for (size_t i = 0; i < 8; ++i, dw >>= 3)
         pColor[i] = XMVectorSetW(pColor[i], fAlpha[dw & 0x7]);
@@ -941,7 +941,7 @@ void DirectX::D3DXDecodeBC3(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     assert(pBC && pColor);
     static_assert(sizeof(D3DX_BC3) == 16, "D3DX_BC3 should be 16 bytes");

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -28,7 +28,7 @@ namespace DirectX
 // Constants
 //-------------------------------------------------------------------------------------
 
-enum BC_FLAGS
+enum BC_FLAGS : unsigned long
 {
     BC_FLAGS_NONE               = 0x0,
     BC_FLAGS_DITHER_RGB         = 0x10000,  // Enables dithering for RGB colors for BC1-3

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -28,7 +28,7 @@ namespace DirectX
 // Constants
 //-------------------------------------------------------------------------------------
 
-enum BC_FLAGS : unsigned long
+enum BC_FLAGS : uint32_t
 {
     BC_FLAGS_NONE               = 0x0,
     BC_FLAGS_DITHER_RGB         = 0x10000,  // Enables dithering for RGB colors for BC1-3
@@ -302,7 +302,7 @@ template <bool bRange> void OptimizeAlpha(float *pX, float *pY, const float *pPo
 //-------------------------------------------------------------------------------------
 
 typedef void (*BC_DECODE)(XMVECTOR *pColor, const uint8_t *pBC);
-typedef void (*BC_ENCODE)(uint8_t *pDXT, const XMVECTOR *pColor, DWORD flags);
+typedef void (*BC_ENCODE)(uint8_t *pDXT, const XMVECTOR *pColor, uint32_t flags);
 
 void D3DXDecodeBC1(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(8) const uint8_t *pBC) noexcept;
 void D3DXDecodeBC2(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
@@ -315,17 +315,17 @@ void D3DXDecodeBC6HU(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_re
 void D3DXDecodeBC6HS(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
 void D3DXDecodeBC7(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
 
-void D3DXEncodeBC1(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ float threshold, _In_ DWORD flags) noexcept;
+void D3DXEncodeBC1(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ float threshold, _In_ uint32_t flags) noexcept;
     // BC1 requires one additional parameter, so it doesn't match signature of BC_ENCODE above
 
-void D3DXEncodeBC2(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC3(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC4U(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC4S(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC5U(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC5S(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC6HU(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC6HS(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
-void D3DXEncodeBC7(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ DWORD flags) noexcept;
+void D3DXEncodeBC2(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC3(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC4U(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC4S(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC5U(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC5S(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC6HU(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC6HS(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+void D3DXEncodeBC7(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
 
 } // namespace

--- a/DirectXTex/BC4BC5.cpp
+++ b/DirectXTex/BC4BC5.cpp
@@ -416,7 +416,7 @@ void DirectX::D3DXDecodeBC4S(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC4U(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC4U(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
 
@@ -437,7 +437,7 @@ void DirectX::D3DXEncodeBC4U(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) 
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC4S(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC4S(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
 
@@ -494,7 +494,7 @@ void DirectX::D3DXDecodeBC5S(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC5U(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC5U(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
 
@@ -528,7 +528,7 @@ void DirectX::D3DXEncodeBC5U(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) 
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC5S(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC5S(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
 

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -761,7 +761,7 @@ namespace
     {
     public:
         void Decode(_Out_writes_(NUM_PIXELS_PER_BLOCK) HDRColorA* pOut) const noexcept;
-        void Encode(DWORD flags, _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA* const pIn) noexcept;
+        void Encode(uint32_t flags, _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA* const pIn) noexcept;
 
     private:
         struct ModeInfo
@@ -2726,7 +2726,7 @@ void D3DX_BC7::Decode(HDRColorA* pOut) const noexcept
 }
 
 _Use_decl_annotations_
-void D3DX_BC7::Encode(DWORD flags, const HDRColorA* const pIn) noexcept
+void D3DX_BC7::Encode(uint32_t flags, const HDRColorA* const pIn) noexcept
 {
     assert(pIn);
 
@@ -3528,7 +3528,7 @@ void DirectX::D3DXDecodeBC6HS(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC6HU(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC6HU(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
     assert(pBC && pColor);
@@ -3537,7 +3537,7 @@ void DirectX::D3DXEncodeBC6HU(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags)
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC6HS(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC6HS(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
     assert(pBC && pColor);
@@ -3558,7 +3558,7 @@ void DirectX::D3DXDecodeBC7(XMVECTOR *pColor, const uint8_t *pBC) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::D3DXEncodeBC7(uint8_t *pBC, const XMVECTOR *pColor, DWORD flags) noexcept
+void DirectX::D3DXEncodeBC7(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
 {
     assert(pBC && pColor);
     static_assert(sizeof(D3DX_BC7) == 16, "D3DX_BC7 should be 16 bytes");

--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -173,7 +173,7 @@ HRESULT GPUCompressBC::Initialize(ID3D11Device* pDevice)
 
 
 //-------------------------------------------------------------------------------------
-HRESULT GPUCompressBC::Prepare(size_t width, size_t height, DWORD flags, DXGI_FORMAT format, float alphaWeight)
+HRESULT GPUCompressBC::Prepare(size_t width, size_t height, uint32_t flags, DXGI_FORMAT format, float alphaWeight)
 {
     if (!width || !height || alphaWeight < 0.f)
         return E_INVALIDARG;

--- a/DirectXTex/BCDirectCompute.h
+++ b/DirectXTex/BCDirectCompute.h
@@ -19,7 +19,7 @@ namespace DirectX
 
         HRESULT Initialize(_In_ ID3D11Device* pDevice);
 
-        HRESULT Prepare(size_t width, size_t height, DWORD flags, DXGI_FORMAT format, float alphaWeight);
+        HRESULT Prepare(size_t width, size_t height, uint32_t flags, DXGI_FORMAT format, float alphaWeight);
 
         HRESULT Compress(const Image& srcImage, const Image& destImage);
 

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -512,10 +512,10 @@ namespace DirectX
 
     HRESULT __cdecl Convert(
         _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold,
-        _Out_ ScratchImage& image);
+        _Out_ ScratchImage& image) noexcept;
     HRESULT __cdecl Convert(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold, _Out_ ScratchImage& result);
+        _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold, _Out_ ScratchImage& result) noexcept;
         // Convert the image to a new format
 
     HRESULT __cdecl ConvertToSinglePlane(_In_ const Image& srcImage, _Out_ ScratchImage& image) noexcept;
@@ -604,19 +604,19 @@ namespace DirectX
 
     HRESULT __cdecl Compress(
         _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold,
-        _Out_ ScratchImage& cImage);
+        _Out_ ScratchImage& cImage) noexcept;
     HRESULT __cdecl Compress(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold, _Out_ ScratchImage& cImages);
+        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold, _Out_ ScratchImage& cImages) noexcept;
         // Note that threshold is only used by BC1. TEX_THRESHOLD_DEFAULT is a typical value to use
 
 #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
     HRESULT __cdecl Compress(
         _In_ ID3D11Device* pDevice, _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress,
-        _In_ float alphaWeight, _Out_ ScratchImage& image);
+        _In_ float alphaWeight, _Out_ ScratchImage& image) noexcept;
     HRESULT __cdecl Compress(
         _In_ ID3D11Device* pDevice, _In_ const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float alphaWeight, _Out_ ScratchImage& cImages);
+        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float alphaWeight, _Out_ ScratchImage& cImages) noexcept;
         // DirectCompute-based compression (alphaWeight is only used by BC7. 1.0 is the typical value to use)
 #endif
 
@@ -675,7 +675,7 @@ namespace DirectX
 
     HRESULT __cdecl CopyRectangle(
         _In_ const Image& srcImage, _In_ const Rect& srcRect, _In_ const Image& dstImage,
-        _In_ TEX_FILTER_FLAGS filter, _In_ size_t xOffset, _In_ size_t yOffset);
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t xOffset, _In_ size_t yOffset) noexcept;
 
     enum CMSE_FLAGS : unsigned long
     {

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -55,7 +55,7 @@ namespace DirectX
 
     size_t __cdecl BitsPerColor(_In_ DXGI_FORMAT fmt) noexcept;
 
-    enum CP_FLAGS
+    enum CP_FLAGS : unsigned long
     {
         CP_FLAGS_NONE               = 0x0,      // Normal operation
         CP_FLAGS_LEGACY_DWORD       = 0x1,      // Assume pitch is DWORD aligned instead of BYTE aligned
@@ -71,7 +71,7 @@ namespace DirectX
 
     HRESULT __cdecl ComputePitch(
         _In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height,
-        _Out_ size_t& rowPitch, _Out_ size_t& slicePitch, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
+        _Out_ size_t& rowPitch, _Out_ size_t& slicePitch, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
 
     size_t __cdecl ComputeScanlines(_In_ DXGI_FORMAT fmt, _In_ size_t height) noexcept;
 
@@ -138,7 +138,7 @@ namespace DirectX
             // Helper for dimension
     };
 
-    enum DDS_FLAGS
+    enum DDS_FLAGS : unsigned long
     {
         DDS_FLAGS_NONE                  = 0x0,
 
@@ -174,7 +174,7 @@ namespace DirectX
 
     };
 
-    enum WIC_FLAGS
+    enum WIC_FLAGS : unsigned long
     {
         WIC_FLAGS_NONE                  = 0x0,
 
@@ -220,11 +220,11 @@ namespace DirectX
 
     HRESULT __cdecl GetMetadataFromDDSMemory(
         _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
-        _In_ DWORD flags,
+        _In_ DDS_FLAGS flags,
         _Out_ TexMetadata& metadata) noexcept;
     HRESULT __cdecl GetMetadataFromDDSFile(
         _In_z_ const wchar_t* szFile,
-        _In_ DWORD flags,
+        _In_ DDS_FLAGS flags,
         _Out_ TexMetadata& metadata) noexcept;
 
     HRESULT __cdecl GetMetadataFromHDRMemory(
@@ -243,13 +243,13 @@ namespace DirectX
 
     HRESULT __cdecl GetMetadataFromWICMemory(
         _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
-        _In_ DWORD flags,
+        _In_ WIC_FLAGS flags,
         _Out_ TexMetadata& metadata,
         _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
 
     HRESULT __cdecl GetMetadataFromWICFile(
         _In_z_ const wchar_t* szFile,
-        _In_ DWORD flags,
+        _In_ WIC_FLAGS flags,
         _Out_ TexMetadata& metadata,
         _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
 
@@ -279,17 +279,17 @@ namespace DirectX
         ScratchImage(const ScratchImage&) = delete;
         ScratchImage& operator=(const ScratchImage&) = delete;
 
-        HRESULT __cdecl Initialize(_In_ const TexMetadata& mdata, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize(_In_ const TexMetadata& mdata, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
 
-        HRESULT __cdecl Initialize1D(_In_ DXGI_FORMAT fmt, _In_ size_t length, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
-        HRESULT __cdecl Initialize2D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
-        HRESULT __cdecl Initialize3D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t depth, _In_ size_t mipLevels, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
-        HRESULT __cdecl InitializeCube(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t nCubes, _In_ size_t mipLevels, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize1D(_In_ DXGI_FORMAT fmt, _In_ size_t length, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize2D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize3D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t depth, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeCube(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t nCubes, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
 
-        HRESULT __cdecl InitializeFromImage(_In_ const Image& srcImage, _In_ bool allow1D = false, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
-        HRESULT __cdecl InitializeArrayFromImages(_In_reads_(nImages) const Image* images, _In_ size_t nImages, _In_ bool allow1D = false, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
-        HRESULT __cdecl InitializeCubeFromImages(_In_reads_(nImages) const Image* images, _In_ size_t nImages, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
-        HRESULT __cdecl Initialize3DFromImages(_In_reads_(depth) const Image* images, _In_ size_t depth, _In_ DWORD flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeFromImage(_In_ const Image& srcImage, _In_ bool allow1D = false, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeArrayFromImages(_In_reads_(nImages) const Image* images, _In_ size_t nImages, _In_ bool allow1D = false, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeCubeFromImages(_In_reads_(nImages) const Image* images, _In_ size_t nImages, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize3DFromImages(_In_reads_(depth) const Image* images, _In_ size_t depth, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
 
         void __cdecl Release() noexcept;
 
@@ -348,26 +348,26 @@ namespace DirectX
     // DDS operations
     HRESULT __cdecl LoadFromDDSMemory(
         _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
-        _In_ DWORD flags,
+        _In_ DDS_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
     HRESULT __cdecl LoadFromDDSFile(
         _In_z_ const wchar_t* szFile,
-        _In_ DWORD flags,
+        _In_ DDS_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
 
     HRESULT __cdecl SaveToDDSMemory(
         _In_ const Image& image,
-        _In_ DWORD flags,
+        _In_ DDS_FLAGS flags,
         _Out_ Blob& blob) noexcept;
     HRESULT __cdecl SaveToDDSMemory(
         _In_reads_(nimages) const Image* images, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD flags,
+        _In_ DDS_FLAGS flags,
         _Out_ Blob& blob) noexcept;
 
-    HRESULT __cdecl SaveToDDSFile(_In_ const Image& image, _In_ DWORD flags, _In_z_ const wchar_t* szFile) noexcept;
+    HRESULT __cdecl SaveToDDSFile(_In_ const Image& image, _In_ DDS_FLAGS flags, _In_z_ const wchar_t* szFile) noexcept;
     HRESULT __cdecl SaveToDDSFile(
         _In_reads_(nimages) const Image* images, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD flags, _In_z_ const wchar_t* szFile) noexcept;
+        _In_ DDS_FLAGS flags, _In_z_ const wchar_t* szFile) noexcept;
 
     // HDR operations
     HRESULT __cdecl LoadFromHDRMemory(
@@ -394,38 +394,38 @@ namespace DirectX
     // WIC operations
     HRESULT __cdecl LoadFromWICMemory(
         _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
-        _In_ DWORD flags,
+        _In_ WIC_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image,
         _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
     HRESULT __cdecl LoadFromWICFile(
-        _In_z_ const wchar_t* szFile, _In_ DWORD flags,
+        _In_z_ const wchar_t* szFile, _In_ WIC_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image,
         _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
 
     HRESULT __cdecl SaveToWICMemory(
-        _In_ const Image& image, _In_ DWORD flags, _In_ REFGUID guidContainerFormat,
+        _In_ const Image& image, _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _Out_ Blob& blob, _In_opt_ const GUID* targetFormat = nullptr,
         _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
     HRESULT __cdecl SaveToWICMemory(
         _In_count_(nimages) const Image* images, _In_ size_t nimages,
-        _In_ DWORD flags, _In_ REFGUID guidContainerFormat,
+        _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _Out_ Blob& blob, _In_opt_ const GUID* targetFormat = nullptr,
         _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
 
     HRESULT __cdecl SaveToWICFile(
-        _In_ const Image& image, _In_ DWORD flags, _In_ REFGUID guidContainerFormat,
+        _In_ const Image& image, _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* szFile, _In_opt_ const GUID* targetFormat = nullptr,
         _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
     HRESULT __cdecl SaveToWICFile(
         _In_count_(nimages) const Image* images, _In_ size_t nimages,
-        _In_ DWORD flags, _In_ REFGUID guidContainerFormat,
+        _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* szFile, _In_opt_ const GUID* targetFormat = nullptr,
         _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
 
     //---------------------------------------------------------------------------------
     // Texture conversion, resizing, mipmap generation, and block compression
 
-    enum TEX_FR_FLAGS
+    enum TEX_FR_FLAGS : unsigned long
     {
         TEX_FR_ROTATE0          = 0x0,
         TEX_FR_ROTATE90         = 0x1,
@@ -435,13 +435,13 @@ namespace DirectX
         TEX_FR_FLIP_VERTICAL    = 0x10,
     };
 
-    HRESULT __cdecl FlipRotate(_In_ const Image& srcImage, _In_ DWORD flags, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl FlipRotate(_In_ const Image& srcImage, _In_ TEX_FR_FLAGS flags, _Out_ ScratchImage& image) noexcept;
     HRESULT __cdecl FlipRotate(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD flags, _Out_ ScratchImage& result) noexcept;
+        _In_ TEX_FR_FLAGS flags, _Out_ ScratchImage& result) noexcept;
         // Flip and/or rotate image
 
-    enum TEX_FILTER_FLAGS
+    enum TEX_FILTER_FLAGS : unsigned long
     {
         TEX_FILTER_DEFAULT          = 0,
 
@@ -494,13 +494,16 @@ namespace DirectX
             // Forces use of the WIC path even when logic would have picked a non-WIC path when both are an option
     };
 
+    constexpr unsigned long TEX_FILTER_MODE_MASK = 0xF00000;
+    constexpr unsigned long TEX_FILTER_SRGB_MASK = 0xF000000;
+
     HRESULT __cdecl Resize(
         _In_ const Image& srcImage, _In_ size_t width, _In_ size_t height,
-        _In_ DWORD filter,
+        _In_ TEX_FILTER_FLAGS filter,
         _Out_ ScratchImage& image) noexcept;
     HRESULT __cdecl Resize(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ size_t width, _In_ size_t height, _In_ DWORD filter, _Out_ ScratchImage& result) noexcept;
+        _In_ size_t width, _In_ size_t height, _In_ TEX_FILTER_FLAGS filter, _Out_ ScratchImage& result) noexcept;
         // Resize the image to width x height. Defaults to Fant filtering.
         // Note for a complex resize, the result will always have mipLevels == 1
 
@@ -508,11 +511,11 @@ namespace DirectX
         // Default value for alpha threshold used when converting to 1-bit alpha
 
     HRESULT __cdecl Convert(
-        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ DWORD filter, _In_ float threshold,
+        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold,
         _Out_ ScratchImage& image);
     HRESULT __cdecl Convert(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _In_ DWORD filter, _In_ float threshold, _Out_ ScratchImage& result);
+        _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold, _Out_ ScratchImage& result);
         // Convert the image to a new format
 
     HRESULT __cdecl ConvertToSinglePlane(_In_ const Image& srcImage, _Out_ ScratchImage& image) noexcept;
@@ -522,20 +525,20 @@ namespace DirectX
         // Converts the image from a planar format to an equivalent non-planar format
 
     HRESULT __cdecl GenerateMipMaps(
-        _In_ const Image& baseImage, _In_ DWORD filter, _In_ size_t levels,
+        _In_ const Image& baseImage, _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels,
         _Inout_ ScratchImage& mipChain, _In_ bool allow1D = false) noexcept;
     HRESULT __cdecl GenerateMipMaps(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD filter, _In_ size_t levels, _Inout_ ScratchImage& mipChain);
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels, _Inout_ ScratchImage& mipChain);
         // levels of '0' indicates a full mipchain, otherwise is generates that number of total levels (including the source base image)
         // Defaults to Fant filtering which is equivalent to a box filter
 
     HRESULT __cdecl GenerateMipMaps3D(
-        _In_reads_(depth) const Image* baseImages, _In_ size_t depth, _In_ DWORD filter, _In_ size_t levels,
+        _In_reads_(depth) const Image* baseImages, _In_ size_t depth, _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels,
         _Out_ ScratchImage& mipChain) noexcept;
     HRESULT __cdecl GenerateMipMaps3D(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD filter, _In_ size_t levels, _Out_ ScratchImage& mipChain);
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels, _Out_ ScratchImage& mipChain);
         // levels of '0' indicates a full mipchain, otherwise is generates that number of total levels (including the source base image)
         // Defaults to Fant filtering which is equivalent to a box filter
 
@@ -544,7 +547,7 @@ namespace DirectX
         _In_ float alphaReference, _Inout_ ScratchImage& mipChain) noexcept;
 
 
-    enum TEX_PMALPHA_FLAGS
+    enum TEX_PMALPHA_FLAGS : unsigned long
     {
         TEX_PMALPHA_DEFAULT         = 0,
 
@@ -561,13 +564,13 @@ namespace DirectX
             // if the output format type is IsSRGB(), then SRGB_OUT is on by default
     };
 
-    HRESULT __cdecl PremultiplyAlpha(_In_ const Image& srcImage, _In_ DWORD flags, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl PremultiplyAlpha(_In_ const Image& srcImage, _In_ TEX_PMALPHA_FLAGS flags, _Out_ ScratchImage& image) noexcept;
     HRESULT __cdecl PremultiplyAlpha(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD flags, _Out_ ScratchImage& result) noexcept;
+        _In_ TEX_PMALPHA_FLAGS flags, _Out_ ScratchImage& result) noexcept;
         // Converts to/from a premultiplied alpha version of the texture
 
-    enum TEX_COMPRESS_FLAGS
+    enum TEX_COMPRESS_FLAGS : unsigned long
     {
         TEX_COMPRESS_DEFAULT            = 0,
 
@@ -600,20 +603,20 @@ namespace DirectX
     };
 
     HRESULT __cdecl Compress(
-        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ DWORD compress, _In_ float threshold,
+        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold,
         _Out_ ScratchImage& cImage);
     HRESULT __cdecl Compress(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _In_ DWORD compress, _In_ float threshold, _Out_ ScratchImage& cImages);
+        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold, _Out_ ScratchImage& cImages);
         // Note that threshold is only used by BC1. TEX_THRESHOLD_DEFAULT is a typical value to use
 
 #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
     HRESULT __cdecl Compress(
-        _In_ ID3D11Device* pDevice, _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ DWORD compress,
+        _In_ ID3D11Device* pDevice, _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress,
         _In_ float alphaWeight, _Out_ ScratchImage& image);
     HRESULT __cdecl Compress(
         _In_ ID3D11Device* pDevice, _In_ const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _In_ DWORD compress, _In_ float alphaWeight, _Out_ ScratchImage& cImages);
+        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float alphaWeight, _Out_ ScratchImage& cImages);
         // DirectCompute-based compression (alphaWeight is only used by BC7. 1.0 is the typical value to use)
 #endif
 
@@ -625,7 +628,7 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Normal map operations
 
-    enum CNMAP_FLAGS
+    enum CNMAP_FLAGS : unsigned long
     {
         CNMAP_DEFAULT           = 0,
 
@@ -650,11 +653,11 @@ namespace DirectX
     };
 
     HRESULT __cdecl ComputeNormalMap(
-        _In_ const Image& srcImage, _In_ DWORD flags, _In_ float amplitude,
+        _In_ const Image& srcImage, _In_ CNMAP_FLAGS flags, _In_ float amplitude,
         _In_ DXGI_FORMAT format, _Out_ ScratchImage& normalMap) noexcept;
     HRESULT __cdecl ComputeNormalMap(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DWORD flags, _In_ float amplitude, _In_ DXGI_FORMAT format, _Out_ ScratchImage& normalMaps) noexcept;
+        _In_ CNMAP_FLAGS flags, _In_ float amplitude, _In_ DXGI_FORMAT format, _Out_ ScratchImage& normalMaps) noexcept;
 
     //---------------------------------------------------------------------------------
     // Misc image operations
@@ -672,9 +675,9 @@ namespace DirectX
 
     HRESULT __cdecl CopyRectangle(
         _In_ const Image& srcImage, _In_ const Rect& srcRect, _In_ const Image& dstImage,
-        _In_ DWORD filter, _In_ size_t xOffset, _In_ size_t yOffset);
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t xOffset, _In_ size_t yOffset);
 
-    enum CMSE_FLAGS
+    enum CMSE_FLAGS : unsigned long
     {
         CMSE_DEFAULT                = 0,
 
@@ -693,7 +696,7 @@ namespace DirectX
             // Indicates that image should be scaled and biased before comparison (i.e. UNORM -> SNORM)
     };
 
-    HRESULT __cdecl ComputeMSE(_In_ const Image& image1, _In_ const Image& image2, _Out_ float& mse, _Out_writes_opt_(4) float* mseV, _In_ DWORD flags = 0) noexcept;
+    HRESULT __cdecl ComputeMSE(_In_ const Image& image1, _In_ const Image& image2, _Out_ float& mse, _Out_writes_opt_(4) float* mseV, _In_ CMSE_FLAGS flags = CMSE_DEFAULT) noexcept;
 
     HRESULT __cdecl EvaluateImage(
         _In_ const Image& image,
@@ -718,7 +721,7 @@ namespace DirectX
 
     enum WICCodecs
     {
-        WIC_CODEC_BMP = 1,     // Windows Bitmap (.bmp)
+        WIC_CODEC_BMP = 1,          // Windows Bitmap (.bmp)
         WIC_CODEC_JPEG,             // Joint Photographic Experts Group (.jpg, .jpeg)
         WIC_CODEC_PNG,              // Portable Network Graphics (.png)
         WIC_CODEC_TIFF,             // Tagged Image File Format  (.tif, .tiff)
@@ -787,6 +790,7 @@ namespace DirectX
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #pragma clang diagnostic ignored "-Wswitch-enum"
 #endif
 

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -494,8 +494,9 @@ namespace DirectX
             // Forces use of the WIC path even when logic would have picked a non-WIC path when both are an option
     };
 
-    constexpr unsigned long TEX_FILTER_MODE_MASK = 0xF00000;
-    constexpr unsigned long TEX_FILTER_SRGB_MASK = 0xF000000;
+    constexpr unsigned long TEX_FILTER_DITHER_MASK  = 0xF0000;
+    constexpr unsigned long TEX_FILTER_MODE_MASK    = 0xF00000;
+    constexpr unsigned long TEX_FILTER_SRGB_MASK    = 0xF000000;
 
     HRESULT __cdecl Resize(
         _In_ const Image& srcImage, _In_ size_t width, _In_ size_t height,

--- a/DirectXTex/DirectXTex.inl
+++ b/DirectXTex/DirectXTex.inl
@@ -12,6 +12,32 @@
 #pragma once
 
 //=====================================================================================
+// Bitmask flags enumerator operators
+//=====================================================================================
+DEFINE_ENUM_FLAG_OPERATORS(CP_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(DDS_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(WIC_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_FR_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_FILTER_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_PMALPHA_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_COMPRESS_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(CNMAP_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(CMSE_FLAGS);
+
+// WIC_FILTER modes match TEX_FILTER modes
+inline constexpr WIC_FLAGS operator|(WIC_FLAGS a, TEX_FILTER_FLAGS b) { return static_cast<WIC_FLAGS>(static_cast<unsigned long>(a) | static_cast<unsigned long>(b & TEX_FILTER_MODE_MASK)); }
+inline constexpr WIC_FLAGS operator|(TEX_FILTER_FLAGS a, WIC_FLAGS b) { return static_cast<WIC_FLAGS>(static_cast<unsigned long>(a & TEX_FILTER_MODE_MASK) | static_cast<unsigned long>(b)); }
+
+// TEX_PMALPHA_SRGB match TEX_FILTER_SRGB
+inline constexpr TEX_PMALPHA_FLAGS operator|(TEX_PMALPHA_FLAGS a, TEX_FILTER_FLAGS b) { return static_cast<TEX_PMALPHA_FLAGS>(static_cast<unsigned long>(a) | static_cast<unsigned long>(b & TEX_FILTER_SRGB_MASK)); }
+inline constexpr TEX_PMALPHA_FLAGS operator|(TEX_FILTER_FLAGS a, TEX_PMALPHA_FLAGS b) { return static_cast<TEX_PMALPHA_FLAGS>(static_cast<unsigned long>(a & TEX_FILTER_SRGB_MASK) | static_cast<unsigned long>(b)); }
+
+// TEX_COMPRESS_SRGB match TEX_FILTER_SRGB
+inline constexpr TEX_COMPRESS_FLAGS operator|(TEX_COMPRESS_FLAGS a, TEX_FILTER_FLAGS b) { return static_cast<TEX_COMPRESS_FLAGS>(static_cast<unsigned long>(a) | static_cast<unsigned long>(b & TEX_FILTER_SRGB_MASK)); }
+inline constexpr TEX_COMPRESS_FLAGS operator|(TEX_FILTER_FLAGS a, TEX_COMPRESS_FLAGS b) { return static_cast<TEX_COMPRESS_FLAGS>(static_cast<unsigned long>(a & TEX_FILTER_SRGB_MASK) | static_cast<unsigned long>(b)); }
+
+
+//=====================================================================================
 // DXGI Format Utilities
 //=====================================================================================
 
@@ -94,7 +120,7 @@ inline bool __cdecl IsSRGB(DXGI_FORMAT fmt) noexcept
 // Image I/O
 //=====================================================================================
 _Use_decl_annotations_
-inline HRESULT __cdecl SaveToDDSMemory(const Image& image, DWORD flags, Blob& blob) noexcept
+inline HRESULT __cdecl SaveToDDSMemory(const Image& image, DDS_FLAGS flags, Blob& blob) noexcept
 {
     TexMetadata mdata = {};
     mdata.width = image.width;
@@ -109,7 +135,7 @@ inline HRESULT __cdecl SaveToDDSMemory(const Image& image, DWORD flags, Blob& bl
 }
 
 _Use_decl_annotations_
-inline HRESULT __cdecl SaveToDDSFile(const Image& image, DWORD flags, const wchar_t* szFile) noexcept
+inline HRESULT __cdecl SaveToDDSFile(const Image& image, DDS_FLAGS flags, const wchar_t* szFile) noexcept
 {
     TexMetadata mdata = {};
     mdata.width = image.width;

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -73,7 +73,7 @@ namespace
         const Image& result,
         DWORD bcflags,
         TEX_FILTER_FLAGS srgb,
-        float threshold)
+        float threshold) noexcept
     {
         if (!image.pixels || !result.pixels)
             return E_POINTER;
@@ -202,7 +202,7 @@ namespace
         const Image& result,
         DWORD bcflags,
         TEX_FILTER_FLAGS srgb,
-        float threshold)
+        float threshold) noexcept
     {
         if (!image.pixels || !result.pixels)
             return E_POINTER;
@@ -596,7 +596,7 @@ HRESULT DirectX::Compress(
     DXGI_FORMAT format,
     TEX_COMPRESS_FLAGS compress,
     float threshold,
-    ScratchImage& image)
+    ScratchImage& image) noexcept
 {
     if (IsCompressed(srcImage.format) || !IsCompressed(format))
         return E_INVALIDARG;
@@ -645,7 +645,7 @@ HRESULT DirectX::Compress(
     DXGI_FORMAT format,
     TEX_COMPRESS_FLAGS compress,
     float threshold,
-    ScratchImage& cImages)
+    ScratchImage& cImages) noexcept
 {
     if (!srcImages || !nimages)
         return E_INVALIDARG;

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -22,7 +22,7 @@ using namespace DirectX;
 
 namespace
 {
-    inline DWORD GetBCFlags(_In_ DWORD compress) noexcept
+    inline DWORD GetBCFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
     {
         static_assert(static_cast<int>(TEX_COMPRESS_RGB_DITHER) == static_cast<int>(BC_FLAGS_DITHER_RGB), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
         static_assert(static_cast<int>(TEX_COMPRESS_A_DITHER) == static_cast<int>(BC_FLAGS_DITHER_A), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
@@ -33,33 +33,34 @@ namespace
         return (compress & (BC_FLAGS_DITHER_RGB | BC_FLAGS_DITHER_A | BC_FLAGS_UNIFORM | BC_FLAGS_USE_3SUBSETS | BC_FLAGS_FORCE_BC7_MODE6));
     }
 
-    inline DWORD GetSRGBFlags(_In_ DWORD compress) noexcept
+    inline TEX_FILTER_FLAGS GetSRGBFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
     {
+        static_assert(TEX_FILTER_SRGB_IN == 0x1000000, "TEX_FILTER_SRGB flag values don't match TEX_FILTER_SRGB_MASK");
         static_assert(static_cast<int>(TEX_COMPRESS_SRGB_IN) == static_cast<int>(TEX_FILTER_SRGB_IN), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
         static_assert(static_cast<int>(TEX_COMPRESS_SRGB_OUT) == static_cast<int>(TEX_FILTER_SRGB_OUT), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
         static_assert(static_cast<int>(TEX_COMPRESS_SRGB) == static_cast<int>(TEX_FILTER_SRGB), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
-        return (compress & TEX_COMPRESS_SRGB);
+        return static_cast<TEX_FILTER_FLAGS>(compress & TEX_FILTER_SRGB_MASK);
     }
 
-    inline bool DetermineEncoderSettings(_In_ DXGI_FORMAT format, _Out_ BC_ENCODE& pfEncode, _Out_ size_t& blocksize, _Out_ DWORD& cflags) noexcept
+    inline bool DetermineEncoderSettings(_In_ DXGI_FORMAT format, _Out_ BC_ENCODE& pfEncode, _Out_ size_t& blocksize, _Out_ TEX_FILTER_FLAGS& cflags) noexcept
     {
         switch (format)
         {
         case DXGI_FORMAT_BC1_UNORM:
-        case DXGI_FORMAT_BC1_UNORM_SRGB:    pfEncode = nullptr;         blocksize = 8;   cflags = 0; break;
+        case DXGI_FORMAT_BC1_UNORM_SRGB:    pfEncode = nullptr;         blocksize = 8;   cflags = TEX_FILTER_DEFAULT; break;
         case DXGI_FORMAT_BC2_UNORM:
-        case DXGI_FORMAT_BC2_UNORM_SRGB:    pfEncode = D3DXEncodeBC2;   blocksize = 16;  cflags = 0; break;
+        case DXGI_FORMAT_BC2_UNORM_SRGB:    pfEncode = D3DXEncodeBC2;   blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
         case DXGI_FORMAT_BC3_UNORM:
-        case DXGI_FORMAT_BC3_UNORM_SRGB:    pfEncode = D3DXEncodeBC3;   blocksize = 16;  cflags = 0; break;
+        case DXGI_FORMAT_BC3_UNORM_SRGB:    pfEncode = D3DXEncodeBC3;   blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
         case DXGI_FORMAT_BC4_UNORM:         pfEncode = D3DXEncodeBC4U;  blocksize = 8;   cflags = TEX_FILTER_RGB_COPY_RED; break;
         case DXGI_FORMAT_BC4_SNORM:         pfEncode = D3DXEncodeBC4S;  blocksize = 8;   cflags = TEX_FILTER_RGB_COPY_RED; break;
         case DXGI_FORMAT_BC5_UNORM:         pfEncode = D3DXEncodeBC5U;  blocksize = 16;  cflags = TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN; break;
         case DXGI_FORMAT_BC5_SNORM:         pfEncode = D3DXEncodeBC5S;  blocksize = 16;  cflags = TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN; break;
-        case DXGI_FORMAT_BC6H_UF16:         pfEncode = D3DXEncodeBC6HU; blocksize = 16;  cflags = 0; break;
-        case DXGI_FORMAT_BC6H_SF16:         pfEncode = D3DXEncodeBC6HS; blocksize = 16;  cflags = 0; break;
+        case DXGI_FORMAT_BC6H_UF16:         pfEncode = D3DXEncodeBC6HU; blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        case DXGI_FORMAT_BC6H_SF16:         pfEncode = D3DXEncodeBC6HS; blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
         case DXGI_FORMAT_BC7_UNORM:
-        case DXGI_FORMAT_BC7_UNORM_SRGB:    pfEncode = D3DXEncodeBC7;   blocksize = 16;  cflags = 0; break;
-        default:                            pfEncode = nullptr;         blocksize = 0;   cflags = 0; return false;
+        case DXGI_FORMAT_BC7_UNORM_SRGB:    pfEncode = D3DXEncodeBC7;   blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        default:                            pfEncode = nullptr;         blocksize = 0;   cflags = TEX_FILTER_DEFAULT; return false;
         }
 
         return true;
@@ -71,7 +72,7 @@ namespace
         const Image& image,
         const Image& result,
         DWORD bcflags,
-        DWORD srgb,
+        TEX_FILTER_FLAGS srgb,
         float threshold)
     {
         if (!image.pixels || !result.pixels)
@@ -99,7 +100,7 @@ namespace
         // Determine BC format encoder
         BC_ENCODE pfEncode;
         size_t blocksize;
-        DWORD cflags;
+        TEX_FILTER_FLAGS cflags;
         if (!DetermineEncoderSettings(result.format, pfEncode, blocksize, cflags))
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
@@ -200,7 +201,7 @@ namespace
         const Image& image,
         const Image& result,
         DWORD bcflags,
-        DWORD srgb,
+        TEX_FILTER_FLAGS srgb,
         float threshold)
     {
         if (!image.pixels || !result.pixels)
@@ -228,7 +229,7 @@ namespace
         // Determine BC format encoder
         BC_ENCODE pfEncode;
         size_t blocksize;
-        DWORD cflags;
+        TEX_FILTER_FLAGS cflags;
         if (!DetermineEncoderSettings(result.format, pfEncode, blocksize, cflags))
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
@@ -452,7 +453,7 @@ namespace
             for (size_t count = 0; (count < cImage.rowPitch) && (w < cImage.width); count += sbpp, w += 4)
             {
                 pfDecode(temp, sptr);
-                _ConvertScanline(temp, 16, format, cformat, 0);
+                _ConvertScanline(temp, 16, format, cformat, TEX_FILTER_DEFAULT);
 
                 size_t pw = std::min<size_t>(4, cImage.width - w);
                 assert(pw > 0 && ph > 0);
@@ -593,7 +594,7 @@ _Use_decl_annotations_
 HRESULT DirectX::Compress(
     const Image& srcImage,
     DXGI_FORMAT format,
-    DWORD compress,
+    TEX_COMPRESS_FLAGS compress,
     float threshold,
     ScratchImage& image)
 {
@@ -642,7 +643,7 @@ HRESULT DirectX::Compress(
     size_t nimages,
     const TexMetadata& metadata,
     DXGI_FORMAT format,
-    DWORD compress,
+    TEX_COMPRESS_FLAGS compress,
     float threshold,
     ScratchImage& cImages)
 {

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -22,7 +22,7 @@ using namespace DirectX;
 
 namespace
 {
-    inline DWORD GetBCFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
+    inline uint32_t GetBCFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
     {
         static_assert(static_cast<int>(TEX_COMPRESS_RGB_DITHER) == static_cast<int>(BC_FLAGS_DITHER_RGB), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
         static_assert(static_cast<int>(TEX_COMPRESS_A_DITHER) == static_cast<int>(BC_FLAGS_DITHER_A), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
@@ -71,7 +71,7 @@ namespace
     HRESULT CompressBC(
         const Image& image,
         const Image& result,
-        DWORD bcflags,
+        uint32_t bcflags,
         TEX_FILTER_FLAGS srgb,
         float threshold) noexcept
     {
@@ -200,7 +200,7 @@ namespace
     HRESULT CompressBC_Parallel(
         const Image& image,
         const Image& result,
-        DWORD bcflags,
+        uint32_t bcflags,
         TEX_FILTER_FLAGS srgb,
         float threshold) noexcept
     {

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -34,7 +34,7 @@ namespace
         const Image& srcImage,
         ScratchImage& image,
         bool srgb,
-        TEX_FILTER_FLAGS filter)
+        TEX_FILTER_FLAGS filter) noexcept
     {
         if (!srcImage.pixels)
             return E_POINTER;
@@ -97,7 +97,7 @@ namespace
     HRESULT ConvertToRGBAF32(
         const Image& srcImage,
         ScratchImage& image,
-        TEX_FILTER_FLAGS filter)
+        TEX_FILTER_FLAGS filter) noexcept
     {
         if (!srcImage.pixels)
             return E_POINTER;
@@ -212,7 +212,7 @@ HRESULT DirectX::Compress(
     DXGI_FORMAT format,
     TEX_COMPRESS_FLAGS compress,
     float alphaWeight,
-    ScratchImage& image)
+    ScratchImage& image) noexcept
 {
     if (!pDevice || IsCompressed(srcImage.format) || !IsCompressed(format))
         return E_INVALIDARG;
@@ -262,7 +262,7 @@ HRESULT DirectX::Compress(
     DXGI_FORMAT format,
     TEX_COMPRESS_FLAGS compress,
     float alphaWeight,
-    ScratchImage& cImages)
+    ScratchImage& cImages) noexcept
 {
     if (!pDevice || !srcImages || !nimages)
         return E_INVALIDARG;

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -17,12 +17,13 @@ using namespace DirectX;
 
 namespace
 {
-    inline DWORD GetSRGBFlags(_In_ DWORD compress) noexcept
+    inline TEX_FILTER_FLAGS GetSRGBFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
     {
+        static_assert(TEX_FILTER_SRGB_IN == 0x1000000, "TEX_FILTER_SRGB flag values don't match TEX_FILTER_SRGB_MASK");
         static_assert(static_cast<int>(TEX_COMPRESS_SRGB_IN) == static_cast<int>(TEX_FILTER_SRGB_IN), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
         static_assert(static_cast<int>(TEX_COMPRESS_SRGB_OUT) == static_cast<int>(TEX_FILTER_SRGB_OUT), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
         static_assert(static_cast<int>(TEX_COMPRESS_SRGB) == static_cast<int>(TEX_FILTER_SRGB), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
-        return (compress & TEX_COMPRESS_SRGB);
+        return static_cast<TEX_FILTER_FLAGS>(compress & TEX_FILTER_SRGB_MASK);
     }
 
 
@@ -33,7 +34,7 @@ namespace
         const Image& srcImage,
         ScratchImage& image,
         bool srgb,
-        DWORD filter)
+        TEX_FILTER_FLAGS filter)
     {
         if (!srcImage.pixels)
             return E_POINTER;
@@ -96,7 +97,7 @@ namespace
     HRESULT ConvertToRGBAF32(
         const Image& srcImage,
         ScratchImage& image,
-        DWORD filter)
+        TEX_FILTER_FLAGS filter)
     {
         if (!srcImage.pixels)
             return E_POINTER;
@@ -145,7 +146,7 @@ namespace
         _In_ GPUCompressBC* gpubc,
         const Image& srcImage,
         const Image& destImage,
-        DWORD compress)
+        TEX_COMPRESS_FLAGS compress)
     {
         if (!gpubc)
             return E_POINTER;
@@ -165,7 +166,7 @@ namespace
             ScratchImage image;
             HRESULT hr = E_UNEXPECTED;
 
-            DWORD srgb = GetSRGBFlags(compress);
+            auto srgb = GetSRGBFlags(compress);
 
             switch (format)
             {
@@ -209,7 +210,7 @@ HRESULT DirectX::Compress(
     ID3D11Device* pDevice,
     const Image& srcImage,
     DXGI_FORMAT format,
-    DWORD compress,
+    TEX_COMPRESS_FLAGS compress,
     float alphaWeight,
     ScratchImage& image)
 {
@@ -259,7 +260,7 @@ HRESULT DirectX::Compress(
     size_t nimages,
     const TexMetadata& metadata,
     DXGI_FORMAT format,
-    DWORD compress,
+    TEX_COMPRESS_FLAGS compress,
     float alphaWeight,
     ScratchImage& cImages)
 {

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -3659,7 +3659,7 @@ void DirectX::_ConvertScanline(
                 // RGB format -> RG format
                 switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE)))
                 {
-                case static_cast<int>(TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_BLUE):
+                case static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE):
                 {
                     XMVECTOR* ptr = pBuffer;
                     for (size_t i = 0; i < count; ++i)
@@ -3671,7 +3671,7 @@ void DirectX::_ConvertScanline(
                 }
                 break;
 
-                case static_cast<int>(TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE):
+                case static_cast<int>(TEX_FILTER_RGB_COPY_GREEN) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE):
                 {
                     XMVECTOR* ptr = pBuffer;
                     for (size_t i = 0; i < count; ++i)
@@ -3683,7 +3683,7 @@ void DirectX::_ConvertScanline(
                 }
                 break;
 
-                case static_cast<int>(TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN):
+                case static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_GREEN):
                 default:
                     // Leave data unchanged and the store will handle this...
                     break;

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -3009,7 +3009,7 @@ void DirectX::_ConvertScanline(
     size_t count,
     DXGI_FORMAT outFormat,
     DXGI_FORMAT inFormat,
-    TEX_FILTER_FLAGS flags)
+    TEX_FILTER_FLAGS flags) noexcept
 {
     assert(pBuffer && count > 0 && ((reinterpret_cast<uintptr_t>(pBuffer) & 0xF) == 0));
     assert(IsValid(outFormat) && !IsTypeless(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
@@ -4582,7 +4582,7 @@ namespace
         _In_ TEX_FILTER_FLAGS filter,
         _In_ const Image& destImage,
         _In_ float threshold,
-        size_t z)
+        size_t z) noexcept
     {
         assert(srcImage.width == destImage.width);
         assert(srcImage.height == destImage.height);
@@ -4828,7 +4828,7 @@ HRESULT DirectX::Convert(
     DXGI_FORMAT format,
     TEX_FILTER_FLAGS filter,
     float threshold,
-    ScratchImage& image)
+    ScratchImage& image) noexcept
 {
     if ((srcImage.format == format) || !IsValid(format))
         return E_INVALIDARG;
@@ -4887,7 +4887,7 @@ HRESULT DirectX::Convert(
     DXGI_FORMAT format,
     TEX_FILTER_FLAGS filter,
     float threshold,
-    ScratchImage& result)
+    ScratchImage& result) noexcept
 {
     if (!srcImages || !nimages || (metadata.format == format) || !IsValid(format))
         return E_INVALIDARG;

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -205,7 +205,7 @@ void DirectX::_CopyScanline(
     const void* pSource,
     size_t inSize,
     DXGI_FORMAT format,
-    DWORD tflags) noexcept
+    uint32_t tflags) noexcept
 {
     assert(pDestination && outSize > 0);
     assert(pSource && inSize > 0);
@@ -450,7 +450,7 @@ void DirectX::_SwizzleScanline(
     const void* pSource,
     size_t inSize,
     DXGI_FORMAT format,
-    DWORD tflags) noexcept
+    uint32_t tflags) noexcept
 {
     assert(pDestination && outSize > 0);
     assert(pSource && inSize > 0);
@@ -621,7 +621,7 @@ bool DirectX::_ExpandScanline(
     const void* pSource,
     size_t inSize,
     DXGI_FORMAT inFormat,
-    DWORD tflags) noexcept
+    uint32_t tflags) noexcept
 {
     assert(pDestination && outSize > 0);
     assert(pSource && inSize > 0);
@@ -2880,8 +2880,8 @@ namespace
     struct ConvertData
     {
         DXGI_FORMAT format;
-        size_t datasize;
-        DWORD flags;
+        size_t      datasize;
+        uint32_t    flags;
     };
 
     const ConvertData g_ConvertTable[] =
@@ -2984,7 +2984,7 @@ namespace
 }
 
 _Use_decl_annotations_
-DWORD DirectX::_GetConvertFlags(DXGI_FORMAT format) noexcept
+uint32_t DirectX::_GetConvertFlags(DXGI_FORMAT format) noexcept
 {
 #ifdef _DEBUG
     // Ensure conversion table is in ascending order
@@ -3107,7 +3107,7 @@ void DirectX::_ConvertScanline(
     }
 
     // Handle conversion special cases
-    DWORD diffFlags = in->flags ^ out->flags;
+    uint32_t diffFlags = in->flags ^ out->flags;
     if (diffFlags != 0)
     {
         if (diffFlags & CONVF_DEPTH)
@@ -4505,7 +4505,7 @@ namespace
             filter &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
         }
 
-        DWORD wicsrgb = _CheckWICColorSpace(pfGUID, targetGUID);
+        auto wicsrgb = _CheckWICColorSpace(pfGUID, targetGUID);
 
         if (wicsrgb != (filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)))
         {

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -205,13 +205,13 @@ void DirectX::_CopyScanline(
     const void* pSource,
     size_t inSize,
     DXGI_FORMAT format,
-    DWORD flags) noexcept
+    DWORD tflags) noexcept
 {
     assert(pDestination && outSize > 0);
     assert(pSource && inSize > 0);
     assert(IsValid(format) && !IsPalettized(format));
 
-    if (flags & TEXP_SCANLINE_SETALPHA)
+    if (tflags & TEXP_SCANLINE_SETALPHA)
     {
         switch (static_cast<int>(format))
         {
@@ -450,7 +450,7 @@ void DirectX::_SwizzleScanline(
     const void* pSource,
     size_t inSize,
     DXGI_FORMAT format,
-    DWORD flags) noexcept
+    DWORD tflags) noexcept
 {
     assert(pDestination && outSize > 0);
     assert(pSource && inSize > 0);
@@ -466,7 +466,7 @@ void DirectX::_SwizzleScanline(
     case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
         if (inSize >= 4 && outSize >= 4)
         {
-            if (flags & TEXP_SCANLINE_LEGACY)
+            if (tflags & TEXP_SCANLINE_LEGACY)
             {
                 // Swap Red (R) and Blue (B) channel (used for D3DFMT_A2R10G10B10 legacy sources)
                 if (pDestination == pSource)
@@ -479,7 +479,7 @@ void DirectX::_SwizzleScanline(
                         uint32_t t1 = (t & 0x3ff00000) >> 20;
                         uint32_t t2 = (t & 0x000003ff) << 20;
                         uint32_t t3 = (t & 0x000ffc00);
-                        uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xC0000000 : (t & 0xC0000000);
+                        uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xC0000000 : (t & 0xC0000000);
 
                         *(dPtr++) = t1 | t2 | t3 | ta;
                     }
@@ -496,7 +496,7 @@ void DirectX::_SwizzleScanline(
                         uint32_t t1 = (t & 0x3ff00000) >> 20;
                         uint32_t t2 = (t & 0x000003ff) << 20;
                         uint32_t t3 = (t & 0x000ffc00);
-                        uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xC0000000 : (t & 0xC0000000);
+                        uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xC0000000 : (t & 0xC0000000);
 
                         *(dPtr++) = t1 | t2 | t3 | ta;
                     }
@@ -529,7 +529,7 @@ void DirectX::_SwizzleScanline(
                     uint32_t t1 = (t & 0x00ff0000) >> 16;
                     uint32_t t2 = (t & 0x000000ff) << 16;
                     uint32_t t3 = (t & 0x0000ff00);
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (t & 0xFF000000);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (t & 0xFF000000);
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -546,7 +546,7 @@ void DirectX::_SwizzleScanline(
                     uint32_t t1 = (t & 0x00ff0000) >> 16;
                     uint32_t t2 = (t & 0x000000ff) << 16;
                     uint32_t t3 = (t & 0x0000ff00);
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (t & 0xFF000000);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (t & 0xFF000000);
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -559,7 +559,7 @@ void DirectX::_SwizzleScanline(
     case DXGI_FORMAT_YUY2:
         if (inSize >= 4 && outSize >= 4)
         {
-            if (flags & TEXP_SCANLINE_LEGACY)
+            if (tflags & TEXP_SCANLINE_LEGACY)
             {
                 // Reorder YUV components (used to convert legacy UYVY -> YUY2)
                 if (pDestination == pSource)
@@ -621,7 +621,7 @@ bool DirectX::_ExpandScanline(
     const void* pSource,
     size_t inSize,
     DXGI_FORMAT inFormat,
-    DWORD flags) noexcept
+    DWORD tflags) noexcept
 {
     assert(pDestination && outSize > 0);
     assert(pSource && inSize > 0);
@@ -671,7 +671,7 @@ bool DirectX::_ExpandScanline(
                 uint32_t t1 = uint32_t(((t & 0x7c00) >> 7) | ((t & 0x7000) >> 12));
                 uint32_t t2 = uint32_t(((t & 0x03e0) << 6) | ((t & 0x0380) << 1));
                 uint32_t t3 = uint32_t(((t & 0x001f) << 19) | ((t & 0x001c) << 14));
-                uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0x8000) ? 0xff000000 : 0);
+                uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0x8000) ? 0xff000000 : 0);
 
                 *(dPtr++) = t1 | t2 | t3 | ta;
             }
@@ -696,7 +696,7 @@ bool DirectX::_ExpandScanline(
                 uint32_t t1 = uint32_t(((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8));
                 uint32_t t2 = uint32_t(((t & 0x00f0) << 8) | ((t & 0x00f0) << 4));
                 uint32_t t3 = uint32_t(((t & 0x000f) << 20) | ((t & 0x000f) << 16));
-                uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf000) << 16) | ((t & 0xf000) << 12));
+                uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf000) << 16) | ((t & 0xf000) << 12));
 
                 *(dPtr++) = t1 | t2 | t3 | ta;
             }
@@ -2732,7 +2732,7 @@ bool DirectX::_StoreScanlineLinear(
     DXGI_FORMAT format,
     XMVECTOR* pSource,
     size_t count,
-    DWORD flags,
+    TEX_FILTER_FLAGS flags,
     float threshold) noexcept
 {
     assert(pDestination && size > 0);
@@ -2774,7 +2774,7 @@ bool DirectX::_StoreScanlineLinear(
 
     default:
         // can't treat A8, XR, Depth, SNORM, UINT, or SINT as sRGB
-        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB);
+        flags &= ~TEX_FILTER_SRGB;
         break;
     }
 
@@ -2808,7 +2808,7 @@ bool DirectX::_LoadScanlineLinear(
     const void* pSource,
     size_t size,
     DXGI_FORMAT format,
-    DWORD flags) noexcept
+    TEX_FILTER_FLAGS flags) noexcept
 {
     assert(pDestination && count > 0 && ((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0));
     assert(pSource && size > 0);
@@ -2849,7 +2849,7 @@ bool DirectX::_LoadScanlineLinear(
 
     default:
         // can't treat A8, XR, Depth, SNORM, UINT, or SINT as sRGB
-        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB);
+        flags &= ~TEX_FILTER_SRGB;
         break;
     }
 
@@ -3009,7 +3009,7 @@ void DirectX::_ConvertScanline(
     size_t count,
     DXGI_FORMAT outFormat,
     DXGI_FORMAT inFormat,
-    DWORD flags)
+    TEX_FILTER_FLAGS flags)
 {
     assert(pBuffer && count > 0 && ((reinterpret_cast<uintptr_t>(pBuffer) & 0xF) == 0));
     assert(IsValid(outFormat) && !IsTypeless(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
@@ -3060,7 +3060,7 @@ void DirectX::_ConvertScanline(
 
     case DXGI_FORMAT_A8_UNORM:
     case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
-        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN);
+        flags &= ~TEX_FILTER_SRGB_IN;
         break;
 
     default:
@@ -3081,7 +3081,7 @@ void DirectX::_ConvertScanline(
 
     case DXGI_FORMAT_A8_UNORM:
     case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
-        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_OUT);
+        flags &= ~TEX_FILTER_SRGB_OUT;
         break;
 
     default:
@@ -3090,7 +3090,7 @@ void DirectX::_ConvertScanline(
 
     if ((flags & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
     {
-        flags &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+        flags &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
     }
 
     // sRGB input processing (sRGB -> Linear RGB)
@@ -3657,9 +3657,9 @@ void DirectX::_ConvertScanline(
             else if ((out->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G))
             {
                 // RGB format -> RG format
-                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE))
+                switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE)))
                 {
-                case TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_BLUE:
+                case static_cast<int>(TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_BLUE):
                 {
                     XMVECTOR* ptr = pBuffer;
                     for (size_t i = 0; i < count; ++i)
@@ -3671,7 +3671,7 @@ void DirectX::_ConvertScanline(
                 }
                 break;
 
-                case TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE:
+                case static_cast<int>(TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE):
                 {
                     XMVECTOR* ptr = pBuffer;
                     for (size_t i = 0; i < count; ++i)
@@ -3683,7 +3683,7 @@ void DirectX::_ConvertScanline(
                 }
                 break;
 
-                case TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN:
+                case static_cast<int>(TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN):
                 default:
                     // Leave data unchanged and the store will handle this...
                     break;
@@ -4367,7 +4367,7 @@ namespace
     // Selection logic for using WIC vs. our own routines
     //-------------------------------------------------------------------------------------
     inline bool UseWICConversion(
-        _In_ DWORD filter,
+        _In_ TEX_FILTER_FLAGS filter,
         _In_ DXGI_FORMAT sformat,
         _In_ DXGI_FORMAT tformat,
         _Out_ WICPixelFormatGUID& pfGUID,
@@ -4502,7 +4502,7 @@ namespace
 
         if ((filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
         {
-            filter &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+            filter &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
         }
 
         DWORD wicsrgb = _CheckWICColorSpace(pfGUID, targetGUID);
@@ -4523,7 +4523,7 @@ namespace
         _In_ const Image& srcImage,
         _In_ const WICPixelFormatGUID& pfGUID,
         _In_ const WICPixelFormatGUID& targetGUID,
-        _In_ DWORD filter,
+        _In_ TEX_FILTER_FLAGS filter,
         _In_ float threshold,
         _In_ const Image& destImage)
     {
@@ -4579,7 +4579,7 @@ namespace
     //-------------------------------------------------------------------------------------
     HRESULT ConvertCustom(
         _In_ const Image& srcImage,
-        _In_ DWORD filter,
+        _In_ TEX_FILTER_FLAGS filter,
         _In_ const Image& destImage,
         _In_ float threshold,
         size_t z)
@@ -4826,7 +4826,7 @@ _Use_decl_annotations_
 HRESULT DirectX::Convert(
     const Image& srcImage,
     DXGI_FORMAT format,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     float threshold,
     ScratchImage& image)
 {
@@ -4885,7 +4885,7 @@ HRESULT DirectX::Convert(
     size_t nimages,
     const TexMetadata& metadata,
     DXGI_FORMAT format,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     float threshold,
     ScratchImage& result)
 {

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -24,7 +24,7 @@ namespace
     //-------------------------------------------------------------------------------------
     // Legacy format mapping table (used for DDS files without 'DX10' extended header)
     //-------------------------------------------------------------------------------------
-    enum CONVERSION_FLAGS
+    enum CONVERSION_FLAGS : unsigned long
     {
         CONV_FLAGS_NONE = 0x0,
         CONV_FLAGS_EXPAND = 0x1,      // Conversion requires expanded pixel size
@@ -534,7 +534,7 @@ namespace
 _Use_decl_annotations_
 HRESULT DirectX::_EncodeDDSHeader(
     const TexMetadata& metadata,
-    DWORD flags,
+    DDS_FLAGS flags,
     void* pDestination,
     size_t maxsize,
     size_t& required) noexcept
@@ -900,7 +900,7 @@ namespace
             size_t inSize,
             _In_ TEXP_LEGACY_FORMAT inFormat,
             _In_reads_opt_(256) const uint32_t* pal8,
-            _In_ DWORD flags) noexcept
+            _In_ DWORD tflags) noexcept
     {
         assert(pDestination && outSize > 0);
         assert(pSource && inSize > 0);
@@ -998,7 +998,7 @@ namespace
                     uint32_t t1 = uint32_t((t & 0x00e0) | ((t & 0x00e0) >> 3) | ((t & 0x00c0) >> 6));
                     uint32_t t2 = uint32_t(((t & 0x001c) << 11) | ((t & 0x001c) << 8) | ((t & 0x0018) << 5));
                     uint32_t t3 = uint32_t(((t & 0x0003) << 22) | ((t & 0x0003) << 20) | ((t & 0x0003) << 18) | ((t & 0x0003) << 16));
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -1041,7 +1041,7 @@ namespace
                     uint16_t t = *(sPtr++);
 
                     uint32_t t1 = pal8[t & 0xff];
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
 
                     *(dPtr++) = t1 | ta;
                 }
@@ -1064,7 +1064,7 @@ namespace
                         unsigned t = *(sPtr++);
 
                         unsigned t1 = (t & 0x0fu);
-                        unsigned ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xf000u : ((t & 0xf0u) << 8);
+                        unsigned ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xf000u : ((t & 0xf0u) << 8);
 
                         *(dPtr++) = static_cast<uint16_t>(t1 | (t1 << 4) | (t1 << 8) | ta);
                     }
@@ -1084,7 +1084,7 @@ namespace
                         uint8_t t = *(sPtr++);
 
                         uint32_t t1 = uint32_t(((t & 0x0f) << 4) | (t & 0x0f));
-                        uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf0) << 24) | ((t & 0xf0) << 20));
+                        uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf0) << 24) | ((t & 0xf0) << 20));
 
                         *(dPtr++) = t1 | (t1 << 8) | (t1 << 16) | ta;
                     }
@@ -1113,7 +1113,7 @@ namespace
                     uint32_t t1 = uint32_t((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8);
                     uint32_t t2 = uint32_t((t & 0x00f0) << 8) | ((t & 0x00f0) << 4);
                     uint32_t t3 = uint32_t((t & 0x000f) << 20) | ((t & 0x000f) << 16);
-                    uint32_t ta = uint32_t((flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf000) << 16) | ((t & 0xf000) << 12)));
+                    uint32_t ta = uint32_t((tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf000) << 16) | ((t & 0xf000) << 12)));
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -1184,7 +1184,7 @@ namespace
                     uint32_t t1 = uint32_t(t & 0xff);
                     uint32_t t2 = uint32_t(t1 << 8);
                     uint32_t t3 = uint32_t(t1 << 16);
-                    uint32_t ta = (flags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
 
                     *(dPtr++) = t1 | t2 | t3 | ta;
                 }
@@ -1205,7 +1205,7 @@ namespace
         _In_reads_bytes_(size) const void* pPixels,
         _In_ size_t size,
         _In_ const TexMetadata& metadata,
-        _In_ DWORD cpFlags,
+        _In_ CP_FLAGS cpFlags,
         _In_ DWORD convFlags,
         _In_reads_opt_(256) const uint32_t *pal8,
         _In_ const ScratchImage& image) noexcept
@@ -1535,7 +1535,7 @@ _Use_decl_annotations_
 HRESULT DirectX::GetMetadataFromDDSMemory(
     const void* pSource,
     size_t size,
-    DWORD flags,
+    DDS_FLAGS flags,
     TexMetadata& metadata) noexcept
 {
     if (!pSource || size == 0)
@@ -1548,7 +1548,7 @@ HRESULT DirectX::GetMetadataFromDDSMemory(
 _Use_decl_annotations_
 HRESULT DirectX::GetMetadataFromDDSFile(
     const wchar_t* szFile,
-    DWORD flags,
+    DDS_FLAGS flags,
     TexMetadata& metadata) noexcept
 {
     if (!szFile)
@@ -1606,7 +1606,7 @@ _Use_decl_annotations_
 HRESULT DirectX::LoadFromDDSMemory(
     const void* pSource,
     size_t size,
-    DWORD flags,
+    DDS_FLAGS flags,
     TexMetadata* metadata,
     ScratchImage& image) noexcept
 {
@@ -1641,7 +1641,7 @@ HRESULT DirectX::LoadFromDDSMemory(
     if (FAILED(hr))
         return hr;
 
-    DWORD cflags = CP_FLAGS_NONE;
+    CP_FLAGS cflags = CP_FLAGS_NONE;
     if (flags & DDS_FLAGS_LEGACY_DWORD)
     {
         cflags |= CP_FLAGS_LEGACY_DWORD;
@@ -1678,7 +1678,7 @@ HRESULT DirectX::LoadFromDDSMemory(
 _Use_decl_annotations_
 HRESULT DirectX::LoadFromDDSFile(
     const wchar_t* szFile,
-    DWORD flags,
+    DDS_FLAGS flags,
     TexMetadata* metadata,
     ScratchImage& image) noexcept
 {
@@ -1799,7 +1799,7 @@ HRESULT DirectX::LoadFromDDSFile(
             return E_FAIL;
         }
 
-        DWORD cflags = CP_FLAGS_NONE;
+        CP_FLAGS cflags = CP_FLAGS_NONE;
         if (flags & DDS_FLAGS_LEGACY_DWORD)
         {
             cflags |= CP_FLAGS_LEGACY_DWORD;
@@ -1869,7 +1869,7 @@ HRESULT DirectX::SaveToDDSMemory(
     const Image* images,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD flags,
+    DDS_FLAGS flags,
     Blob& blob) noexcept
 {
     if (!images || (nimages == 0))
@@ -2097,7 +2097,7 @@ HRESULT DirectX::SaveToDDSFile(
     const Image* images,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD flags,
+    DDS_FLAGS flags,
     const wchar_t* szFile) noexcept
 {
     if (!szFile)

--- a/DirectXTex/DirectXTexFlipRotate.cpp
+++ b/DirectXTex/DirectXTexFlipRotate.cpp
@@ -21,7 +21,7 @@ namespace
     //-------------------------------------------------------------------------------------
     HRESULT PerformFlipRotateUsingWIC(
         const Image& srcImage,
-        DWORD flags,
+        TEX_FR_FLAGS flags,
         const WICPixelFormatGUID& pfGUID,
         const Image& destImage) noexcept
     {
@@ -90,7 +90,7 @@ namespace
     //-------------------------------------------------------------------------------------
     HRESULT PerformFlipRotateViaF16(
         const Image& srcImage,
-        DWORD flags,
+        TEX_FR_FLAGS flags,
         const Image& destImage) noexcept
     {
         if (!srcImage.pixels || !destImage.pixels)
@@ -132,7 +132,7 @@ namespace
 
     HRESULT PerformFlipRotateViaF32(
         const Image& srcImage,
-        DWORD flags,
+        TEX_FR_FLAGS flags,
         const Image& destImage) noexcept
     {
         if (!srcImage.pixels || !destImage.pixels)
@@ -184,7 +184,7 @@ namespace
 _Use_decl_annotations_
 HRESULT DirectX::FlipRotate(
     const Image& srcImage,
-    DWORD flags,
+    TEX_FR_FLAGS flags,
     ScratchImage& image) noexcept
 {
     if (!srcImage.pixels)
@@ -283,7 +283,7 @@ HRESULT DirectX::FlipRotate(
     const Image* srcImages,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD flags,
+    TEX_FR_FLAGS flags,
     ScratchImage& result) noexcept
 {
     if (!srcImages || !nimages)

--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -26,7 +26,7 @@ using namespace DirectX;
 _Use_decl_annotations_
 bool DirectX::_DetermineImageArray(
     const TexMetadata& metadata,
-    DWORD cpFlags,
+    CP_FLAGS cpFlags,
     size_t& nImages,
     size_t& pixelSize) noexcept
 {
@@ -131,7 +131,7 @@ bool DirectX::_SetupImageArray(
     uint8_t *pMemory,
     size_t pixelSize,
     const TexMetadata& metadata,
-    DWORD cpFlags,
+    CP_FLAGS cpFlags,
     Image* images,
     size_t nImages) noexcept
 {
@@ -282,7 +282,7 @@ ScratchImage& ScratchImage::operator= (ScratchImage&& moveFrom) noexcept
 // Methods
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-HRESULT ScratchImage::Initialize(const TexMetadata& mdata, DWORD flags) noexcept
+HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexcept
 {
     if (!IsValid(mdata.format))
         return E_INVALIDARG;
@@ -368,7 +368,7 @@ HRESULT ScratchImage::Initialize(const TexMetadata& mdata, DWORD flags) noexcept
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::Initialize1D(DXGI_FORMAT fmt, size_t length, size_t arraySize, size_t mipLevels, DWORD flags) noexcept
+HRESULT ScratchImage::Initialize1D(DXGI_FORMAT fmt, size_t length, size_t arraySize, size_t mipLevels, CP_FLAGS flags) noexcept
 {
     if (!length || !arraySize)
         return E_INVALIDARG;
@@ -384,7 +384,7 @@ HRESULT ScratchImage::Initialize1D(DXGI_FORMAT fmt, size_t length, size_t arrayS
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height, size_t arraySize, size_t mipLevels, DWORD flags) noexcept
+HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height, size_t arraySize, size_t mipLevels, CP_FLAGS flags) noexcept
 {
     if (!IsValid(fmt) || !width || !height || !arraySize)
         return E_INVALIDARG;
@@ -435,7 +435,7 @@ HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height,
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height, size_t depth, size_t mipLevels, DWORD flags) noexcept
+HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height, size_t depth, size_t mipLevels, CP_FLAGS flags) noexcept
 {
     if (!IsValid(fmt) || !width || !height || !depth)
         return E_INVALIDARG;
@@ -489,7 +489,7 @@ HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height,
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::InitializeCube(DXGI_FORMAT fmt, size_t width, size_t height, size_t nCubes, size_t mipLevels, DWORD flags) noexcept
+HRESULT ScratchImage::InitializeCube(DXGI_FORMAT fmt, size_t width, size_t height, size_t nCubes, size_t mipLevels, CP_FLAGS flags) noexcept
 {
     if (!width || !height || !nCubes)
         return E_INVALIDARG;
@@ -505,7 +505,7 @@ HRESULT ScratchImage::InitializeCube(DXGI_FORMAT fmt, size_t width, size_t heigh
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::InitializeFromImage(const Image& srcImage, bool allow1D, DWORD flags) noexcept
+HRESULT ScratchImage::InitializeFromImage(const Image& srcImage, bool allow1D, CP_FLAGS flags) noexcept
 {
     HRESULT hr = (srcImage.height > 1 || !allow1D)
         ? Initialize2D(srcImage.format, srcImage.width, srcImage.height, 1, 1, flags)
@@ -542,7 +542,7 @@ HRESULT ScratchImage::InitializeFromImage(const Image& srcImage, bool allow1D, D
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::InitializeArrayFromImages(const Image* images, size_t nImages, bool allow1D, DWORD flags) noexcept
+HRESULT ScratchImage::InitializeArrayFromImages(const Image* images, size_t nImages, bool allow1D, CP_FLAGS flags) noexcept
 {
     if (!images || !nImages)
         return E_INVALIDARG;
@@ -602,7 +602,7 @@ HRESULT ScratchImage::InitializeArrayFromImages(const Image* images, size_t nIma
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::InitializeCubeFromImages(const Image* images, size_t nImages, DWORD flags) noexcept
+HRESULT ScratchImage::InitializeCubeFromImages(const Image* images, size_t nImages, CP_FLAGS flags) noexcept
 {
     if (!images || !nImages)
         return E_INVALIDARG;
@@ -621,7 +621,7 @@ HRESULT ScratchImage::InitializeCubeFromImages(const Image* images, size_t nImag
 }
 
 _Use_decl_annotations_
-HRESULT ScratchImage::Initialize3DFromImages(const Image* images, size_t depth, DWORD flags) noexcept
+HRESULT ScratchImage::Initialize3DFromImages(const Image* images, size_t depth, CP_FLAGS flags) noexcept
 {
     if (!images || !depth)
         return E_INVALIDARG;

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -68,7 +68,7 @@ namespace
     HRESULT EnsureWicBitmapPixelFormat(
         _In_ IWICImagingFactory* pWIC,
         _In_ IWICBitmap* src,
-        _In_ DWORD filter,
+        _In_ TEX_FILTER_FLAGS filter,
         _In_ const WICPixelFormatGUID& desiredPixelFormat,
         _Deref_out_ IWICBitmap** dest) noexcept
     {
@@ -226,7 +226,6 @@ namespace
             return E_OUTOFMEMORY;
         }
 
-        const DWORD flags = 0;
         const XMVECTOR scale = XMVectorReplicate(alphaScale);
 
         const uint8_t *pSrcRow0 = srcImage.pixels;
@@ -242,13 +241,13 @@ namespace
         size_t coverageCount = 0;
         for (size_t y = 0; y < srcImage.height - 1; ++y)
         {
-            if (!_LoadScanlineLinear(row0.get(), srcImage.width, pSrcRow0, srcImage.rowPitch, srcImage.format, flags))
+            if (!_LoadScanlineLinear(row0.get(), srcImage.width, pSrcRow0, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
             {
                 return E_FAIL;
             }
 
             const uint8_t *pSrcRow1 = pSrcRow0 + srcImage.rowPitch;
-            if (!_LoadScanlineLinear(row1.get(), srcImage.width, pSrcRow1, srcImage.rowPitch, srcImage.format, flags))
+            if (!_LoadScanlineLinear(row1.get(), srcImage.width, pSrcRow1, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
             {
                 return E_FAIL;
             }
@@ -351,7 +350,7 @@ namespace DirectX
         // Also used by Compress
 
     HRESULT _ResizeSeparateColorAndAlpha(_In_ IWICImagingFactory* pWIC, _In_ bool iswic2, _In_ IWICBitmap* original,
-        _In_ size_t newWidth, _In_ size_t newHeight, _In_ DWORD filter, _Inout_ const Image* img) noexcept;
+        _In_ size_t newWidth, _In_ size_t newHeight, _In_ TEX_FILTER_FLAGS filter, _Inout_ const Image* img) noexcept;
         // Also used by Resize
 
     bool _CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept
@@ -400,7 +399,7 @@ namespace DirectX
         IWICBitmap* original,
         size_t newWidth,
         size_t newHeight,
-        DWORD filter,
+        TEX_FILTER_FLAGS filter,
         const Image* img) noexcept
     {
         if (!pWIC || !original || !img)
@@ -613,7 +612,7 @@ namespace DirectX
 namespace
 {
     //--- determine when to use WIC vs. non-WIC paths ---
-    bool UseWICFiltering(_In_ DXGI_FORMAT format, _In_ DWORD filter) noexcept
+    bool UseWICFiltering(_In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter) noexcept
     {
         if (filter & TEX_FILTER_FORCE_NON_WIC)
         {
@@ -642,9 +641,9 @@ namespace
         }
 #endif
 
-        static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+        static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
 
-        switch (filter & TEX_FILTER_MASK)
+        switch (filter & TEX_FILTER_MODE_MASK)
         {
         case TEX_FILTER_LINEAR:
             if (filter & TEX_FILTER_WRAP)
@@ -686,7 +685,7 @@ namespace
     //--- mipmap (1D/2D) generation using WIC image scalar ---
     HRESULT GenerateMipMapsUsingWIC(
         _In_ const Image& baseImage,
-        _In_ DWORD filter,
+        _In_ TEX_FILTER_FLAGS filter,
         _In_ size_t levels,
         _In_ const WICPixelFormatGUID& pfGUID,
         _In_ const ScratchImage& mipChain,
@@ -968,7 +967,7 @@ namespace
 
 
     //--- 2D Box Filter ---
-    HRESULT Generate2DMipsBoxFilter(size_t levels, DWORD filter, const ScratchImage& mipChain, size_t item) noexcept
+    HRESULT Generate2DMipsBoxFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
         if (!mipChain.GetImages())
             return E_INVALIDARG;
@@ -1062,7 +1061,7 @@ namespace
 
 
     //--- 2D Linear Filter ---
-    HRESULT Generate2DMipsLinearFilter(size_t levels, DWORD filter, const ScratchImage& mipChain, size_t item) noexcept
+    HRESULT Generate2DMipsLinearFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
         if (!mipChain.GetImages())
             return E_INVALIDARG;
@@ -1173,7 +1172,7 @@ namespace
     }
 
     //--- 2D Cubic Filter ---
-    HRESULT Generate2DMipsCubicFilter(size_t levels, DWORD filter, const ScratchImage& mipChain, size_t item) noexcept
+    HRESULT Generate2DMipsCubicFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
         if (!mipChain.GetImages())
             return E_INVALIDARG;
@@ -1359,7 +1358,7 @@ namespace
 
 
     //--- 2D Triangle Filter ---
-    HRESULT Generate2DMipsTriangleFilter(size_t levels, DWORD filter, const ScratchImage& mipChain, size_t item) noexcept
+    HRESULT Generate2DMipsTriangleFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
         if (!mipChain.GetImages())
             return E_INVALIDARG;
@@ -1775,7 +1774,7 @@ namespace
 
 
     //--- 3D Box Filter ---
-    HRESULT Generate3DMipsBoxFilter(size_t depth, size_t levels, DWORD filter, const ScratchImage& mipChain) noexcept
+    HRESULT Generate3DMipsBoxFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
@@ -1947,7 +1946,7 @@ namespace
 
 
     //--- 3D Linear Filter ---
-    HRESULT Generate3DMipsLinearFilter(size_t depth, size_t levels, DWORD filter, const ScratchImage& mipChain) noexcept
+    HRESULT Generate3DMipsLinearFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
@@ -2140,7 +2139,7 @@ namespace
 
 
     //--- 3D Cubic Filter ---
-    HRESULT Generate3DMipsCubicFilter(size_t depth, size_t levels, DWORD filter, const ScratchImage& mipChain) noexcept
+    HRESULT Generate3DMipsCubicFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
@@ -2519,7 +2518,7 @@ namespace
 
 
     //--- 3D Triangle Filter ---
-    HRESULT Generate3DMipsTriangleFilter(size_t depth, size_t levels, DWORD filter, const ScratchImage& mipChain) noexcept
+    HRESULT Generate3DMipsTriangleFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
@@ -2772,7 +2771,7 @@ namespace
 _Use_decl_annotations_
 HRESULT DirectX::GenerateMipMaps(
     const Image& baseImage,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     size_t levels,
     ScratchImage& mipChain,
     bool allow1D) noexcept
@@ -2796,7 +2795,7 @@ HRESULT DirectX::GenerateMipMaps(
 
     HRESULT hr = E_UNEXPECTED;
 
-    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
 
     bool usewic = UseWICFiltering(baseImage.format, filter);
 
@@ -2820,7 +2819,7 @@ HRESULT DirectX::GenerateMipMaps(
     if (usewic)
     {
         //--- Use WIC filtering to generate mipmaps -----------------------------------
-        switch (filter & TEX_FILTER_MASK)
+        switch (filter & TEX_FILTER_MODE_MASK)
         {
         case 0:
         case TEX_FILTER_POINT:
@@ -2894,7 +2893,7 @@ HRESULT DirectX::GenerateMipMaps(
         mdata.mipLevels = levels;
         mdata.format = baseImage.format;
 
-        DWORD filter_select = (filter & TEX_FILTER_MASK);
+        DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
         if (!filter_select)
         {
             // Default filter choice
@@ -2964,7 +2963,7 @@ HRESULT DirectX::GenerateMipMaps(
     const Image* srcImages,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     size_t levels,
     ScratchImage& mipChain)
 {
@@ -3009,7 +3008,7 @@ HRESULT DirectX::GenerateMipMaps(
     if (baseImages.empty())
         return hr;
 
-    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
 
     bool usewic = !metadata.IsPMAlpha() && UseWICFiltering(metadata.format, filter);
 
@@ -3033,7 +3032,7 @@ HRESULT DirectX::GenerateMipMaps(
     if (usewic)
     {
         //--- Use WIC filtering to generate mipmaps -----------------------------------
-        switch (filter & TEX_FILTER_MASK)
+        switch (filter & TEX_FILTER_MODE_MASK)
         {
         case 0:
         case TEX_FILTER_POINT:
@@ -3107,7 +3106,7 @@ HRESULT DirectX::GenerateMipMaps(
         TexMetadata mdata2 = metadata;
         mdata2.mipLevels = levels;
 
-        DWORD filter_select = (filter & TEX_FILTER_MASK);
+        DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
         if (!filter_select)
         {
             // Default filter choice
@@ -3195,7 +3194,7 @@ _Use_decl_annotations_
 HRESULT DirectX::GenerateMipMaps3D(
     const Image* baseImages,
     size_t depth,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     size_t levels,
     ScratchImage& mipChain) noexcept
 {
@@ -3230,11 +3229,11 @@ HRESULT DirectX::GenerateMipMaps3D(
     if (IsCompressed(format) || IsTypeless(format) || IsPlanar(format) || IsPalettized(format))
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
-    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
 
     HRESULT hr = E_UNEXPECTED;
 
-    DWORD filter_select = (filter & TEX_FILTER_MASK);
+    DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
     if (!filter_select)
     {
         // Default filter choice
@@ -3303,7 +3302,7 @@ HRESULT DirectX::GenerateMipMaps3D(
     const Image* srcImages,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     size_t levels,
     ScratchImage& mipChain)
 {
@@ -3348,9 +3347,9 @@ HRESULT DirectX::GenerateMipMaps3D(
 
     HRESULT hr = E_UNEXPECTED;
 
-    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
 
-    DWORD filter_select = (filter & TEX_FILTER_MASK);
+    DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
     if (!filter_select)
     {
         // Default filter choice

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -2893,7 +2893,7 @@ HRESULT DirectX::GenerateMipMaps(
         mdata.mipLevels = levels;
         mdata.format = baseImage.format;
 
-        DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
+        unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
         if (!filter_select)
         {
             // Default filter choice
@@ -3106,7 +3106,7 @@ HRESULT DirectX::GenerateMipMaps(
         TexMetadata mdata2 = metadata;
         mdata2.mipLevels = levels;
 
-        DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
+        unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
         if (!filter_select)
         {
             // Default filter choice
@@ -3233,7 +3233,7 @@ HRESULT DirectX::GenerateMipMaps3D(
 
     HRESULT hr = E_UNEXPECTED;
 
-    DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
+    unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
     if (!filter_select)
     {
         // Default filter choice
@@ -3349,7 +3349,7 @@ HRESULT DirectX::GenerateMipMaps3D(
 
     static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
 
-    DWORD filter_select = (filter & TEX_FILTER_MODE_MASK);
+    unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
     if (!filter_select)
     {
         // Default filter choice

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -272,7 +272,7 @@ HRESULT DirectX::CopyRectangle(
     const Image& dstImage,
     TEX_FILTER_FLAGS filter,
     size_t xOffset,
-    size_t yOffset)
+    size_t yOffset) noexcept
 {
     if (!srcImage.pixels || !dstImage.pixels)
         return E_POINTER;

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -23,7 +23,7 @@ namespace
         const Image& image2,
         float& mse,
         _Out_writes_opt_(4) float* mseV,
-        DWORD flags) noexcept
+        CMSE_FLAGS flags) noexcept
     {
         if (!image1.pixels || !image2.pixels)
             return E_POINTER;
@@ -270,7 +270,7 @@ HRESULT DirectX::CopyRectangle(
     const Image& srcImage,
     const Rect& srcRect,
     const Image& dstImage,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     size_t xOffset,
     size_t yOffset)
 {
@@ -384,7 +384,7 @@ HRESULT DirectX::ComputeMSE(
     const Image& image2,
     float& mse,
     float* mseV,
-    DWORD flags) noexcept
+    CMSE_FLAGS flags) noexcept
 {
     if (!image1.pixels || !image2.pixels)
         return E_POINTER;

--- a/DirectXTex/DirectXTexNormalMaps.cpp
+++ b/DirectXTex/DirectXTexNormalMaps.cpp
@@ -79,7 +79,7 @@ namespace
         if (!srcImage.pixels || !normalMap.pixels)
             return E_INVALIDARG;
 
-        const DWORD convFlags = _GetConvertFlags(format);
+        const uint32_t convFlags = _GetConvertFlags(format);
         if (!convFlags)
             return E_FAIL;
 

--- a/DirectXTex/DirectXTexNormalMaps.cpp
+++ b/DirectXTex/DirectXTexNormalMaps.cpp
@@ -17,7 +17,7 @@ namespace
 {
 
 #pragma prefast(suppress : 25000, "FXMVECTOR is 16 bytes")
-    inline float EvaluateColor(_In_ FXMVECTOR val, _In_ DWORD flags) noexcept
+    inline float EvaluateColor(_In_ FXMVECTOR val, _In_ CNMAP_FLAGS flags) noexcept
     {
         XMFLOAT4A f;
 
@@ -49,7 +49,7 @@ namespace
         _In_reads_(width) const XMVECTOR* pSource,
         _Out_writes_(width + 2) float* pDest,
         size_t width,
-        DWORD flags) noexcept
+        CNMAP_FLAGS flags) noexcept
     {
         assert(pSource && pDest);
         assert(width > 0);
@@ -73,7 +73,7 @@ namespace
         }
     }
 
-    HRESULT ComputeNMap(_In_ const Image& srcImage, _In_ DWORD flags, _In_ float amplitude,
+    HRESULT ComputeNMap(_In_ const Image& srcImage, _In_ CNMAP_FLAGS flags, _In_ float amplitude,
         _In_ DXGI_FORMAT format, _In_ const Image& normalMap) noexcept
     {
         if (!srcImage.pixels || !normalMap.pixels)
@@ -255,7 +255,7 @@ namespace
 _Use_decl_annotations_
 HRESULT DirectX::ComputeNormalMap(
     const Image& srcImage,
-    DWORD flags,
+    CNMAP_FLAGS flags,
     float amplitude,
     DXGI_FORMAT format,
     ScratchImage& normalMap) noexcept
@@ -313,7 +313,7 @@ HRESULT DirectX::ComputeNormalMap(
     const Image* srcImages,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD flags,
+    CNMAP_FLAGS flags,
     float amplitude,
     DXGI_FORMAT format,
     ScratchImage& normalMaps) noexcept

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -318,7 +318,7 @@ namespace DirectX
 
     void __cdecl _ConvertScanline(
         _Inout_updates_all_(count) XMVECTOR* pBuffer, _In_ size_t count,
-        _In_ DXGI_FORMAT outFormat, _In_ DXGI_FORMAT inFormat, _In_ TEX_FILTER_FLAGS flags);
+        _In_ DXGI_FORMAT outFormat, _In_ DXGI_FORMAT inFormat, _In_ TEX_FILTER_FLAGS flags) noexcept;
 
     //---------------------------------------------------------------------------------
     // DDS helper functions

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -150,14 +150,14 @@ namespace DirectX
 
     TEX_FILTER_FLAGS __cdecl _CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept;
 
-    inline WICBitmapDitherType __cdecl _GetWICDither(_In_ DWORD flags) noexcept
+    inline WICBitmapDitherType __cdecl _GetWICDither(_In_ TEX_FILTER_FLAGS flags) noexcept
     {
         static_assert(TEX_FILTER_DITHER == 0x10000, "TEX_FILTER_DITHER* flag values don't match mask");
 
         static_assert(static_cast<int>(TEX_FILTER_DITHER) == static_cast<int>(WIC_FLAGS_DITHER), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
         static_assert(static_cast<int>(TEX_FILTER_DITHER_DIFFUSION) == static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
 
-        switch (flags & 0xF0000)
+        switch (flags & TEX_FILTER_DITHER_MASK)
         {
             case TEX_FILTER_DITHER:
                 return WICBitmapDitherTypeOrdered4x4;
@@ -167,6 +167,21 @@ namespace DirectX
 
             default:
                 return WICBitmapDitherTypeNone;
+        }
+    }
+
+    inline WICBitmapDitherType __cdecl _GetWICDither(_In_ WIC_FLAGS flags) noexcept
+    {
+        switch (flags & TEX_FILTER_DITHER_MASK)
+        {
+        case WIC_FLAGS_DITHER:
+            return WICBitmapDitherTypeOrdered4x4;
+
+        case WIC_FLAGS_DITHER_DIFFUSION:
+            return WICBitmapDitherTypeErrorDiffusion;
+
+        default:
+            return WICBitmapDitherTypeNone;
         }
     }
 
@@ -230,14 +245,14 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Conversion helper functions
 
-    enum TEXP_SCANLINE_FLAGS
+    enum TEXP_SCANLINE_FLAGS : uint32_t
     {
         TEXP_SCANLINE_NONE          = 0,
         TEXP_SCANLINE_SETALPHA      = 0x1,  // Set alpha channel to known opaque value
         TEXP_SCANLINE_LEGACY        = 0x2,  // Enables specific legacy format conversion cases
     };
 
-    enum CONVERT_FLAGS
+    enum CONVERT_FLAGS : uint32_t
     {
         CONVF_FLOAT     = 0x1,
         CONVF_UNORM     = 0x2,
@@ -261,27 +276,27 @@ namespace DirectX
         CONVF_RGBA_MASK = 0xF0000,
     };
 
-    DWORD __cdecl _GetConvertFlags(_In_ DXGI_FORMAT format) noexcept;
+    uint32_t __cdecl _GetConvertFlags(_In_ DXGI_FORMAT format) noexcept;
 
     void __cdecl _CopyScanline(
         _When_(pDestination == pSource, _Inout_updates_bytes_(outSize))
         _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
         void* pDestination, _In_ size_t outSize,
         _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
-        _In_ DXGI_FORMAT format, _In_ DWORD tflags) noexcept;
+        _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
 
     void __cdecl _SwizzleScanline(
         _When_(pDestination == pSource, _In_)
         _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
         void* pDestination, _In_ size_t outSize,
         _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
-        _In_ DXGI_FORMAT format, _In_ DWORD tflags) noexcept;
+        _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
  
     _Success_(return != false) bool __cdecl _ExpandScanline(
         _Out_writes_bytes_(outSize) void* pDestination, _In_ size_t outSize,
         _In_ DXGI_FORMAT outFormat,
         _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
-        _In_ DXGI_FORMAT inFormat, _In_ DWORD tflags) noexcept;
+        _In_ DXGI_FORMAT inFormat, _In_ uint32_t tflags) noexcept;
 
     _Success_(return != false) bool __cdecl _LoadScanline(
         _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,

--- a/DirectXTex/DirectXTexPMAlpha.cpp
+++ b/DirectXTex/DirectXTexPMAlpha.cpp
@@ -15,6 +15,15 @@ using namespace DirectX;
 
 namespace
 {
+    inline TEX_FILTER_FLAGS GetSRGBFlags(_In_ TEX_PMALPHA_FLAGS compress) noexcept
+    {
+        static_assert(TEX_FILTER_SRGB_IN == 0x1000000, "TEX_FILTER_SRGB flag values don't match TEX_FILTER_SRGB_MASK");
+        static_assert(static_cast<int>(TEX_PMALPHA_SRGB_IN) == static_cast<int>(TEX_FILTER_SRGB_IN), "TEX_PMALPHA_SRGB* should match TEX_FILTER_SRGB*");
+        static_assert(static_cast<int>(TEX_PMALPHA_SRGB_OUT) == static_cast<int>(TEX_FILTER_SRGB_OUT), "TEX_PMALPHA_SRGB* should match TEX_FILTER_SRGB*");
+        static_assert(static_cast<int>(TEX_PMALPHA_SRGB) == static_cast<int>(TEX_FILTER_SRGB), "TEX_PMALPHA_SRGB* should match TEX_FILTER_SRGB*");
+        return static_cast<TEX_FILTER_FLAGS>(compress & TEX_FILTER_SRGB_MASK);
+    }
+
     //---------------------------------------------------------------------------------
     // NonPremultiplied alpha -> Premultiplied alpha
     HRESULT PremultiplyAlpha_(const Image& srcImage, const Image& destImage) noexcept
@@ -55,7 +64,7 @@ namespace
         return S_OK;
     }
 
-    HRESULT PremultiplyAlphaLinear(const Image& srcImage, DWORD flags, const Image& destImage) noexcept
+    HRESULT PremultiplyAlphaLinear(const Image& srcImage, TEX_PMALPHA_FLAGS flags, const Image& destImage) noexcept
     {
         assert(srcImage.width == destImage.width);
         assert(srcImage.height == destImage.height);
@@ -74,9 +83,11 @@ namespace
         if (!pSrc || !pDest)
             return E_POINTER;
 
+        TEX_FILTER_FLAGS filter = GetSRGBFlags(flags);
+
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, flags))
+            if (!_LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, filter))
                 return E_FAIL;
 
             XMVECTOR* ptr = scanline.get();
@@ -88,7 +99,7 @@ namespace
                 *(ptr++) = XMVectorSelect(v, alpha, g_XMSelect1110);
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, flags))
+            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, filter))
                 return E_FAIL;
 
             pSrc += srcImage.rowPitch;
@@ -141,7 +152,7 @@ namespace
         return S_OK;
     }
 
-    HRESULT DemultiplyAlphaLinear(const Image& srcImage, DWORD flags, const Image& destImage) noexcept
+    HRESULT DemultiplyAlphaLinear(const Image& srcImage, TEX_PMALPHA_FLAGS flags, const Image& destImage) noexcept
     {
         assert(srcImage.width == destImage.width);
         assert(srcImage.height == destImage.height);
@@ -160,9 +171,11 @@ namespace
         if (!pSrc || !pDest)
             return E_POINTER;
 
+        TEX_FILTER_FLAGS filter = GetSRGBFlags(flags);
+
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, flags))
+            if (!_LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, filter))
                 return E_FAIL;
 
             XMVECTOR* ptr = scanline.get();
@@ -177,7 +190,7 @@ namespace
                 *(ptr++) = XMVectorSelect(v, alpha, g_XMSelect1110);
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, flags))
+            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, filter))
                 return E_FAIL;
 
             pSrc += srcImage.rowPitch;
@@ -199,7 +212,7 @@ namespace
 _Use_decl_annotations_
 HRESULT DirectX::PremultiplyAlpha(
     const Image& srcImage,
-    DWORD flags,
+    TEX_PMALPHA_FLAGS flags,
     ScratchImage& image) noexcept
 {
     if (!srcImage.pixels)
@@ -252,7 +265,7 @@ HRESULT DirectX::PremultiplyAlpha(
     const Image* srcImages,
     size_t nimages,
     const TexMetadata& metadata,
-    DWORD flags,
+    TEX_PMALPHA_FLAGS flags,
     ScratchImage& result) noexcept
 {
     if (!srcImages || !nimages)

--- a/DirectXTex/DirectXTexResize.cpp
+++ b/DirectXTex/DirectXTexResize.cpp
@@ -19,7 +19,7 @@ using Microsoft::WRL::ComPtr;
 namespace DirectX
 {
     extern HRESULT _ResizeSeparateColorAndAlpha(_In_ IWICImagingFactory* pWIC, _In_ bool iswic2, _In_ IWICBitmap* original,
-        _In_ size_t newWidth, _In_ size_t newHeight, _In_ DWORD filter, _Inout_ const Image* img) noexcept;
+        _In_ size_t newWidth, _In_ size_t newHeight, _In_ TEX_FILTER_FLAGS filter, _Inout_ const Image* img) noexcept;
 }
 
 namespace
@@ -27,7 +27,7 @@ namespace
     //--- Do image resize using WIC ---
     HRESULT PerformResizeUsingWIC(
         const Image& srcImage,
-        DWORD filter,
+        TEX_FILTER_FLAGS filter,
         const WICPixelFormatGUID& pfGUID,
         const Image& destImage) noexcept
     {
@@ -128,7 +128,7 @@ namespace
     //--- Do conversion, resize using WIC, conversion cycle ---
     HRESULT PerformResizeViaF32(
         const Image& srcImage,
-        DWORD filter,
+        TEX_FILTER_FLAGS filter,
         const Image& destImage) noexcept
     {
         if (!srcImage.pixels || !destImage.pixels)
@@ -170,7 +170,7 @@ namespace
 
 
     //--- determine when to use WIC vs. non-WIC paths ---
-    bool UseWICFiltering(_In_ DXGI_FORMAT format, _In_ DWORD filter) noexcept
+    bool UseWICFiltering(_In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter) noexcept
     {
         if (filter & TEX_FILTER_FORCE_NON_WIC)
         {
@@ -201,7 +201,7 @@ namespace
 
         static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
 
-        switch (filter & TEX_FILTER_MASK)
+        switch (filter & TEX_FILTER_MODE_MASK)
         {
         case TEX_FILTER_LINEAR:
             if (filter & TEX_FILTER_WRAP)
@@ -303,7 +303,7 @@ namespace
 
 
     //--- Box Filter ---
-    HRESULT ResizeBoxFilter(const Image& srcImage, DWORD filter, const Image& destImage) noexcept
+    HRESULT ResizeBoxFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
@@ -365,7 +365,7 @@ namespace
 
 
     //--- Linear Filter ---
-    HRESULT ResizeLinearFilter(const Image& srcImage, DWORD filter, const Image& destImage) noexcept
+    HRESULT ResizeLinearFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
@@ -451,7 +451,7 @@ namespace
 
 
     //--- Cubic Filter ---
-    HRESULT ResizeCubicFilter(const Image& srcImage, DWORD filter, const Image& destImage) noexcept
+    HRESULT ResizeCubicFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
@@ -611,7 +611,7 @@ namespace
 
 
     //--- Triangle Filter ---
-    HRESULT ResizeTriangleFilter(const Image& srcImage, DWORD filter, const Image& destImage) noexcept
+    HRESULT ResizeTriangleFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
@@ -790,14 +790,14 @@ namespace
 
 
     //--- Custom filter resize ---
-    HRESULT PerformResizeUsingCustomFilters(const Image& srcImage, DWORD filter, const Image& destImage) noexcept
+    HRESULT PerformResizeUsingCustomFilters(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
         if (!srcImage.pixels || !destImage.pixels)
             return E_POINTER;
 
         static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
 
-        DWORD filter_select = (filter & TEX_FILTER_MASK);
+        unsigned long filter_select = filter & TEX_FILTER_MODE_MASK;
         if (!filter_select)
         {
             // Default filter choice
@@ -841,7 +841,7 @@ HRESULT DirectX::Resize(
     const Image& srcImage,
     size_t width,
     size_t height,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     ScratchImage& image) noexcept
 {
     if (width == 0 || height == 0)
@@ -928,7 +928,7 @@ HRESULT DirectX::Resize(
     const TexMetadata& metadata,
     size_t width,
     size_t height,
-    DWORD filter,
+    TEX_FILTER_FLAGS filter,
     ScratchImage& result) noexcept
 {
     if (!srcImages || !nimages || width == 0 || height == 0)

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -490,7 +490,7 @@ namespace
                         size_t j = size_t(*sPtr & 0x7F) + 1;
                         ++sPtr;
 
-                        DWORD t;
+                        uint32_t t;
                         if (convFlags & CONV_FLAGS_EXPAND)
                         {
                             assert(offset * 3 < rowPitch);

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -136,7 +136,7 @@ namespace
         size_t size,
         _Out_ TexMetadata& metadata,
         size_t& offset,
-        _Inout_opt_ DWORD* convFlags) noexcept
+        _Inout_opt_ uint32_t* convFlags) noexcept
     {
         if (!pSource)
             return E_INVALIDARG;
@@ -276,7 +276,7 @@ namespace
         _In_reads_bytes_(size) const void* pSource,
         size_t size,
         _In_ const Image* image,
-        _In_ DWORD convFlags) noexcept
+        _In_ uint32_t convFlags) noexcept
     {
         assert(pSource && size > 0);
 
@@ -626,7 +626,7 @@ namespace
         _In_reads_bytes_(size) const void* pSource,
         size_t size,
         _In_ const Image* image,
-        _In_ DWORD convFlags) noexcept
+        _In_ uint32_t convFlags) noexcept
     {
         assert(pSource && size > 0);
 
@@ -810,7 +810,7 @@ namespace
     //-------------------------------------------------------------------------------------
     // Encodes TGA file header
     //-------------------------------------------------------------------------------------
-    HRESULT EncodeTGAHeader(_In_ const Image& image, _Out_ TGA_HEADER& header, _Inout_ DWORD& convFlags) noexcept
+    HRESULT EncodeTGAHeader(_In_ const Image& image, _Out_ TGA_HEADER& header, _Inout_ uint32_t& convFlags) noexcept
     {
         memset(&header, 0, sizeof(TGA_HEADER));
 
@@ -1068,7 +1068,7 @@ HRESULT DirectX::LoadFromTGAMemory(
     image.Release();
 
     size_t offset;
-    DWORD convFlags = 0;
+    uint32_t convFlags = 0;
     TexMetadata mdata;
     HRESULT hr = DecodeTGAHeader(pSource, size, mdata, offset, &convFlags);
     if (FAILED(hr))
@@ -1183,7 +1183,7 @@ HRESULT DirectX::LoadFromTGAFile(
     }
 
     size_t offset;
-    DWORD convFlags = 0;
+    uint32_t convFlags = 0;
     TexMetadata mdata;
     HRESULT hr = DecodeTGAHeader(header, bytesRead, mdata, offset, &convFlags);
     if (FAILED(hr))
@@ -1282,7 +1282,7 @@ HRESULT DirectX::LoadFromTGAFile(
                 pPixels += rowPitch;
             }
 
-            DWORD tflags = TEXP_SCANLINE_NONE;
+            uint32_t tflags = TEXP_SCANLINE_NONE;
             if (maxalpha == 0)
             {
                 opaquealpha = true;
@@ -1471,7 +1471,7 @@ HRESULT DirectX::SaveToTGAMemory(const Image& image, Blob& blob, const TexMetada
         return E_POINTER;
 
     TGA_HEADER tga_header = {};
-    DWORD convFlags = 0;
+    uint32_t convFlags = 0;
     HRESULT hr = EncodeTGAHeader(image, tga_header, convFlags);
     if (FAILED(hr))
         return hr;
@@ -1565,7 +1565,7 @@ HRESULT DirectX::SaveToTGAFile(const Image& image, const wchar_t* szFile, const 
         return E_POINTER;
 
     TGA_HEADER tga_header = {};
-    DWORD convFlags = 0;
+    uint32_t convFlags = 0;
     HRESULT hr = EncodeTGAHeader(image, tga_header, convFlags);
     if (FAILED(hr))
         return hr;

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -201,9 +201,9 @@ bool DirectX::_DXGIToWIC(DXGI_FORMAT format, GUID& guid, bool ignoreRGBvsBGR) no
     return false;
 }
 
-DWORD DirectX::_CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept
+TEX_FILTER_FLAGS DirectX::_CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept
 {
-    DWORD srgb = 0;
+    TEX_FILTER_FLAGS srgb = TEX_FILTER_DEFAULT;
 
     for (size_t i = 0; i < _countof(g_WICFormats); ++i)
     {
@@ -222,7 +222,7 @@ DWORD DirectX::_CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID&
 
     if ((srgb & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
     {
-        srgb &= ~static_cast<uint32_t>(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+        srgb &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
     }
 
     return srgb;
@@ -874,7 +874,7 @@ size_t DirectX::BitsPerColor(DXGI_FORMAT fmt) noexcept
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
 HRESULT DirectX::ComputePitch(DXGI_FORMAT fmt, size_t width, size_t height,
-    size_t& rowPitch, size_t& slicePitch, DWORD flags) noexcept
+    size_t& rowPitch, size_t& slicePitch, CP_FLAGS flags) noexcept
 {
     uint64_t pitch = 0;
     uint64_t slice = 0;

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -147,7 +147,7 @@ namespace
     //-------------------------------------------------------------------------------------
     DXGI_FORMAT DetermineFormat(
         _In_ const WICPixelFormatGUID& pixelFormat,
-        DWORD flags,
+        WIC_FLAGS flags,
         bool iswic2,
         _Out_opt_ WICPixelFormatGUID* pConvert,
         _Out_ TEX_ALPHA_MODE* alphaMode) noexcept
@@ -253,7 +253,7 @@ namespace
     // Determines metadata for image
     //-------------------------------------------------------------------------------------
     HRESULT DecodeMetadata(
-        DWORD flags,
+        WIC_FLAGS flags,
         bool iswic2,
         _In_ IWICBitmapDecoder *decoder,
         _In_ IWICBitmapFrameDecode *frame,
@@ -397,7 +397,7 @@ namespace
     // Decodes a single frame
     //-------------------------------------------------------------------------------------
     HRESULT DecodeSingleFrame(
-        DWORD flags,
+        WIC_FLAGS flags,
         const TexMetadata& metadata,
         const WICPixelFormatGUID& convertGUID,
         _In_ IWICBitmapFrameDecode *frame,
@@ -464,7 +464,7 @@ namespace
     // Decodes an image array, resizing/format converting as needed
     //-------------------------------------------------------------------------------------
     HRESULT DecodeMultiframe(
-        DWORD flags,
+        WIC_FLAGS flags,
         const TexMetadata& metadata,
         _In_ IWICBitmapDecoder *decoder,
         _Inout_ ScratchImage& image)
@@ -599,7 +599,7 @@ namespace
     // Encodes image metadata
     //-------------------------------------------------------------------------------------
     HRESULT EncodeMetadata(
-        DWORD flags,
+        WIC_FLAGS flags,
         _In_ IWICBitmapFrameEncode* frame,
         const GUID& containerFormat,
         DXGI_FORMAT format)
@@ -700,7 +700,7 @@ namespace
     //-------------------------------------------------------------------------------------
     HRESULT EncodeImage(
         const Image& image,
-        DWORD flags,
+        WIC_FLAGS flags,
         _In_ REFGUID containerFormat,
         _In_ IWICBitmapFrameEncode* frame,
         _In_opt_ IPropertyBag2* props,
@@ -803,7 +803,7 @@ namespace
 
     HRESULT EncodeSingleFrame(
         const Image& image,
-        DWORD flags,
+        WIC_FLAGS flags,
         _In_ REFGUID containerFormat,
         _Inout_ IStream* stream,
         _In_opt_ const GUID* targetFormat,
@@ -868,7 +868,7 @@ namespace
     HRESULT EncodeMultiframe(
         _In_reads_(nimages) const Image* images,
         size_t nimages,
-        DWORD flags,
+        WIC_FLAGS flags,
         _In_ REFGUID containerFormat,
         _Inout_ IStream* stream,
         _In_opt_ const GUID* targetFormat,
@@ -946,7 +946,7 @@ _Use_decl_annotations_
 HRESULT DirectX::GetMetadataFromWICMemory(
     const void* pSource,
     size_t size,
-    DWORD flags,
+    WIC_FLAGS flags,
     TexMetadata& metadata,
     std::function<void(IWICMetadataQueryReader*)> getMQR)
 {
@@ -998,7 +998,7 @@ HRESULT DirectX::GetMetadataFromWICMemory(
 _Use_decl_annotations_
 HRESULT DirectX::GetMetadataFromWICFile(
     const wchar_t* szFile,
-    DWORD flags,
+    WIC_FLAGS flags,
     TexMetadata& metadata,
     std::function<void(IWICMetadataQueryReader*)> getMQR)
 {
@@ -1037,7 +1037,7 @@ _Use_decl_annotations_
 HRESULT DirectX::LoadFromWICMemory(
     const void* pSource,
     size_t size,
-    DWORD flags,
+    WIC_FLAGS flags,
     TexMetadata* metadata,
     ScratchImage& image,
     std::function<void(IWICMetadataQueryReader*)> getMQR)
@@ -1111,7 +1111,7 @@ HRESULT DirectX::LoadFromWICMemory(
 _Use_decl_annotations_
 HRESULT DirectX::LoadFromWICFile(
     const wchar_t* szFile,
-    DWORD flags,
+    WIC_FLAGS flags,
     TexMetadata* metadata,
     ScratchImage& image,
     std::function<void(IWICMetadataQueryReader*)> getMQR)
@@ -1172,7 +1172,7 @@ HRESULT DirectX::LoadFromWICFile(
 _Use_decl_annotations_
 HRESULT DirectX::SaveToWICMemory(
     const Image& image,
-    DWORD flags,
+    WIC_FLAGS flags,
     REFGUID containerFormat,
     Blob& blob,
     const GUID* targetFormat,
@@ -1225,7 +1225,7 @@ _Use_decl_annotations_
 HRESULT DirectX::SaveToWICMemory(
     const Image* images,
     size_t nimages,
-    DWORD flags,
+    WIC_FLAGS flags,
     REFGUID containerFormat,
     Blob& blob,
     const GUID* targetFormat,
@@ -1285,7 +1285,7 @@ HRESULT DirectX::SaveToWICMemory(
 _Use_decl_annotations_
 HRESULT DirectX::SaveToWICFile(
     const Image& image,
-    DWORD flags,
+    WIC_FLAGS flags,
     REFGUID containerFormat,
     const wchar_t* szFile,
     const GUID* targetFormat,
@@ -1326,7 +1326,7 @@ _Use_decl_annotations_
 HRESULT DirectX::SaveToWICFile(
     const Image* images,
     size_t nimages,
-    DWORD flags,
+    WIC_FLAGS flags,
     REFGUID containerFormat,
     const wchar_t* szFile,
     const GUID* targetFormat,

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -928,9 +928,9 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     size_t height = 0;
 
     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
-    DWORD dwFilter = TEX_FILTER_DEFAULT;
-    DWORD dwSRGB = 0;
-    DWORD dwFilterOpts = 0;
+    TEX_FILTER_FLAGS dwFilter = TEX_FILTER_DEFAULT;
+    TEX_FILTER_FLAGS dwSRGB = TEX_FILTER_DEFAULT;
+    TEX_FILTER_FLAGS dwFilterOpts = TEX_FILTER_DEFAULT;
     DWORD fileType = WIC_CODEC_BMP;
 
     wchar_t szOutputFile[MAX_PATH] = {};
@@ -1056,7 +1056,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 break;
 
             case OPT_FILTER:
-                dwFilter = LookupByName(pValue, g_pFilters);
+                dwFilter = static_cast<TEX_FILTER_FLAGS>(LookupByName(pValue, g_pFilters));
                 if (!dwFilter)
                 {
                     wprintf(L"Invalid value specified with -if (%ls)\n", pValue);

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -573,7 +573,7 @@ namespace
         PrintList(15, g_pDumpFileTypes);
     }
 
-    HRESULT LoadImage(const wchar_t *fileName, DWORD dwOptions, DWORD dwFilter, TexMetadata& info, std::unique_ptr<ScratchImage>& image)
+    HRESULT LoadImage(const wchar_t *fileName, DWORD dwOptions, TEX_FILTER_FLAGS dwFilter, TexMetadata& info, std::unique_ptr<ScratchImage>& image)
     {
         if (!fileName)
             return E_INVALIDARG;
@@ -587,7 +587,7 @@ namespace
 
         if (_wcsicmp(ext, L".dds") == 0)
         {
-            DWORD ddsFlags = DDS_FLAGS_NONE;
+            DDS_FLAGS ddsFlags = DDS_FLAGS_NONE;
             if (dwOptions & (1 << OPT_DDS_DWORD_ALIGN))
                 ddsFlags |= DDS_FLAGS_LEGACY_DWORD;
             if (dwOptions & (1 << OPT_EXPAND_LUMINANCE))
@@ -1233,7 +1233,7 @@ namespace
 
 
     //--------------------------------------------------------------------------------------
-    HRESULT Difference(const Image& image1, const Image& image2, DWORD dwFilter, DXGI_FORMAT format, ScratchImage& result)
+    HRESULT Difference(const Image& image1, const Image& image2, TEX_FILTER_FLAGS dwFilter, DXGI_FORMAT format, ScratchImage& result)
     {
         if (!image1.pixels || !image2.pixels)
             return E_POINTER;
@@ -3033,7 +3033,7 @@ namespace
 int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 {
     // Parameters and defaults
-    DWORD dwFilter = TEX_FILTER_DEFAULT;
+    TEX_FILTER_FLAGS dwFilter = TEX_FILTER_DEFAULT;
     int pixelx = -1;
     int pixely = -1;
     DXGI_FORMAT diffFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
@@ -3149,7 +3149,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 break;
 
             case OPT_FILTER:
-                dwFilter = LookupByName(pValue, g_pFilters);
+                dwFilter = static_cast<TEX_FILTER_FLAGS>(LookupByName(pValue, g_pFilters));
                 if (!dwFilter)
                 {
                     wprintf(L"Invalid value specified with -if (%ls)\n", pValue);


### PR DESCRIPTION
There are many different flags in DirectXTex, and they all use DWORD so it's easy to get the wrong flag.

This PR changes all the flags in DirectXTex's public interface to strongly-typed flags via the ``DEFINE_ENUM_FLAG_OPERATORS`` macro from winnt.h--this is what Direct3D uses to type flags.

**This is a breaking change** but it's fairly easy to fix them up as you can see in the ``texconv`` et al. tools. You can also check out the [test suite](https://github.com/walbourn/directxtextest/pull/13) for examples.