### PR TITLE
Fix of CaptureTexture for Reserved and MultiSample resources

### DIFF
--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -691,12 +691,8 @@ namespace
             return HRESULT_E_NOT_SUPPORTED;
 
         D3D12_HEAP_PROPERTIES sourceHeapProperties;
-        D3D12_HEAP_FLAGS sourceHeapFlags;
-        HRESULT hr = pSource->GetHeapProperties(&sourceHeapProperties, &sourceHeapFlags);
-        if (FAILED(hr))
-            return hr;
-
-        if (sourceHeapProperties.Type == D3D12_HEAP_TYPE_READBACK)
+        HRESULT hr = pSource->GetHeapProperties(&sourceHeapProperties, nullptr);
+        if (SUCCEEDED(hr) && sourceHeapProperties.Type == D3D12_HEAP_TYPE_READBACK)
         {
             // Handle case where the source is already a staging texture we can use directly
             pStaging = pSource;
@@ -745,6 +741,7 @@ namespace
             auto descCopy = desc;
             descCopy.SampleDesc.Count = 1;
             descCopy.SampleDesc.Quality = 0;
+            descCopy.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
             ComPtr<ID3D12Resource> pTemp;
             hr = device->CreateCommittedResource(


### PR DESCRIPTION
#### Fix of reserved resources extraction.
It is unable to call `GetHeapProperties` for reserved resources. But such info required only for `READBACK` resources optimization, capture code should not fail for reserved resources in this case.
```
D3D12 ERROR: ID3D12Resource2::ID3D12Resource::GetHeapProperties: GetHeapProperties can not be called on a resource created with the CreateReservedResource API. [ RESOURCE_MANIPULATION ERROR #901: GETHEAPPROPERTIES_INVALIDRESOURCE]
```

#### Fix of multisample resources extraction.
Invalid desc for resolved resource copied from the original multisample resource with `Alignment = D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT`, which fails creation call.