### PR TITLE
CMake package support 

### DIFF
--- a/.nuget/directxtex-config.cmake.in
+++ b/.nuget/directxtex-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
 endif()
 
 if(MSVC)
-    # Use max Warning Level 
+    # Use max Warning Level
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,15 @@
-# DirectX Texture Library
-#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-#
-# http://go.microsoft.com/fwlink/?LinkId=248926
 
 cmake_minimum_required (VERSION 3.11)
 
-project (DirectXTex LANGUAGES CXX)
+set(DIRECTXTEX_VERSION 1.9.1)
+
+project (DirectXTex
+  VERSION ${DIRECTXTEX_VERSION}
+  DESCRIPTION "DirectX Texture Library"
+  HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkId=248926"
+  LANGUAGES CXX)
 
 # Includes the functions for creating Direct3D 11 resources at runtime
 option(BUILD_DX11 "Build with DirectX11 Runtime support" ON)
@@ -28,12 +30,16 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 
+#--- Library
+set(LIBRARY_HEADERS
+    DirectXTex/DirectXTex.h
+    DirectXTex/DirectXTex.inl)
+
 set(LIBRARY_SOURCES
     DirectXTex/BC.h
     DirectXTex/BCDirectCompute.h
     DirectXTex/d3dx12.h
     DirectXTex/DDS.h
-    DirectXTex/DirectXTex.h
     DirectXTex/DirectXTexP.h
     DirectXTex/filters.h
     DirectXTex/scoped.h
@@ -62,10 +68,10 @@ set(SHADER_SOURCES
     DirectXTex/Shaders/BC7Encode.hlsl)
 
 if(BUILD_DX11)
-   set(LIBRARY_SOURCES ${LIBRARY_SOURCES} DirectXTex/DirectXTexD3D11.cpp)
+   set(LIBRARY_SOURCES ${LIBRARY_SOURCES} ${LIBRARY_HEADERS} DirectXTex/DirectXTexD3D11.cpp)
 endif()
 if(BUILD_DX12)
-   set(LIBRARY_SOURCES ${LIBRARY_SOURCES} DirectXTex/DirectXTexD3D12.cpp)
+   set(LIBRARY_SOURCES ${LIBRARY_SOURCES} ${LIBRARY_HEADERS} DirectXTex/DirectXTexD3D12.cpp)
 endif()
 
 add_library(${PROJECT_NAME} STATIC ${LIBRARY_SOURCES} DirectXTex/Shaders/Compiled/BC6HEncode_EncodeBlockCS.inc)
@@ -81,7 +87,9 @@ add_custom_command(
 
 source_group(${PROJECT_NAME} REGULAR_EXPRESSION DirectXTex/*.*)
 
-target_include_directories(${PROJECT_NAME} PUBLIC DirectXTex)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DirectXTex>
+  $<INSTALL_INTERFACE:include>)
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
     target_precompile_headers(${PROJECT_NAME} PRIVATE DirectXTex/DirectXTexP.h)
@@ -99,6 +107,39 @@ if(MSVC)
     string(REPLACE "/GR " "/GR- " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
+#--- Package
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+  VERSION ${DIRECTXTEX_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/.nuget/${PROJECT_NAME}-config.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION cmake/})
+
+install(EXPORT ${PROJECT_NAME}-targets
+  FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE Microsoft::
+  DESTINATION cmake/)
+
+install(FILES ${LIBRARY_HEADERS}
+  DESTINATION include)
+
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+  DESTINATION cmake/)
+
+#--- Command-line tools
 add_executable(texassemble
     Texassemble/texassemble.cpp
     Texassemble/AnimatedGif.cpp)


### PR DESCRIPTION
This PR updates the CMake support in DirectXTex to support ``find_package(directxtex CONFIG)``:

```
find_package(directxtex CONFIG REQUIRED)

target_link_libraries(foo Microsoft::DirectXTex)
```
