### PR TITLE
Avoid static initialization order fiasco

### DIFF
--- a/WICTextureLoader/WICTextureLoader11.cpp
+++ b/WICTextureLoader/WICTextureLoader11.cpp
@@ -63,7 +63,7 @@ namespace
     //-------------------------------------------------------------------------------------
     struct WICTranslate
     {
-        GUID                wic;
+        const GUID&         wic;
         DXGI_FORMAT         format;
     };
 
@@ -98,8 +98,8 @@ namespace
 
     struct WICConvert
     {
-        GUID        source;
-        GUID        target;
+        const GUID&        source;
+        const GUID&        target;
     };
 
     const WICConvert g_WICConvert[] =

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -50,7 +50,7 @@ namespace
     //-------------------------------------------------------------------------------------
     struct WICTranslate
     {
-        GUID                wic;
+        const GUID&         wic;
         DXGI_FORMAT         format;
     };
 
@@ -87,8 +87,8 @@ namespace
 
     struct WICConvert
     {
-        GUID        source;
-        GUID        target;
+        const GUID&        source;
+        const GUID&        target;
     };
 
     const WICConvert g_WICConvert[] =

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -47,7 +47,7 @@ namespace
     //-------------------------------------------------------------------------------------
     struct WICTranslate
     {
-        GUID                wic;
+        const GUID&         wic;
         D3DFORMAT           format;
     };
 
@@ -80,8 +80,8 @@ namespace
 
     struct WICConvert
     {
-        GUID        source;
-        GUID        target;
+        const GUID&        source;
+        const GUID&        target;
     };
 
     const WICConvert g_WICConvert[] =


### PR DESCRIPTION
GUIDs in wincodec.h are defined out of line, so an initializer for a static
variable can read them before they have been initialized themselves. Taking a
reference rather than copying the value bypasses this issue.

This might turn out not to be a problem in most cases, but is still undefined
behavior. Anecdotally, removing it fixed a startup crash I got on incremental
builds (so there might be some weird interaction with the linker). So it is
probably worth fixing anyway.