### PR TITLE
Code review for standard library header usage

### DIFF
--- a/DDSView/ddsview.cpp
+++ b/DDSView/ddsview.cpp
@@ -9,16 +9,16 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#include <windows.h>
-
-#include <assert.h>
-#include <stdio.h>
-#include <dxgiformat.h>
-#include <d3d11.h>
+#include <Windows.h>
 
 #include <algorithm>
+#include <cassert>
+#include <cstdio>
 
-#include <directxmath.h>
+#include <dxgiformat.h>
+#include <d3d11_1.h>
+
+#include <DirectXMath.h>
 
 #pragma warning(disable : 4619 4616 26812)
 

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -11,9 +11,10 @@
 
 #pragma once
 
-#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <utility>
 #include <vector>
 
 #if !defined(__d3d11_h__) && !defined(__d3d11_x_h__) && !defined(__d3d12_h__) && !defined(__d3d12_x_h__) && !defined(__XBOX_D3D12_X__)
@@ -32,10 +33,10 @@
 
 #include <OCIdl.h>
 
-#define DIRECTX_TEX_VERSION 191
-
 struct IWICImagingFactory;
 struct IWICMetadataQueryReader;
+
+#define DIRECTX_TEX_VERSION 191
 
 
 namespace DirectX

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------
-// DirectXTexp.h
-//  
+// DirectXTexP.h
+//
 // DirectX Texture Library - Private header
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -85,11 +85,11 @@
 #define NOHELP
 #pragma warning(pop)
 
+#include <Windows.h>
+
 #ifndef _WIN32_WINNT_WIN10
 #define _WIN32_WINNT_WIN10 0x0A00
 #endif
-
-#include <Windows.h>
 
 #ifdef _GAMING_XBOX_SCARLETT
 #include <d3d12_xs.h>
@@ -107,25 +107,21 @@
 
 #define _XM_NO_XMVECTOR_OVERLOADS_
 
-#include <DirectXMath.h>
-#include <DirectXPackedVector.h>
-#include <assert.h>
-
-#include <malloc.h>
-#include <memory>
-
-#include <vector>
-
-#include <time.h>
-#include <stdlib.h>
-#include <search.h>
-
-#include <Ole2.h>
-
 #include "DirectXTex.h"
 
-#include <wincodec.h>
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <ctime>
+#include <cstring>
+#include <memory>
 
+#include <DirectXPackedVector.h>
+
+#include <malloc.h>
+
+#include <Ole2.h>
+#include <wincodec.h>
 #include <wrl\client.h>
 
 #include "scoped.h"
@@ -262,7 +258,7 @@ namespace DirectX
         CONVF_FLOAT     = 0x1,
         CONVF_UNORM     = 0x2,
         CONVF_UINT      = 0x4,
-        CONVF_SNORM     = 0x8, 
+        CONVF_SNORM     = 0x8,
         CONVF_SINT      = 0x10,
         CONVF_DEPTH     = 0x20,
         CONVF_STENCIL   = 0x40,
@@ -296,7 +292,7 @@ namespace DirectX
         void* pDestination, _In_ size_t outSize,
         _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
         _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
- 
+
     _Success_(return != false) bool __cdecl _ExpandScanline(
         _Out_writes_bytes_(outSize) void* pDestination, _In_ size_t outSize,
         _In_ DXGI_FORMAT outFormat,

--- a/Texassemble/AnimatedGif.cpp
+++ b/Texassemble/AnimatedGif.cpp
@@ -24,7 +24,9 @@
 #define NOHELP
 #pragma warning(pop)
 
+#include <cstddef>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <wrl/client.h>

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -20,13 +20,14 @@
 #define NOHELP
 #pragma warning(pop)
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <memory>
 #include <list>
+#include <utility>
 #include <vector>
 
 #include <wrl/client.h>

--- a/Texconv/ExtendedBMP.cpp
+++ b/Texconv/ExtendedBMP.cpp
@@ -24,6 +24,7 @@
 
 #include <Windows.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -21,6 +21,7 @@
 
 #include <Windows.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -19,10 +19,11 @@
 #define NOHELP
 #pragma warning(pop)
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <memory>
 #include <list>

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -20,10 +20,11 @@
 #define NOHELP
 #pragma warning(pop)
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <memory>
 #include <list>


### PR DESCRIPTION
Reviewed all the C++ standard library header usage and normalized usage for improved conformance.

* ``algorithm`` was used internally, but not in the public interface
* ``size_t`` requires ``cstddef``
* ``memcpy``, ``memcpy_s`` is officially in ``cstring``
* Use ``cassert`` instead of ``assert.h``, ``ctime`` instead of ``time.h``
* ``std::move`` is in ``utility``

> The non-standard malloc.h is still being included for ``_aligned_malloc`` / ``_aligned_free``. To be conformant, I should update it to use ``aligned_alloc`` and ``free`` when building for C++17 which is in ``cstdlib``.

Also trimmed trailing whitespace in these files.