### PR TITLE
Add missing `find_dependency` calls to cmake config file

### DIFF
--- a/.nuget/DirectXTex-config.cmake.in
+++ b/.nuget/DirectXTex-config.cmake.in
@@ -1,5 +1,16 @@
 @PACKAGE_INIT@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+include(CMakeFindDependencyMacro)
+
+set(ENABLE_OPENEXR_SUPPORT @ENABLE_OPENEXR_SUPPORT@)
+if(ENABLE_OPENEXR_SUPPORT)
+    find_dependency(OpenEXR)
+endif()
+
+if((NOT WIN32) OR VCPKG_TOOLCHAIN)
+    find_dependency(directx-headers CONFIG)
+    find_dependency(directxmath CONFIG)
+endif()
 
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
These `find_dependency` calls in the config file need to mirror the `find_package` calls in the `CMakeLists.txt`, or else the configure step will fail with missing dependencies.
https://github.com/microsoft/DirectXTex/blob/6c6c910af327b182d5cd610dc3d2f7ec284f7629/CMakeLists.txt#L139
https://github.com/microsoft/DirectXTex/blob/6c6c910af327b182d5cd610dc3d2f7ec284f7629/CMakeLists.txt#L161-L162