### PR TITLE
texconv support for -r:keep

### DIFF
--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -410,7 +410,7 @@ namespace
                     wchar_t dir[_MAX_DIR] = {};
                     _wsplitpath_s(path, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
 
-                    SConversion conv;
+                    SConversion conv = {};
                     _wmakepath_s(conv.szSrc, drive, dir, findData.cFileName, nullptr);
                     files.push_back(conv);
                 }
@@ -925,7 +925,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     }
                     else
                     {
-                        SConversion conv;
+                        SConversion conv = {};
                         wcscpy_s(conv.szSrc, MAX_PATH, fname);
                         conversion.push_back(conv);
                     }
@@ -974,7 +974,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
         }
         else
         {
-            SConversion conv;
+            SConversion conv = {};
             wcscpy_s(conv.szSrc, MAX_PATH, pArg);
 
             conversion.push_back(conv);

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -19,7 +19,7 @@
 #define NOHELP
 #pragma warning(pop)
 
-#include <shlobj.h>
+#include <ShlObj.h>
 
 #include <algorithm>
 #include <cassert>
@@ -3117,7 +3117,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     continue;
                 }
 
-                int err = SHCreateDirectoryExW(nullptr, szPath, nullptr);
+                auto err = static_cast<DWORD>(SHCreateDirectoryExW(nullptr, szPath, nullptr));
                 if (err != ERROR_SUCCESS && err != ERROR_ALREADY_EXISTS)
                 {
                     wprintf(L" directory creation FAILED (%x)\n", static_cast<unsigned int>(HRESULT_FROM_WIN32(err)));
@@ -3126,7 +3126,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             }
 
             if (*szPrefix)
-                wcscpy_s(szDest, szPrefix);
+                wcscat_s(szDest, szPrefix);
 
             pchSlash = wcsrchr(pConv->szSrc, L'\\');
             if (pchSlash)

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -3103,7 +3103,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             // Figure out dest filename
             wchar_t *pchSlash, *pchDot;
 
-            wchar_t szDest[4096] = {};
+            wchar_t szDest[1024] = {};
             wcscpy_s(szDest, szOutputDir);
 
             if (keepRecursiveDirs && *pConv->szFolder)

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -420,7 +420,7 @@ namespace
                     wchar_t dir[_MAX_DIR] = {};
                     _wsplitpath_s(path, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
 
-                    SConversion conv;
+                    SConversion conv = {};
                     _wmakepath_s(conv.szSrc, drive, dir, findData.cFileName, nullptr);
                     files.push_back(conv);
                 }
@@ -3292,7 +3292,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     }
                     else
                     {
-                        SConversion conv;
+                        SConversion conv = {};
                         wcscpy_s(conv.szSrc, MAX_PATH, fname);
                         conversion.push_back(conv);
                     }
@@ -3319,7 +3319,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
         }
         else
         {
-            SConversion conv;
+            SConversion conv = {};
             wcscpy_s(conv.szSrc, MAX_PATH, pArg);
 
             conversion.push_back(conv);


### PR DESCRIPTION
Added ``-r:keep`` as an option for recursive copying of the directory structure to the output directory.

```
texconv -r:keep -o targetdir <source>\*png
```

If you use ``-r`` or ``-r:flatten``, it copies the outputs all to the same directory as it did before.