### PR TITLE
DirectXTex updated with DDS_FLAGS_ALLOW_LARGE_FILES

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -172,6 +172,8 @@ namespace DirectX
         DDS_FLAGS_FORCE_DX9_LEGACY      = 0x40000,
             // Force use of legacy header for DDS writer (will fail if unable to write as such)
 
+        DDS_FLAGS_ALLOW_LARGE_FILES     = 0x1000000,
+            // Enables the loader to read large dimension .dds files (i.e. greater than known hardware requirements)
     };
 
     enum WIC_FLAGS : unsigned long

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -525,6 +525,25 @@ namespace
             metadata.SetAlphaMode(TEX_ALPHA_MODE_PREMULTIPLIED);
         }
 
+        // Check for .dds files that exceed known hardware support
+        if (!(flags & DDS_FLAGS_ALLOW_LARGE_FILES))
+        {
+            // 16k is the maximum required resource size supported by Direct3D
+            if (metadata.width > 16384u /* D3D12_REQ_TEXTURE1D_U_DIMENSION, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION */
+                || metadata.height > 16384u /* D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION */
+                || metadata.mipLevels > 15u /* D3D12_REQ_MIP_LEVELS */)
+            {
+                return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+            }
+
+            // 2048 is the maximum required depth/array size supported by Direct3D
+            if (metadata.arraySize > 2048u /* D3D12_REQ_TEXTURE1D_ARRAY_AXIS_DIMENSION, D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION */
+                || metadata.depth > 2048u /* D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION */)
+            {
+                return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+            }
+        }
+
         return S_OK;
     }
 }

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -1068,7 +1068,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             case CMD_V_STRIP:
                 if (_wcsicmp(ext, L".dds") == 0)
                 {
-                    hr = LoadFromDDSFile(pConv->szSrc, DDS_FLAGS_NONE, &info, *image);
+                    hr = LoadFromDDSFile(pConv->szSrc, DDS_FLAGS_ALLOW_LARGE_FILES, &info, *image);
                     if (FAILED(hr))
                     {
                         wprintf(L" FAILED (%x)\n", static_cast<unsigned int>(hr));
@@ -1095,7 +1095,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             case CMD_ARRAY_STRIP:
                 if (_wcsicmp(ext, L".dds") == 0)
                 {
-                    hr = LoadFromDDSFile(pConv->szSrc, DDS_FLAGS_NONE, &info, *image);
+                    hr = LoadFromDDSFile(pConv->szSrc, DDS_FLAGS_ALLOW_LARGE_FILES, &info, *image);
                     if (FAILED(hr))
                     {
                         wprintf(L" FAILED (%x)\n", static_cast<unsigned int>(hr));
@@ -1118,7 +1118,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             default:
                 if (_wcsicmp(ext, L".dds") == 0)
                 {
-                    hr = LoadFromDDSFile(pConv->szSrc, DDS_FLAGS_NONE, &info, *image);
+                    hr = LoadFromDDSFile(pConv->szSrc, DDS_FLAGS_ALLOW_LARGE_FILES, &info, *image);
                     if (FAILED(hr))
                     {
                         wprintf(L" FAILED (%x)\n", static_cast<unsigned int>(hr));

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -1672,7 +1672,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 
         if (_wcsicmp(ext, L".dds") == 0)
         {
-            DDS_FLAGS ddsFlags = DDS_FLAGS_NONE;
+            DDS_FLAGS ddsFlags = DDS_FLAGS_ALLOW_LARGE_FILES;
             if (dwOptions & (DWORD64(1) << OPT_DDS_DWORD_ALIGN))
                 ddsFlags |= DDS_FLAGS_LEGACY_DWORD;
             if (dwOptions & (DWORD64(1) << OPT_EXPAND_LUMINANCE))

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -592,7 +592,7 @@ namespace
 
         if (_wcsicmp(ext, L".dds") == 0)
         {
-            DDS_FLAGS ddsFlags = DDS_FLAGS_NONE;
+            DDS_FLAGS ddsFlags = DDS_FLAGS_ALLOW_LARGE_FILES;
             if (dwOptions & (1 << OPT_DDS_DWORD_ALIGN))
                 ddsFlags |= DDS_FLAGS_LEGACY_DWORD;
             if (dwOptions & (1 << OPT_EXPAND_LUMINANCE))


### PR DESCRIPTION
The DDSTextureLoader modules have checks for 'maximum required' size bounds for rejecting extremely large ``.DDS`` files that probably won't work with Direct3D at runtime. DIrectXTex's DDS codec being intended for tools didn't have such checks in case you wanted to convert some weirdly large .DDS file.

While I generally encourage using DDSTextureLoader for run-time texture loading scenarios, some people prefer to use DirectXTex. Also for viewer tools, you probably don't want to try to load unbounded size images anyhow.

This PR adds bounds checks to the DDS codec, but you can opt-out of these with a new loading flag for tools where you want to support these. I use this new flag for the command-line tools, although in practice only the x64 native versions of those tools are likely to be able to handle such large files anyhow.