### PR TITLE
Convert internal functions to use Internal namespace instead of leading underscore

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -828,6 +828,13 @@ namespace DirectX
 #endif
 
     //---------------------------------------------------------------------------------
+    // DDS helper functions
+    HRESULT __cdecl EncodeDDSHeader(
+        _In_ const TexMetadata& metadata, DDS_FLAGS flags,
+        _Out_writes_bytes_to_opt_(maxsize, required) void* pDestination, _In_ size_t maxsize,
+        _Out_ size_t& required) noexcept;
+
+    //---------------------------------------------------------------------------------
     // Direct3D 11 functions
 #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
     bool __cdecl IsSupportedTexture(_In_ ID3D11Device* pDevice, _In_ const TexMetadata& metadata) noexcept;

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -19,6 +19,7 @@
 #include "BC.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 namespace
 {
@@ -122,25 +123,25 @@ namespace
                 ptrdiff_t bytesLeft = pEnd - sptr;
                 assert(bytesLeft > 0);
                 size_t bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft));
-                if (!_LoadScanline(&temp[0], pw, sptr, bytesToRead, format))
+                if (!LoadScanline(&temp[0], pw, sptr, bytesToRead, format))
                     return E_FAIL;
 
                 if (ph > 1)
                 {
                     bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch);
-                    if (!_LoadScanline(&temp[4], pw, sptr + rowPitch, bytesToRead, format))
+                    if (!LoadScanline(&temp[4], pw, sptr + rowPitch, bytesToRead, format))
                         return E_FAIL;
 
                     if (ph > 2)
                     {
                         bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch * 2);
-                        if (!_LoadScanline(&temp[8], pw, sptr + rowPitch * 2, bytesToRead, format))
+                        if (!LoadScanline(&temp[8], pw, sptr + rowPitch * 2, bytesToRead, format))
                             return E_FAIL;
 
                         if (ph > 3)
                         {
                             bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch * 3);
-                            if (!_LoadScanline(&temp[12], pw, sptr + rowPitch * 3, bytesToRead, format))
+                            if (!LoadScanline(&temp[12], pw, sptr + rowPitch * 3, bytesToRead, format))
                                 return E_FAIL;
                         }
                     }
@@ -176,7 +177,7 @@ namespace
                     }
                 }
 
-                _ConvertScanline(temp, 16, result.format, format, cflags | srgb);
+                ConvertScanline(temp, 16, result.format, format, cflags | srgb);
 
                 if (pfEncode)
                     pfEncode(dptr, temp, bcflags);
@@ -264,25 +265,25 @@ namespace
             size_t bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft));
 
             XM_ALIGNED_DATA(16) XMVECTOR temp[16];
-            if (!_LoadScanline(&temp[0], pw, pSrc, bytesToRead, format))
+            if (!LoadScanline(&temp[0], pw, pSrc, bytesToRead, format))
                 fail = true;
 
             if (ph > 1)
             {
                 bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft) - rowPitch);
-                if (!_LoadScanline(&temp[4], pw, pSrc + rowPitch, bytesToRead, format))
+                if (!LoadScanline(&temp[4], pw, pSrc + rowPitch, bytesToRead, format))
                     fail = true;
 
                 if (ph > 2)
                 {
                     bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft) - rowPitch * 2);
-                    if (!_LoadScanline(&temp[8], pw, pSrc + rowPitch * 2, bytesToRead, format))
+                    if (!LoadScanline(&temp[8], pw, pSrc + rowPitch * 2, bytesToRead, format))
                         fail = true;
 
                     if (ph > 3)
                     {
                         bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft) - rowPitch * 3);
-                        if (!_LoadScanline(&temp[12], pw, pSrc + rowPitch * 3, bytesToRead, format))
+                        if (!LoadScanline(&temp[12], pw, pSrc + rowPitch * 3, bytesToRead, format))
                             fail = true;
                     }
                 }
@@ -316,7 +317,7 @@ namespace
                 }
             }
 
-            _ConvertScanline(temp, 16, result.format, format, cflags | srgb);
+            ConvertScanline(temp, 16, result.format, format, cflags | srgb);
 
             if (pfEncode)
                 pfEncode(pDest, temp, bcflags);
@@ -453,27 +454,27 @@ namespace
             for (size_t count = 0; (count < cImage.rowPitch) && (w < cImage.width); count += sbpp, w += 4)
             {
                 pfDecode(temp, sptr);
-                _ConvertScanline(temp, 16, format, cformat, TEX_FILTER_DEFAULT);
+                ConvertScanline(temp, 16, format, cformat, TEX_FILTER_DEFAULT);
 
                 size_t pw = std::min<size_t>(4, cImage.width - w);
                 assert(pw > 0 && ph > 0);
 
-                if (!_StoreScanline(dptr, rowPitch, format, &temp[0], pw))
+                if (!StoreScanline(dptr, rowPitch, format, &temp[0], pw))
                     return E_FAIL;
 
                 if (ph > 1)
                 {
-                    if (!_StoreScanline(dptr + rowPitch, rowPitch, format, &temp[4], pw))
+                    if (!StoreScanline(dptr + rowPitch, rowPitch, format, &temp[4], pw))
                         return E_FAIL;
 
                     if (ph > 2)
                     {
-                        if (!_StoreScanline(dptr + rowPitch * 2, rowPitch, format, &temp[8], pw))
+                        if (!StoreScanline(dptr + rowPitch * 2, rowPitch, format, &temp[8], pw))
                             return E_FAIL;
 
                         if (ph > 3)
                         {
-                            if (!_StoreScanline(dptr + rowPitch * 3, rowPitch, format, &temp[12], pw))
+                            if (!StoreScanline(dptr + rowPitch * 3, rowPitch, format, &temp[12], pw))
                                 return E_FAIL;
                         }
                     }
@@ -492,95 +493,89 @@ namespace
 }
 
 //-------------------------------------------------------------------------------------
-namespace DirectX
+bool DirectX::Internal::IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept
 {
-    bool _IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept;
-        // Also used by Image
+    if (!cImage.pixels)
+        return false;
 
-    bool _IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept
+    // Promote "typeless" BC formats
+    DXGI_FORMAT cformat;
+    switch (cImage.format)
     {
-        if (!cImage.pixels)
-            return false;
+    case DXGI_FORMAT_BC1_TYPELESS:  cformat = DXGI_FORMAT_BC1_UNORM; break;
+    case DXGI_FORMAT_BC2_TYPELESS:  cformat = DXGI_FORMAT_BC2_UNORM; break;
+    case DXGI_FORMAT_BC3_TYPELESS:  cformat = DXGI_FORMAT_BC3_UNORM; break;
+    case DXGI_FORMAT_BC7_TYPELESS:  cformat = DXGI_FORMAT_BC7_UNORM; break;
+    default:                        cformat = cImage.format;         break;
+    }
 
-        // Promote "typeless" BC formats
-        DXGI_FORMAT cformat;
-        switch (cImage.format)
+    // Determine BC format decoder
+    BC_DECODE pfDecode;
+    size_t sbpp;
+    switch (cformat)
+    {
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:    pfDecode = D3DXDecodeBC1;   sbpp = 8;   break;
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:    pfDecode = D3DXDecodeBC2;   sbpp = 16;  break;
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:    pfDecode = D3DXDecodeBC3;   sbpp = 16;  break;
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:    pfDecode = D3DXDecodeBC7;   sbpp = 16;  break;
+    default:
+        // BC4, BC5, and BC6 don't have alpha channels
+        return false;
+    }
+
+    // Scan blocks for non-opaque alpha
+    static const XMVECTORF32 threshold = { { { 0.99f, 0.99f, 0.99f, 0.99f } } };
+
+    XM_ALIGNED_DATA(16) XMVECTOR temp[16];
+    const uint8_t* pPixels = cImage.pixels;
+    for (size_t h = 0; h < cImage.height; h += 4)
+    {
+        const uint8_t* ptr = pPixels;
+        size_t ph = std::min<size_t>(4, cImage.height - h);
+        size_t w = 0;
+        for (size_t count = 0; (count < cImage.rowPitch) && (w < cImage.width); count += sbpp, w += 4)
         {
-        case DXGI_FORMAT_BC1_TYPELESS:  cformat = DXGI_FORMAT_BC1_UNORM; break;
-        case DXGI_FORMAT_BC2_TYPELESS:  cformat = DXGI_FORMAT_BC2_UNORM; break;
-        case DXGI_FORMAT_BC3_TYPELESS:  cformat = DXGI_FORMAT_BC3_UNORM; break;
-        case DXGI_FORMAT_BC7_TYPELESS:  cformat = DXGI_FORMAT_BC7_UNORM; break;
-        default:                        cformat = cImage.format;         break;
-        }
+            pfDecode(temp, ptr);
 
-        // Determine BC format decoder
-        BC_DECODE pfDecode;
-        size_t sbpp;
-        switch (cformat)
-        {
-        case DXGI_FORMAT_BC1_UNORM:
-        case DXGI_FORMAT_BC1_UNORM_SRGB:    pfDecode = D3DXDecodeBC1;   sbpp = 8;   break;
-        case DXGI_FORMAT_BC2_UNORM:
-        case DXGI_FORMAT_BC2_UNORM_SRGB:    pfDecode = D3DXDecodeBC2;   sbpp = 16;  break;
-        case DXGI_FORMAT_BC3_UNORM:
-        case DXGI_FORMAT_BC3_UNORM_SRGB:    pfDecode = D3DXDecodeBC3;   sbpp = 16;  break;
-        case DXGI_FORMAT_BC7_UNORM:
-        case DXGI_FORMAT_BC7_UNORM_SRGB:    pfDecode = D3DXDecodeBC7;   sbpp = 16;  break;
-        default:
-            // BC4, BC5, and BC6 don't have alpha channels
-            return false;
-        }
+            size_t pw = std::min<size_t>(4, cImage.width - w);
+            assert(pw > 0 && ph > 0);
 
-        // Scan blocks for non-opaque alpha
-        static const XMVECTORF32 threshold = { { { 0.99f, 0.99f, 0.99f, 0.99f } } };
-
-        XM_ALIGNED_DATA(16) XMVECTOR temp[16];
-        const uint8_t *pPixels = cImage.pixels;
-        for (size_t h = 0; h < cImage.height; h += 4)
-        {
-            const uint8_t *ptr = pPixels;
-            size_t ph = std::min<size_t>(4, cImage.height - h);
-            size_t w = 0;
-            for (size_t count = 0; (count < cImage.rowPitch) && (w < cImage.width); count += sbpp, w += 4)
+            if (pw == 4 && ph == 4)
             {
-                pfDecode(temp, ptr);
-
-                size_t pw = std::min<size_t>(4, cImage.width - w);
-                assert(pw > 0 && ph > 0);
-
-                if (pw == 4 && ph == 4)
+                // Full blocks
+                for (size_t j = 0; j < 16; ++j)
                 {
-                    // Full blocks
-                    for (size_t j = 0; j < 16; ++j)
+                    XMVECTOR alpha = XMVectorSplatW(temp[j]);
+                    if (XMVector4Less(alpha, threshold))
+                        return false;
+                }
+            }
+            else
+            {
+                // Handle partial blocks
+                for (size_t y = 0; y < ph; ++y)
+                {
+                    for (size_t x = 0; x < pw; ++x)
                     {
-                        XMVECTOR alpha = XMVectorSplatW(temp[j]);
+                        XMVECTOR alpha = XMVectorSplatW(temp[y * 4 + x]);
                         if (XMVector4Less(alpha, threshold))
                             return false;
                     }
                 }
-                else
-                {
-                    // Handle partial blocks
-                    for (size_t y = 0; y < ph; ++y)
-                    {
-                        for (size_t x = 0; x < pw; ++x)
-                        {
-                            XMVECTOR alpha = XMVectorSplatW(temp[y * 4 + x]);
-                            if (XMVector4Less(alpha, threshold))
-                                return false;
-                        }
-                    }
-                }
-
-                ptr += sbpp;
             }
 
-            pPixels += cImage.rowPitch;
+            ptr += sbpp;
         }
 
-        return true;
+        pPixels += cImage.rowPitch;
     }
-};
+
+    return true;
+}
 
 
 //=====================================================================================

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -14,6 +14,7 @@
 #include "BCDirectCompute.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 namespace
 {
@@ -69,15 +70,15 @@ namespace
         const uint8_t *pSrc = srcImage.pixels;
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+            if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
             {
                 image.Release();
                 return E_FAIL;
             }
 
-            _ConvertScanline(scanline.get(), srcImage.width, format, srcImage.format, filter);
+            ConvertScanline(scanline.get(), srcImage.width, format, srcImage.format, filter);
 
-            if (!_StoreScanline(pDest, img->rowPitch, format, scanline.get(), srcImage.width))
+            if (!StoreScanline(pDest, img->rowPitch, format, scanline.get(), srcImage.width))
             {
                 image.Release();
                 return E_FAIL;
@@ -123,13 +124,13 @@ namespace
         const uint8_t *pSrc = srcImage.pixels;
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+            if (!LoadScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
             {
                 image.Release();
                 return E_FAIL;
             }
 
-            _ConvertScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, DXGI_FORMAT_R32G32B32A32_FLOAT, srcImage.format, filter);
+            ConvertScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, DXGI_FORMAT_R32G32B32A32_FLOAT, srcImage.format, filter);
 
             pSrc += srcImage.rowPitch;
             pDest += img->rowPitch;

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -12,6 +12,7 @@
 #include "DirectXTexP.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 using namespace DirectX::PackedVector;
 using Microsoft::WRL::ComPtr;
 
@@ -199,7 +200,7 @@ namespace
 // (can be used in place as well) otherwise copies the image row unmodified.
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-void DirectX::_CopyScanline(
+void DirectX::Internal::CopyScanline(
     void* pDestination,
     size_t outSize,
     const void* pSource,
@@ -444,7 +445,7 @@ void DirectX::_CopyScanline(
 // (can be used in place as well) otherwise copies the image row unmodified.
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-void DirectX::_SwizzleScanline(
+void DirectX::Internal::SwizzleScanline(
     void* pDestination,
     size_t outSize,
     const void* pSource,
@@ -614,7 +615,7 @@ void DirectX::_SwizzleScanline(
 // Returns true if supported, false if expansion case not supported
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-bool DirectX::_ExpandScanline(
+bool DirectX::Internal::ExpandScanline(
     void* pDestination,
     size_t outSize,
     DXGI_FORMAT outFormat,
@@ -755,7 +756,7 @@ bool DirectX::_ExpandScanline(
         return false;
 
 #pragma warning(suppress: 6101)
-_Use_decl_annotations_ bool DirectX::_LoadScanline(
+_Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
     XMVECTOR* pDestination,
     size_t count,
     const void* pSource,
@@ -1603,7 +1604,7 @@ _Use_decl_annotations_ bool DirectX::_LoadScanline(
         return false;
 
 _Use_decl_annotations_
-bool DirectX::_StoreScanline(
+bool DirectX::Internal::StoreScanline(
     void* pDestination,
     size_t size,
     DXGI_FORMAT format,
@@ -2470,7 +2471,7 @@ bool DirectX::_StoreScanline(
 // Convert DXGI image to/from GUID_WICPixelFormat128bppRGBAFloat (no range conversions)
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-HRESULT DirectX::_ConvertToR32G32B32A32(const Image& srcImage, ScratchImage& image) noexcept
+HRESULT DirectX::Internal::ConvertToR32G32B32A32(const Image& srcImage, ScratchImage& image) noexcept
 {
     if (!srcImage.pixels)
         return E_POINTER;
@@ -2496,7 +2497,7 @@ HRESULT DirectX::_ConvertToR32G32B32A32(const Image& srcImage, ScratchImage& ima
     const uint8_t *pSrc = srcImage.pixels;
     for (size_t h = 0; h < srcImage.height; ++h)
     {
-        if (!_LoadScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+        if (!LoadScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
         {
             image.Release();
             return E_FAIL;
@@ -2510,7 +2511,7 @@ HRESULT DirectX::_ConvertToR32G32B32A32(const Image& srcImage, ScratchImage& ima
 }
 
 _Use_decl_annotations_
-HRESULT DirectX::_ConvertFromR32G32B32A32(const Image& srcImage, const Image& destImage) noexcept
+HRESULT DirectX::Internal::ConvertFromR32G32B32A32(const Image& srcImage, const Image& destImage) noexcept
 {
     assert(srcImage.format == DXGI_FORMAT_R32G32B32A32_FLOAT);
 
@@ -2525,7 +2526,7 @@ HRESULT DirectX::_ConvertFromR32G32B32A32(const Image& srcImage, const Image& de
 
     for (size_t h = 0; h < srcImage.height; ++h)
     {
-        if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, reinterpret_cast<const XMVECTOR*>(pSrc), srcImage.width))
+        if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, reinterpret_cast<const XMVECTOR*>(pSrc), srcImage.width))
             return E_FAIL;
 
         pSrc += srcImage.rowPitch;
@@ -2536,7 +2537,10 @@ HRESULT DirectX::_ConvertFromR32G32B32A32(const Image& srcImage, const Image& de
 }
 
 _Use_decl_annotations_
-HRESULT DirectX::_ConvertFromR32G32B32A32(const Image& srcImage, DXGI_FORMAT format, ScratchImage& image) noexcept
+HRESULT DirectX::Internal::ConvertFromR32G32B32A32(
+    const Image& srcImage,
+    DXGI_FORMAT format,
+    ScratchImage& image) noexcept
 {
     if (!srcImage.pixels)
         return E_POINTER;
@@ -2552,7 +2556,7 @@ HRESULT DirectX::_ConvertFromR32G32B32A32(const Image& srcImage, DXGI_FORMAT for
         return E_POINTER;
     }
 
-    hr = _ConvertFromR32G32B32A32(srcImage, *img);
+    hr = ConvertFromR32G32B32A32(srcImage, *img);
     if (FAILED(hr))
     {
         image.Release();
@@ -2563,7 +2567,7 @@ HRESULT DirectX::_ConvertFromR32G32B32A32(const Image& srcImage, DXGI_FORMAT for
 }
 
 _Use_decl_annotations_
-HRESULT DirectX::_ConvertFromR32G32B32A32(
+HRESULT DirectX::Internal::ConvertFromR32G32B32A32(
     const Image* srcImages,
     size_t nimages,
     const TexMetadata& metadata,
@@ -2620,7 +2624,7 @@ HRESULT DirectX::_ConvertFromR32G32B32A32(
 
         for (size_t h = 0; h < src.height; ++h)
         {
-            if (!_StoreScanline(pDest, dst.rowPitch, format, reinterpret_cast<const XMVECTOR*>(pSrc), src.width))
+            if (!StoreScanline(pDest, dst.rowPitch, format, reinterpret_cast<const XMVECTOR*>(pSrc), src.width))
             {
                 result.Release();
                 return E_FAIL;
@@ -2639,7 +2643,7 @@ HRESULT DirectX::_ConvertFromR32G32B32A32(
 // Convert DXGI image to/from GUID_WICPixelFormat64bppRGBAHalf (no range conversions)
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-HRESULT DirectX::_ConvertToR16G16B16A16(const Image& srcImage, ScratchImage& image) noexcept
+HRESULT DirectX::Internal::ConvertToR16G16B16A16(const Image& srcImage, ScratchImage& image) noexcept
 {
     if (!srcImage.pixels)
         return E_POINTER;
@@ -2672,7 +2676,7 @@ HRESULT DirectX::_ConvertToR16G16B16A16(const Image& srcImage, ScratchImage& ima
     const uint8_t *pSrc = srcImage.pixels;
     for (size_t h = 0; h < srcImage.height; ++h)
     {
-        if (!_LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+        if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
         {
             image.Release();
             return E_FAIL;
@@ -2691,7 +2695,7 @@ HRESULT DirectX::_ConvertToR16G16B16A16(const Image& srcImage, ScratchImage& ima
 }
 
 _Use_decl_annotations_
-HRESULT DirectX::_ConvertFromR16G16B16A16(const Image& srcImage, const Image& destImage) noexcept
+HRESULT DirectX::Internal::ConvertFromR16G16B16A16(const Image& srcImage, const Image& destImage) noexcept
 {
     assert(srcImage.format == DXGI_FORMAT_R16G16B16A16_FLOAT);
 
@@ -2715,7 +2719,7 @@ HRESULT DirectX::_ConvertFromR16G16B16A16(const Image& srcImage, const Image& de
             reinterpret_cast<const HALF*>(pSrc), sizeof(HALF),
             srcImage.width * 4);
 
-        if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
+        if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
             return E_FAIL;
 
         pSrc += srcImage.rowPitch;
@@ -2734,7 +2738,7 @@ HRESULT DirectX::_ConvertFromR16G16B16A16(const Image& srcImage, const Image& de
 //                             where a = 0.055
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-bool DirectX::_StoreScanlineLinear(
+bool DirectX::Internal::StoreScanlineLinear(
     void* pDestination,
     size_t size,
     DXGI_FORMAT format,
@@ -2799,7 +2803,7 @@ bool DirectX::_StoreScanlineLinear(
         }
     }
 
-    return _StoreScanline(pDestination, size, format, pSource, count, threshold);
+    return StoreScanline(pDestination, size, format, pSource, count, threshold);
 }
 
 
@@ -2811,7 +2815,7 @@ bool DirectX::_StoreScanlineLinear(
 //                         where a = 0.055
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-bool DirectX::_LoadScanlineLinear(
+bool DirectX::Internal::LoadScanlineLinear(
     XMVECTOR* pDestination,
     size_t count,
     const void* pSource,
@@ -2858,7 +2862,7 @@ bool DirectX::_LoadScanlineLinear(
         break;
     }
 
-    if (_LoadScanline(pDestination, count, pSource, size, format))
+    if (LoadScanline(pDestination, count, pSource, size, format))
     {
         // sRGB input processing (sRGB -> Linear RGB)
         if (flags & TEX_FILTER_SRGB_IN)
@@ -2988,7 +2992,7 @@ namespace
 }
 
 _Use_decl_annotations_
-uint32_t DirectX::_GetConvertFlags(DXGI_FORMAT format) noexcept
+uint32_t DirectX::Internal::GetConvertFlags(DXGI_FORMAT format) noexcept
 {
 #ifdef _DEBUG
     // Ensure conversion table is in ascending order
@@ -3008,7 +3012,7 @@ uint32_t DirectX::_GetConvertFlags(DXGI_FORMAT format) noexcept
 }
 
 _Use_decl_annotations_
-void DirectX::_ConvertScanline(
+void DirectX::Internal::ConvertScanline(
     XMVECTOR* pBuffer,
     size_t count,
     DXGI_FORMAT outFormat,
@@ -3046,8 +3050,8 @@ void DirectX::_ConvertScanline(
         return;
     }
 
-    assert(_GetConvertFlags(inFormat) == in->flags);
-    assert(_GetConvertFlags(outFormat) == out->flags);
+    assert(GetConvertFlags(inFormat) == in->flags);
+    assert(GetConvertFlags(outFormat) == out->flags);
 
     // Handle SRGB filtering modes
     switch (inFormat)
@@ -3903,7 +3907,7 @@ namespace
 #pragma warning( disable : 4127 )
 
 _Use_decl_annotations_
-bool DirectX::_StoreScanlineDither(
+bool DirectX::Internal::StoreScanlineDither(
     void* pDestination,
     size_t size,
     DXGI_FORMAT format,
@@ -4363,7 +4367,7 @@ bool DirectX::_StoreScanlineDither(
         return false;
 
     default:
-        return _StoreScanline(pDestination, size, format, pSource, count, threshold);
+        return StoreScanline(pDestination, size, format, pSource, count, threshold);
     }
 }
 
@@ -4402,7 +4406,7 @@ namespace
             return false;
         }
 
-        if (!_DXGIToWIC(sformat, pfGUID) || !_DXGIToWIC(tformat, targetGUID))
+        if (!DXGIToWIC(sformat, pfGUID) || !DXGIToWIC(tformat, targetGUID))
         {
             // Source or target format are not WIC supported native pixel formats
             return false;
@@ -4525,7 +4529,7 @@ namespace
             filter &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
         }
 
-        auto wicsrgb = _CheckWICColorSpace(pfGUID, targetGUID);
+        auto wicsrgb = CheckWICColorSpace(pfGUID, targetGUID);
 
         if (wicsrgb != (filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)))
         {
@@ -4592,7 +4596,8 @@ namespace
         if (FAILED(hr))
             return hr;
 
-        hr = FC->Initialize(source.Get(), targetGUID, _GetWICDither(filter), nullptr, static_cast<double>(threshold) * 100.0, WICBitmapPaletteTypeMedianCut);
+        hr = FC->Initialize(source.Get(), targetGUID, GetWICDither(filter), nullptr,
+            static_cast<double>(threshold) * 100.0, WICBitmapPaletteTypeMedianCut);
         if (FAILED(hr))
             return hr;
 
@@ -4636,12 +4641,12 @@ namespace
 
             for (size_t h = 0; h < srcImage.height; ++h)
             {
-                if (!_LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
+                if (!LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
                     return E_FAIL;
 
-                _ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
+                ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
 
-                if (!_StoreScanlineDither(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold, h, z, pDiffusionErrors))
+                if (!StoreScanlineDither(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold, h, z, pDiffusionErrors))
                     return E_FAIL;
 
                 pSrc += srcImage.rowPitch;
@@ -4659,12 +4664,12 @@ namespace
                 // Ordered dithering
                 for (size_t h = 0; h < srcImage.height; ++h)
                 {
-                    if (!_LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
+                    if (!LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
                         return E_FAIL;
 
-                    _ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
+                    ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
 
-                    if (!_StoreScanlineDither(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold, h, z, nullptr))
+                    if (!StoreScanlineDither(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold, h, z, nullptr))
                         return E_FAIL;
 
                     pSrc += srcImage.rowPitch;
@@ -4676,12 +4681,12 @@ namespace
                 // No dithering
                 for (size_t h = 0; h < srcImage.height; ++h)
                 {
-                    if (!_LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
+                    if (!LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
                         return E_FAIL;
 
-                    _ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
+                    ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
 
-                    if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold))
+                    if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold))
                         return E_FAIL;
 
                     pSrc += srcImage.rowPitch;
@@ -4694,7 +4699,7 @@ namespace
     }
 
     //-------------------------------------------------------------------------------------
-    DXGI_FORMAT _PlanarToSingle(_In_ DXGI_FORMAT format) noexcept
+    DXGI_FORMAT PlanarToSingle(_In_ DXGI_FORMAT format) noexcept
     {
         switch (format)
         {
@@ -5077,7 +5082,7 @@ HRESULT DirectX::ConvertToSinglePlane(const Image& srcImage, ScratchImage& image
     if (!srcImage.pixels)
         return E_POINTER;
 
-    DXGI_FORMAT format = _PlanarToSingle(srcImage.format);
+    DXGI_FORMAT format = PlanarToSingle(srcImage.format);
     if (format == DXGI_FORMAT_UNKNOWN)
         return HRESULT_E_NOT_SUPPORTED;
 
@@ -5125,7 +5130,7 @@ HRESULT DirectX::ConvertToSinglePlane(
         return HRESULT_E_NOT_SUPPORTED;
     }
 
-    DXGI_FORMAT format = _PlanarToSingle(metadata.format);
+    DXGI_FORMAT format = PlanarToSingle(metadata.format);
     if (format == DXGI_FORMAT_UNKNOWN)
         return HRESULT_E_NOT_SUPPORTED;
 
@@ -5189,7 +5194,7 @@ HRESULT DirectX::ConvertToSinglePlane(
 //-------------------------------------------------------------------------------------
 DirectX::FORMAT_TYPE DirectX::FormatDataType(_In_ DXGI_FORMAT fmt) noexcept
 {
-    auto cflags = _GetConvertFlags(fmt);
+    const auto cflags = GetConvertFlags(fmt);
 
     switch (cflags & (CONVF_FLOAT | CONVF_UNORM | CONVF_UINT | CONVF_SNORM | CONVF_SINT))
     {

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -14,6 +14,7 @@
 #include "DDS.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 static_assert(static_cast<int>(TEX_DIMENSION_TEXTURE1D) == static_cast<int>(DDS_DIMENSION_TEXTURE1D), "header enum mismatch");
 static_assert(static_cast<int>(TEX_DIMENSION_TEXTURE2D) == static_cast<int>(DDS_DIMENSION_TEXTURE2D), "header enum mismatch");
@@ -558,7 +559,7 @@ namespace
 // Encodes DDS file header (magic value, header, optional DX10 extended header)
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-HRESULT DirectX::_EncodeDDSHeader(
+HRESULT DirectX::Internal::EncodeDDSHeader(
     const TexMetadata& metadata,
     DDS_FLAGS flags,
     void* pDestination,
@@ -889,7 +890,7 @@ namespace
         TEXP_LEGACY_A8L8
     };
 
-    inline TEXP_LEGACY_FORMAT _FindLegacyFormat(uint32_t flags) noexcept
+    inline TEXP_LEGACY_FORMAT FindLegacyFormat(uint32_t flags) noexcept
     {
         TEXP_LEGACY_FORMAT lformat = TEXP_LEGACY_UNKNOWN;
 
@@ -1253,7 +1254,7 @@ namespace
         }
 
         size_t pixelSize, nimages;
-        if (!_DetermineImageArray(metadata, cpFlags, nimages, pixelSize))
+        if (!DetermineImageArray(metadata, cpFlags, nimages, pixelSize))
             return HRESULT_E_ARITHMETIC_OVERFLOW;
 
         if ((nimages == 0) || (nimages != image.GetImageCount()))
@@ -1272,7 +1273,7 @@ namespace
             return E_OUTOFMEMORY;
         }
 
-        if (!_SetupImageArray(
+        if (!SetupImageArray(
             const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(pPixels)),
             pixelSize,
             metadata,
@@ -1366,7 +1367,7 @@ namespace
                             {
                                 if (convFlags & (CONV_FLAGS_565 | CONV_FLAGS_5551 | CONV_FLAGS_4444))
                                 {
-                                    if (!_ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
+                                    if (!ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
                                         pSrc, spitch,
                                         (convFlags & CONV_FLAGS_565) ? DXGI_FORMAT_B5G6R5_UNORM : DXGI_FORMAT_B5G5R5A1_UNORM,
                                         tflags))
@@ -1374,7 +1375,7 @@ namespace
                                 }
                                 else
                                 {
-                                    TEXP_LEGACY_FORMAT lformat = _FindLegacyFormat(convFlags);
+                                    TEXP_LEGACY_FORMAT lformat = FindLegacyFormat(convFlags);
                                     if (!LegacyExpandScanline(pDest, dpitch, metadata.format,
                                         pSrc, spitch, lformat, pal8,
                                         tflags))
@@ -1383,12 +1384,12 @@ namespace
                             }
                             else if (convFlags & CONV_FLAGS_SWIZZLE)
                             {
-                                _SwizzleScanline(pDest, dpitch, pSrc, spitch,
+                                SwizzleScanline(pDest, dpitch, pSrc, spitch,
                                     metadata.format, tflags);
                             }
                             else
                             {
-                                _CopyScanline(pDest, dpitch, pSrc, spitch,
+                                CopyScanline(pDest, dpitch, pSrc, spitch,
                                     metadata.format, tflags);
                             }
 
@@ -1459,7 +1460,7 @@ namespace
                             {
                                 if (convFlags & (CONV_FLAGS_565 | CONV_FLAGS_5551 | CONV_FLAGS_4444))
                                 {
-                                    if (!_ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
+                                    if (!ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
                                         pSrc, spitch,
                                         (convFlags & CONV_FLAGS_565) ? DXGI_FORMAT_B5G6R5_UNORM : DXGI_FORMAT_B5G5R5A1_UNORM,
                                         tflags))
@@ -1467,7 +1468,7 @@ namespace
                                 }
                                 else
                                 {
-                                    TEXP_LEGACY_FORMAT lformat = _FindLegacyFormat(convFlags);
+                                    TEXP_LEGACY_FORMAT lformat = FindLegacyFormat(convFlags);
                                     if (!LegacyExpandScanline(pDest, dpitch, metadata.format,
                                         pSrc, spitch, lformat, pal8,
                                         tflags))
@@ -1476,11 +1477,11 @@ namespace
                             }
                             else if (convFlags & CONV_FLAGS_SWIZZLE)
                             {
-                                _SwizzleScanline(pDest, dpitch, pSrc, spitch, metadata.format, tflags);
+                                SwizzleScanline(pDest, dpitch, pSrc, spitch, metadata.format, tflags);
                             }
                             else
                             {
-                                _CopyScanline(pDest, dpitch, pSrc, spitch, metadata.format, tflags);
+                                CopyScanline(pDest, dpitch, pSrc, spitch, metadata.format, tflags);
                             }
 
                             pSrc += spitch;
@@ -1533,11 +1534,11 @@ namespace
             {
                 if (convFlags & CONV_FLAGS_SWIZZLE)
                 {
-                    _SwizzleScanline(pPixels, rowPitch, pPixels, rowPitch, metadata.format, tflags);
+                    SwizzleScanline(pPixels, rowPitch, pPixels, rowPitch, metadata.format, tflags);
                 }
                 else
                 {
-                    _CopyScanline(pPixels, rowPitch, pPixels, rowPitch, metadata.format, tflags);
+                    CopyScanline(pPixels, rowPitch, pPixels, rowPitch, metadata.format, tflags);
                 }
 
                 pPixels += rowPitch;
@@ -1992,7 +1993,7 @@ HRESULT DirectX::SaveToDDSMemory(
 
     // Determine memory required
     size_t required = 0;
-    HRESULT hr = _EncodeDDSHeader(metadata, flags, nullptr, 0, required);
+    HRESULT hr = EncodeDDSHeader(metadata, flags, nullptr, 0, required);
     if (FAILED(hr))
         return hr;
 
@@ -2033,7 +2034,7 @@ HRESULT DirectX::SaveToDDSMemory(
     auto pDestination = static_cast<uint8_t*>(blob.GetBufferPointer());
     assert(pDestination);
 
-    hr = _EncodeDDSHeader(metadata, flags, pDestination, blob.GetBufferSize(), required);
+    hr = EncodeDDSHeader(metadata, flags, pDestination, blob.GetBufferSize(), required);
     if (FAILED(hr))
     {
         blob.Release();
@@ -2083,16 +2084,22 @@ HRESULT DirectX::SaveToDDSMemory(
                         return hr;
                     }
 
-                    size_t rowPitch = images[index].rowPitch;
+                    const size_t rowPitch = images[index].rowPitch;
 
                     const uint8_t * __restrict sPtr = images[index].pixels;
                     uint8_t * __restrict dPtr = pDestination;
 
-                    size_t lines = ComputeScanlines(metadata.format, images[index].height);
-                    size_t csize = std::min<size_t>(rowPitch, ddsRowPitch);
+                    const size_t lines = ComputeScanlines(metadata.format, images[index].height);
+                    const size_t csize = std::min<size_t>(rowPitch, ddsRowPitch);
                     size_t tremaining = remaining;
                     for (size_t j = 0; j < lines; ++j)
                     {
+                        if (tremaining < csize)
+                        {
+                            blob.Release();
+                            return E_FAIL;
+                        }
+
                         memcpy(dPtr, sPtr, csize);
 
                         sPtr += rowPitch;
@@ -2149,16 +2156,22 @@ HRESULT DirectX::SaveToDDSMemory(
                         return hr;
                     }
 
-                    size_t rowPitch = images[index].rowPitch;
+                    const size_t rowPitch = images[index].rowPitch;
 
                     const uint8_t * __restrict sPtr = images[index].pixels;
                     uint8_t * __restrict dPtr = pDestination;
 
-                    size_t lines = ComputeScanlines(metadata.format, images[index].height);
-                    size_t csize = std::min<size_t>(rowPitch, ddsRowPitch);
+                    const size_t lines = ComputeScanlines(metadata.format, images[index].height);
+                    const size_t csize = std::min<size_t>(rowPitch, ddsRowPitch);
                     size_t tremaining = remaining;
                     for (size_t j = 0; j < lines; ++j)
                     {
+                        if (tremaining < csize)
+                        {
+                            blob.Release();
+                            return E_FAIL;
+                        }
+
                         memcpy(dPtr, sPtr, csize);
 
                         sPtr += rowPitch;
@@ -2206,7 +2219,7 @@ HRESULT DirectX::SaveToDDSFile(
     const size_t MAX_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
     uint8_t header[MAX_HEADER_SIZE];
     size_t required;
-    HRESULT hr = _EncodeDDSHeader(metadata, flags, header, MAX_HEADER_SIZE, required);
+    HRESULT hr = EncodeDDSHeader(metadata, flags, header, MAX_HEADER_SIZE, required);
     if (FAILED(hr))
         return hr;
 

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -559,7 +559,7 @@ namespace
 // Encodes DDS file header (magic value, header, optional DX10 extended header)
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-HRESULT DirectX::Internal::EncodeDDSHeader(
+HRESULT DirectX::EncodeDDSHeader(
     const TexMetadata& metadata,
     DDS_FLAGS flags,
     void* pDestination,

--- a/DirectXTex/DirectXTexFlipRotate.cpp
+++ b/DirectXTex/DirectXTexFlipRotate.cpp
@@ -12,6 +12,7 @@
 #include "DirectXTexP.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 using Microsoft::WRL::ComPtr;
 
 namespace
@@ -100,7 +101,7 @@ namespace
         assert(srcImage.format == destImage.format);
 
         ScratchImage temp;
-        HRESULT hr = _ConvertToR16G16B16A16(srcImage, temp);
+        HRESULT hr = ConvertToR16G16B16A16(srcImage, temp);
         if (FAILED(hr))
             return hr;
 
@@ -123,7 +124,7 @@ namespace
 
         temp.Release();
 
-        hr = _ConvertFromR16G16B16A16(*tdest, destImage);
+        hr = ConvertFromR16G16B16A16(*tdest, destImage);
         if (FAILED(hr))
             return hr;
 
@@ -142,7 +143,7 @@ namespace
         assert(srcImage.format == destImage.format);
 
         ScratchImage temp;
-        HRESULT hr = _ConvertToR32G32B32A32(srcImage, temp);
+        HRESULT hr = ConvertToR32G32B32A32(srcImage, temp);
         if (FAILED(hr))
             return hr;
 
@@ -165,7 +166,7 @@ namespace
 
         temp.Release();
 
-        hr = _ConvertFromR32G32B32A32(*tdest, destImage);
+        hr = ConvertFromR32G32B32A32(*tdest, destImage);
         if (FAILED(hr))
             return hr;
 
@@ -245,7 +246,7 @@ HRESULT DirectX::FlipRotate(
     }
 
     WICPixelFormatGUID pfGUID;
-    if (_DXGIToWIC(srcImage.format, pfGUID))
+    if (DXGIToWIC(srcImage.format, pfGUID))
     {
         // Case 1: Source format is supported by Windows Imaging Component
         hr = PerformFlipRotateUsingWIC(srcImage, flags, pfGUID, *rimage);
@@ -345,7 +346,7 @@ HRESULT DirectX::FlipRotate(
     }
 
     WICPixelFormatGUID pfGUID;
-    bool wicpf = _DXGIToWIC(metadata.format, pfGUID);
+    bool wicpf = DXGIToWIC(metadata.format, pfGUID);
 
     for (size_t index = 0; index < nimages; ++index)
     {

--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -11,14 +11,8 @@
 
 #include "DirectXTexP.h"
 
-namespace DirectX
-{
-    extern bool _CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept;
-    extern bool _CalculateMipLevels3D(_In_ size_t width, _In_ size_t height, _In_ size_t depth, _Inout_ size_t& mipLevels) noexcept;
-    extern bool _IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept;
-}
-
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 #ifndef WIN32
 namespace
@@ -37,7 +31,7 @@ namespace
 // Determines number of image array entries and pixel size
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-bool DirectX::_DetermineImageArray(
+bool DirectX::Internal::DetermineImageArray(
     const TexMetadata& metadata,
     CP_FLAGS cpFlags,
     size_t& nImages,
@@ -140,7 +134,7 @@ bool DirectX::_DetermineImageArray(
 // Fills in the image array entries
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-bool DirectX::_SetupImageArray(
+bool DirectX::Internal::SetupImageArray(
     uint8_t *pMemory,
     size_t pixelSize,
     const TexMetadata& metadata,
@@ -311,7 +305,7 @@ HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexc
         if (!mdata.width || mdata.height != 1 || mdata.depth != 1 || !mdata.arraySize)
             return E_INVALIDARG;
 
-        if (!_CalculateMipLevels(mdata.width, 1, mipLevels))
+        if (!CalculateMipLevels(mdata.width, 1, mipLevels))
             return E_INVALIDARG;
         break;
 
@@ -325,7 +319,7 @@ HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexc
                 return E_INVALIDARG;
         }
 
-        if (!_CalculateMipLevels(mdata.width, mdata.height, mipLevels))
+        if (!CalculateMipLevels(mdata.width, mdata.height, mipLevels))
             return E_INVALIDARG;
         break;
 
@@ -333,7 +327,7 @@ HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexc
         if (!mdata.width || !mdata.height || !mdata.depth || mdata.arraySize != 1)
             return E_INVALIDARG;
 
-        if (!_CalculateMipLevels3D(mdata.width, mdata.height, mdata.depth, mipLevels))
+        if (!CalculateMipLevels3D(mdata.width, mdata.height, mdata.depth, mipLevels))
             return E_INVALIDARG;
         break;
 
@@ -354,7 +348,7 @@ HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexc
     m_metadata.dimension = mdata.dimension;
 
     size_t pixelSize, nimages;
-    if (!_DetermineImageArray(m_metadata, flags, nimages, pixelSize))
+    if (!DetermineImageArray(m_metadata, flags, nimages, pixelSize))
         return HRESULT_E_ARITHMETIC_OVERFLOW;
 
     m_image = new (std::nothrow) Image[nimages];
@@ -371,7 +365,7 @@ HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexc
         return E_OUTOFMEMORY;
     }
     m_size = pixelSize;
-    if (!_SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
+    if (!SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
     {
         Release();
         return E_FAIL;
@@ -405,7 +399,7 @@ HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height,
     if (IsPalettized(fmt))
         return HRESULT_E_NOT_SUPPORTED;
 
-    if (!_CalculateMipLevels(width, height, mipLevels))
+    if (!CalculateMipLevels(width, height, mipLevels))
         return E_INVALIDARG;
 
     Release();
@@ -421,7 +415,7 @@ HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height,
     m_metadata.dimension = TEX_DIMENSION_TEXTURE2D;
 
     size_t pixelSize, nimages;
-    if (!_DetermineImageArray(m_metadata, flags, nimages, pixelSize))
+    if (!DetermineImageArray(m_metadata, flags, nimages, pixelSize))
         return HRESULT_E_ARITHMETIC_OVERFLOW;
 
     m_image = new (std::nothrow) Image[nimages];
@@ -438,7 +432,7 @@ HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height,
         return E_OUTOFMEMORY;
     }
     m_size = pixelSize;
-    if (!_SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
+    if (!SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
     {
         Release();
         return E_FAIL;
@@ -456,7 +450,7 @@ HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height,
     if (IsPalettized(fmt))
         return HRESULT_E_NOT_SUPPORTED;
 
-    if (!_CalculateMipLevels3D(width, height, depth, mipLevels))
+    if (!CalculateMipLevels3D(width, height, depth, mipLevels))
         return E_INVALIDARG;
 
     Release();
@@ -472,7 +466,7 @@ HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height,
     m_metadata.dimension = TEX_DIMENSION_TEXTURE3D;
 
     size_t pixelSize, nimages;
-    if (!_DetermineImageArray(m_metadata, flags, nimages, pixelSize))
+    if (!DetermineImageArray(m_metadata, flags, nimages, pixelSize))
         return HRESULT_E_ARITHMETIC_OVERFLOW;
 
     m_image = new (std::nothrow) Image[nimages];
@@ -492,7 +486,7 @@ HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height,
     }
     m_size = pixelSize;
 
-    if (!_SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
+    if (!SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
     {
         Release();
         return E_FAIL;
@@ -793,7 +787,7 @@ bool ScratchImage::IsAlphaAllOpaque() const noexcept
     {
         for (size_t index = 0; index < m_nimages; ++index)
         {
-            if (!_IsAlphaAllOpaqueBC(m_image[index]))
+            if (!IsAlphaAllOpaqueBC(m_image[index]))
                 return false;
         }
     }
@@ -815,7 +809,7 @@ bool ScratchImage::IsAlphaAllOpaque() const noexcept
 
             for (size_t h = 0; h < img.height; ++h)
             {
-                if (!_LoadScanline(scanline.get(), img.width, pPixels, img.rowPitch, img.format))
+                if (!LoadScanline(scanline.get(), img.width, pPixels, img.rowPitch, img.format))
                     return false;
 
                 const XMVECTOR* ptr = scanline.get();

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -14,6 +14,7 @@
 #include "filters.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 using Microsoft::WRL::ComPtr;
 
 namespace
@@ -104,7 +105,8 @@ namespace
 
                 if (SUCCEEDED(hr))
                 {
-                    hr = converter->Initialize(src, desiredPixelFormat, _GetWICDither(filter), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+                    hr = converter->Initialize(src, desiredPixelFormat, GetWICDither(filter), nullptr,
+                        0, WICBitmapPaletteTypeMedianCut);
                 }
 
                 if (SUCCEEDED(hr))
@@ -160,7 +162,7 @@ namespace
 
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+            if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
             {
                 return E_FAIL;
             }
@@ -173,7 +175,7 @@ namespace
                 *(ptr++) = XMVectorSelect(alpha, v, g_XMSelect1110);
             }
 
-            if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
             {
                 return E_FAIL;
             }
@@ -242,13 +244,13 @@ namespace
         size_t coverageCount = 0;
         for (size_t y = 0; y < srcImage.height - 1; ++y)
         {
-            if (!_LoadScanlineLinear(row0.get(), srcImage.width, pSrcRow0, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
+            if (!LoadScanlineLinear(row0.get(), srcImage.width, pSrcRow0, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
             {
                 return E_FAIL;
             }
 
             const uint8_t *pSrcRow1 = pSrcRow0 + srcImage.rowPitch;
-            if (!_LoadScanlineLinear(row1.get(), srcImage.width, pSrcRow1, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
+            if (!LoadScanlineLinear(row1.get(), srcImage.width, pSrcRow1, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
             {
                 return E_FAIL;
             }
@@ -343,276 +345,271 @@ namespace
     }
 }
 
-
-namespace DirectX
+_Use_decl_annotations_
+bool DirectX::Internal::CalculateMipLevels(
+    size_t width,
+    size_t height,
+    size_t& mipLevels) noexcept
 {
-    bool _CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept;
-    bool _CalculateMipLevels3D(_In_ size_t width, _In_ size_t height, _In_ size_t depth, _Inout_ size_t& mipLevels) noexcept;
-        // Also used by Compress
+    if (mipLevels > 1)
+    {
+        size_t maxMips = CountMips(width, height);
+        if (mipLevels > maxMips)
+            return false;
+    }
+    else if (mipLevels == 0)
+    {
+        mipLevels = CountMips(width, height);
+    }
+    else
+    {
+        mipLevels = 1;
+    }
+    return true;
+}
+
+_Use_decl_annotations_
+bool DirectX::Internal::CalculateMipLevels3D(
+    size_t width,
+    size_t height,
+    size_t depth,
+    size_t& mipLevels) noexcept
+{
+    if (mipLevels > 1)
+    {
+        size_t maxMips = CountMips3D(width, height, depth);
+        if (mipLevels > maxMips)
+            return false;
+    }
+    else if (mipLevels == 0)
+    {
+        mipLevels = CountMips3D(width, height, depth);
+    }
+    else
+    {
+        mipLevels = 1;
+    }
+    return true;
+}
 
 #ifdef WIN32
-    HRESULT _ResizeSeparateColorAndAlpha(_In_ IWICImagingFactory* pWIC, _In_ bool iswic2, _In_ IWICBitmap* original,
-        _In_ size_t newWidth, _In_ size_t newHeight, _In_ TEX_FILTER_FLAGS filter, _Inout_ const Image* img) noexcept;
-        // Also used by Resize
-#endif
+//--- Resizing color and alpha channels separately using WIC ---
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ResizeSeparateColorAndAlpha(
+    IWICImagingFactory* pWIC,
+    bool iswic2,
+    IWICBitmap* original,
+    size_t newWidth,
+    size_t newHeight,
+    TEX_FILTER_FLAGS filter,
+    const Image* img) noexcept
+{
+    if (!pWIC || !original || !img)
+        return E_POINTER;
 
-    bool _CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept
+    const WICBitmapInterpolationMode interpolationMode = GetWICInterp(filter);
+
+    WICPixelFormatGUID desiredPixelFormat = GUID_WICPixelFormatUndefined;
+    HRESULT hr = original->GetPixelFormat(&desiredPixelFormat);
+
+    size_t colorBytesInPixel = 0;
+    size_t colorBytesPerPixel = 0;
+    size_t colorWithAlphaBytesPerPixel = 0;
+    WICPixelFormatGUID colorPixelFormat = GUID_WICPixelFormatUndefined;
+    WICPixelFormatGUID colorWithAlphaPixelFormat = GUID_WICPixelFormatUndefined;
+
+    if (SUCCEEDED(hr))
     {
-        if (mipLevels > 1)
-        {
-            size_t maxMips = CountMips(width, height);
-            if (mipLevels > maxMips)
-                return false;
-        }
-        else if (mipLevels == 0)
-        {
-            mipLevels = CountMips(width, height);
-        }
-        else
-        {
-            mipLevels = 1;
-        }
-        return true;
-    }
+        ComPtr<IWICComponentInfo> componentInfo;
+        hr = pWIC->CreateComponentInfo(desiredPixelFormat, componentInfo.GetAddressOf());
 
-    bool _CalculateMipLevels3D(_In_ size_t width, _In_ size_t height, _In_ size_t depth, _Inout_ size_t& mipLevels) noexcept
-    {
-        if (mipLevels > 1)
+        ComPtr<IWICPixelFormatInfo> pixelFormatInfo;
+        if (SUCCEEDED(hr))
         {
-            size_t maxMips = CountMips3D(width, height, depth);
-            if (mipLevels > maxMips)
-                return false;
+            hr = componentInfo.As(&pixelFormatInfo);
         }
-        else if (mipLevels == 0)
+
+        UINT bitsPerPixel = 0;
+        if (SUCCEEDED(hr))
         {
-            mipLevels = CountMips3D(width, height, depth);
+            hr = pixelFormatInfo->GetBitsPerPixel(&bitsPerPixel);
         }
-        else
-        {
-            mipLevels = 1;
-        }
-        return true;
-    }
-
-#ifdef WIN32
-    //--- Resizing color and alpha channels separately using WIC ---
-    _Use_decl_annotations_
-    HRESULT _ResizeSeparateColorAndAlpha(
-        IWICImagingFactory* pWIC,
-        bool iswic2,
-        IWICBitmap* original,
-        size_t newWidth,
-        size_t newHeight,
-        TEX_FILTER_FLAGS filter,
-        const Image* img) noexcept
-    {
-        if (!pWIC || !original || !img)
-            return E_POINTER;
-
-        const WICBitmapInterpolationMode interpolationMode = _GetWICInterp(filter);
-
-        WICPixelFormatGUID desiredPixelFormat = GUID_WICPixelFormatUndefined;
-        HRESULT hr = original->GetPixelFormat(&desiredPixelFormat);
-
-        size_t colorBytesInPixel = 0;
-        size_t colorBytesPerPixel = 0;
-        size_t colorWithAlphaBytesPerPixel = 0;
-        WICPixelFormatGUID colorPixelFormat = GUID_WICPixelFormatUndefined;
-        WICPixelFormatGUID colorWithAlphaPixelFormat = GUID_WICPixelFormatUndefined;
 
         if (SUCCEEDED(hr))
         {
-            ComPtr<IWICComponentInfo> componentInfo;
-            hr = pWIC->CreateComponentInfo(desiredPixelFormat, componentInfo.GetAddressOf());
-
-            ComPtr<IWICPixelFormatInfo> pixelFormatInfo;
-            if (SUCCEEDED(hr))
+            if (bitsPerPixel <= 32)
             {
-                hr = componentInfo.As(&pixelFormatInfo);
+                colorBytesInPixel = colorBytesPerPixel = 3;
+                colorPixelFormat = GUID_WICPixelFormat24bppBGR;
+
+                colorWithAlphaBytesPerPixel = 4;
+                colorWithAlphaPixelFormat = GUID_WICPixelFormat32bppBGRA;
             }
-
-            UINT bitsPerPixel = 0;
-            if (SUCCEEDED(hr))
+            else
             {
-                hr = pixelFormatInfo->GetBitsPerPixel(&bitsPerPixel);
-            }
-
-            if (SUCCEEDED(hr))
-            {
-                if (bitsPerPixel <= 32)
+#if(_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+                if (iswic2)
                 {
-                    colorBytesInPixel = colorBytesPerPixel = 3;
-                    colorPixelFormat = GUID_WICPixelFormat24bppBGR;
+                    colorBytesInPixel = colorBytesPerPixel = 12;
+                    colorPixelFormat = GUID_WICPixelFormat96bppRGBFloat;
+                }
+                else
+#else
+                UNREFERENCED_PARAMETER(iswic2);
+#endif
+                {
+                    colorBytesInPixel = 12;
+                    colorBytesPerPixel = 16;
+                    colorPixelFormat = GUID_WICPixelFormat128bppRGBFloat;
+                }
 
-                    colorWithAlphaBytesPerPixel = 4;
-                    colorWithAlphaPixelFormat = GUID_WICPixelFormat32bppBGRA;
+                colorWithAlphaBytesPerPixel = 16;
+                colorWithAlphaPixelFormat = GUID_WICPixelFormat128bppRGBAFloat;
+            }
+        }
+    }
+
+    // Resize color only image (no alpha channel)
+    ComPtr<IWICBitmap> resizedColor;
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICBitmapScaler> colorScaler;
+        hr = pWIC->CreateBitmapScaler(colorScaler.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> converted;
+            hr = EnsureWicBitmapPixelFormat(pWIC, original, filter, colorPixelFormat, converted.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = colorScaler->Initialize(converted.Get(), static_cast<UINT>(newWidth), static_cast<UINT>(newHeight), interpolationMode);
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> resized;
+            hr = pWIC->CreateBitmapFromSource(colorScaler.Get(), WICBitmapCacheOnDemand, resized.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = EnsureWicBitmapPixelFormat(pWIC, resized.Get(), filter, colorPixelFormat, resizedColor.GetAddressOf());
+            }
+        }
+    }
+
+    // Resize color+alpha image
+    ComPtr<IWICBitmap> resizedColorWithAlpha;
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICBitmapScaler> colorWithAlphaScaler;
+        hr = pWIC->CreateBitmapScaler(colorWithAlphaScaler.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> converted;
+            hr = EnsureWicBitmapPixelFormat(pWIC, original, filter, colorWithAlphaPixelFormat, converted.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = colorWithAlphaScaler->Initialize(converted.Get(), static_cast<UINT>(newWidth), static_cast<UINT>(newHeight), interpolationMode);
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> resized;
+            hr = pWIC->CreateBitmapFromSource(colorWithAlphaScaler.Get(), WICBitmapCacheOnDemand, resized.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = EnsureWicBitmapPixelFormat(pWIC, resized.Get(), filter, colorWithAlphaPixelFormat, resizedColorWithAlpha.GetAddressOf());
+            }
+        }
+    }
+
+    // Merge pixels (copying color channels from color only image to color+alpha image)
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICBitmapLock> colorLock;
+        ComPtr<IWICBitmapLock> colorWithAlphaLock;
+        hr = resizedColor->Lock(nullptr, WICBitmapLockRead, colorLock.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            hr = resizedColorWithAlpha->Lock(nullptr, WICBitmapLockWrite, colorWithAlphaLock.GetAddressOf());
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            WICInProcPointer colorWithAlphaData = nullptr;
+            UINT colorWithAlphaSizeInBytes = 0;
+            UINT colorWithAlphaStride = 0;
+
+            hr = colorWithAlphaLock->GetDataPointer(&colorWithAlphaSizeInBytes, &colorWithAlphaData);
+            if (SUCCEEDED(hr))
+            {
+                if (!colorWithAlphaData)
+                {
+                    hr = E_POINTER;
                 }
                 else
                 {
-#if(_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
-                    if (iswic2)
-                    {
-                        colorBytesInPixel = colorBytesPerPixel = 12;
-                        colorPixelFormat = GUID_WICPixelFormat96bppRGBFloat;
-                    }
-                    else
-#else
-                    UNREFERENCED_PARAMETER(iswic2);
-#endif
-                    {
-                        colorBytesInPixel = 12;
-                        colorBytesPerPixel = 16;
-                        colorPixelFormat = GUID_WICPixelFormat128bppRGBFloat;
-                    }
-
-                    colorWithAlphaBytesPerPixel = 16;
-                    colorWithAlphaPixelFormat = GUID_WICPixelFormat128bppRGBAFloat;
-                }
-            }
-        }
-
-        // Resize color only image (no alpha channel)
-        ComPtr<IWICBitmap> resizedColor;
-        if (SUCCEEDED(hr))
-        {
-            ComPtr<IWICBitmapScaler> colorScaler;
-            hr = pWIC->CreateBitmapScaler(colorScaler.GetAddressOf());
-            if (SUCCEEDED(hr))
-            {
-                ComPtr<IWICBitmap> converted;
-                hr = EnsureWicBitmapPixelFormat(pWIC, original, filter, colorPixelFormat, converted.GetAddressOf());
-                if (SUCCEEDED(hr))
-                {
-                    hr = colorScaler->Initialize(converted.Get(), static_cast<UINT>(newWidth), static_cast<UINT>(newHeight), interpolationMode);
+                    hr = colorWithAlphaLock->GetStride(&colorWithAlphaStride);
                 }
             }
 
+            WICInProcPointer colorData = nullptr;
+            UINT colorSizeInBytes = 0;
+            UINT colorStride = 0;
             if (SUCCEEDED(hr))
             {
-                ComPtr<IWICBitmap> resized;
-                hr = pWIC->CreateBitmapFromSource(colorScaler.Get(), WICBitmapCacheOnDemand, resized.GetAddressOf());
+                hr = colorLock->GetDataPointer(&colorSizeInBytes, &colorData);
                 if (SUCCEEDED(hr))
                 {
-                    hr = EnsureWicBitmapPixelFormat(pWIC, resized.Get(), filter, colorPixelFormat, resizedColor.GetAddressOf());
-                }
-            }
-        }
-
-        // Resize color+alpha image
-        ComPtr<IWICBitmap> resizedColorWithAlpha;
-        if (SUCCEEDED(hr))
-        {
-            ComPtr<IWICBitmapScaler> colorWithAlphaScaler;
-            hr = pWIC->CreateBitmapScaler(colorWithAlphaScaler.GetAddressOf());
-            if (SUCCEEDED(hr))
-            {
-                ComPtr<IWICBitmap> converted;
-                hr = EnsureWicBitmapPixelFormat(pWIC, original, filter, colorWithAlphaPixelFormat, converted.GetAddressOf());
-                if (SUCCEEDED(hr))
-                {
-                    hr = colorWithAlphaScaler->Initialize(converted.Get(), static_cast<UINT>(newWidth), static_cast<UINT>(newHeight), interpolationMode);
-                }
-            }
-
-            if (SUCCEEDED(hr))
-            {
-                ComPtr<IWICBitmap> resized;
-                hr = pWIC->CreateBitmapFromSource(colorWithAlphaScaler.Get(), WICBitmapCacheOnDemand, resized.GetAddressOf());
-                if (SUCCEEDED(hr))
-                {
-                    hr = EnsureWicBitmapPixelFormat(pWIC, resized.Get(), filter, colorWithAlphaPixelFormat, resizedColorWithAlpha.GetAddressOf());
-                }
-            }
-        }
-
-        // Merge pixels (copying color channels from color only image to color+alpha image)
-        if (SUCCEEDED(hr))
-        {
-            ComPtr<IWICBitmapLock> colorLock;
-            ComPtr<IWICBitmapLock> colorWithAlphaLock;
-            hr = resizedColor->Lock(nullptr, WICBitmapLockRead, colorLock.GetAddressOf());
-            if (SUCCEEDED(hr))
-            {
-                hr = resizedColorWithAlpha->Lock(nullptr, WICBitmapLockWrite, colorWithAlphaLock.GetAddressOf());
-            }
-
-            if (SUCCEEDED(hr))
-            {
-                WICInProcPointer colorWithAlphaData = nullptr;
-                UINT colorWithAlphaSizeInBytes = 0;
-                UINT colorWithAlphaStride = 0;
-
-                hr = colorWithAlphaLock->GetDataPointer(&colorWithAlphaSizeInBytes, &colorWithAlphaData);
-                if (SUCCEEDED(hr))
-                {
-                    if (!colorWithAlphaData)
+                    if (!colorData)
                     {
                         hr = E_POINTER;
                     }
                     else
                     {
-                        hr = colorWithAlphaLock->GetStride(&colorWithAlphaStride);
+                        hr = colorLock->GetStride(&colorStride);
                     }
                 }
+            }
 
-                WICInProcPointer colorData = nullptr;
-                UINT colorSizeInBytes = 0;
-                UINT colorStride = 0;
-                if (SUCCEEDED(hr))
+            for (size_t j = 0; SUCCEEDED(hr) && j < newHeight; j++)
+            {
+                for (size_t i = 0; SUCCEEDED(hr) && i < newWidth; i++)
                 {
-                    hr = colorLock->GetDataPointer(&colorSizeInBytes, &colorData);
-                    if (SUCCEEDED(hr))
+                    size_t colorWithAlphaIndex = (j * colorWithAlphaStride) + (i * colorWithAlphaBytesPerPixel);
+                    size_t colorIndex = (j * colorStride) + (i * colorBytesPerPixel);
+
+                    if (((colorWithAlphaIndex + colorBytesInPixel) > colorWithAlphaSizeInBytes)
+                        || ((colorIndex + colorBytesPerPixel) > colorSizeInBytes))
                     {
-                        if (!colorData)
-                        {
-                            hr = E_POINTER;
-                        }
-                        else
-                        {
-                            hr = colorLock->GetStride(&colorStride);
-                        }
+                        hr = E_INVALIDARG;
                     }
-                }
-
-                for (size_t j = 0; SUCCEEDED(hr) && j < newHeight; j++)
-                {
-                    for (size_t i = 0; SUCCEEDED(hr) && i < newWidth; i++)
+                    else
                     {
-                        size_t colorWithAlphaIndex = (j * colorWithAlphaStride) + (i * colorWithAlphaBytesPerPixel);
-                        size_t colorIndex = (j * colorStride) + (i * colorBytesPerPixel);
-
-                        if (((colorWithAlphaIndex + colorBytesInPixel) > colorWithAlphaSizeInBytes)
-                            || ((colorIndex + colorBytesPerPixel) > colorSizeInBytes))
-                        {
-                            hr = E_INVALIDARG;
-                        }
-                        else
-                        {
 #pragma warning( suppress : 26014 6386 ) // No overflow possible here
-                            memcpy_s(colorWithAlphaData + colorWithAlphaIndex, colorWithAlphaBytesPerPixel, colorData + colorIndex, colorBytesInPixel);
-                        }
+                        memcpy_s(colorWithAlphaData + colorWithAlphaIndex, colorWithAlphaBytesPerPixel, colorData + colorIndex, colorBytesInPixel);
                     }
                 }
             }
         }
+    }
 
+    if (SUCCEEDED(hr))
+    {
+        if (img->rowPitch > UINT32_MAX || img->slicePitch > UINT32_MAX)
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+        ComPtr<IWICBitmap> wicBitmap;
+        hr = EnsureWicBitmapPixelFormat(pWIC, resizedColorWithAlpha.Get(), filter, desiredPixelFormat, wicBitmap.GetAddressOf());
         if (SUCCEEDED(hr))
         {
-            if (img->rowPitch > UINT32_MAX || img->slicePitch > UINT32_MAX)
-                return HRESULT_E_ARITHMETIC_OVERFLOW;
-
-            ComPtr<IWICBitmap> wicBitmap;
-            hr = EnsureWicBitmapPixelFormat(pWIC, resizedColorWithAlpha.Get(), filter, desiredPixelFormat, wicBitmap.GetAddressOf());
-            if (SUCCEEDED(hr))
-            {
-                hr = wicBitmap->CopyPixels(nullptr, static_cast<UINT>(img->rowPitch), static_cast<UINT>(img->slicePitch), img->pixels);
-            }
+            hr = wicBitmap->CopyPixels(nullptr, static_cast<UINT>(img->rowPitch), static_cast<UINT>(img->slicePitch), img->pixels);
         }
-
-        return hr;
     }
-#endif // WIN32
+
+    return hr;
 }
+#endif // WIN32
 
 namespace
 {
@@ -770,7 +767,7 @@ namespace
 
             if ((filter & TEX_FILTER_SEPARATE_ALPHA) && supportsTransparency)
             {
-                hr = _ResizeSeparateColorAndAlpha(pWIC, iswic2, source.Get(), width, height, filter, img);
+                hr = ResizeSeparateColorAndAlpha(pWIC, iswic2, source.Get(), width, height, filter, img);
                 if (FAILED(hr))
                     return hr;
             }
@@ -784,7 +781,9 @@ namespace
                 if (img->rowPitch > UINT32_MAX || img->slicePitch > UINT32_MAX)
                     return HRESULT_E_ARITHMETIC_OVERFLOW;
 
-                hr = scaler->Initialize(source.Get(), static_cast<UINT>(width), static_cast<UINT>(height), _GetWICInterp(filter));
+                hr = scaler->Initialize(source.Get(),
+                    static_cast<UINT>(width), static_cast<UINT>(height),
+                    GetWICInterp(filter));
                 if (FAILED(hr))
                     return hr;
 
@@ -815,7 +814,8 @@ namespace
                         return E_UNEXPECTED;
                     }
 
-                    hr = FC->Initialize(scaler.Get(), pfGUID, _GetWICDither(filter), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+                    hr = FC->Initialize(scaler.Get(), pfGUID, GetWICDither(filter), nullptr,
+                        0, WICBitmapPaletteTypeMedianCut);
                     if (FAILED(hr))
                         return hr;
 
@@ -943,7 +943,7 @@ namespace
             {
                 if ((lasty ^ sy) >> 16)
                 {
-                    if (!_LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
+                    if (!LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
                         return E_FAIL;
                     lasty = sy;
                 }
@@ -955,7 +955,7 @@ namespace
                     sx += xinc;
                 }
 
-                if (!_StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
+                if (!StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
                     return E_FAIL;
                 pDest += dest->rowPitch;
 
@@ -976,6 +976,8 @@ namespace
     //--- 2D Box Filter ---
     HRESULT Generate2DMipsBoxFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!mipChain.GetImages())
             return E_INVALIDARG;
 
@@ -1033,13 +1035,13 @@ namespace
 
             for (size_t y = 0; y < nheight; ++y)
             {
-                if (!_LoadScanlineLinear(urow0, width, pSrc, rowPitch, src->format, filter))
+                if (!LoadScanlineLinear(urow0, width, pSrc, rowPitch, src->format, filter))
                     return E_FAIL;
                 pSrc += rowPitch;
 
                 if (urow0 != urow1)
                 {
-                    if (!_LoadScanlineLinear(urow1, width, pSrc, rowPitch, src->format, filter))
+                    if (!LoadScanlineLinear(urow1, width, pSrc, rowPitch, src->format, filter))
                         return E_FAIL;
                     pSrc += rowPitch;
                 }
@@ -1051,7 +1053,7 @@ namespace
                     AVERAGE4(target[x], urow0[x2], urow1[x2], urow2[x2], urow3[x2])
                 }
 
-                if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                     return E_FAIL;
                 pDest += dest->rowPitch;
             }
@@ -1070,6 +1072,8 @@ namespace
     //--- 2D Linear Filter ---
     HRESULT Generate2DMipsLinearFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!mipChain.GetImages())
             return E_INVALIDARG;
 
@@ -1113,10 +1117,10 @@ namespace
             size_t rowPitch = src->rowPitch;
 
             size_t nwidth = (width > 1) ? (width >> 1) : 1;
-            _CreateLinearFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
+            CreateLinearFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
 
             size_t nheight = (height > 1) ? (height >> 1) : 1;
-            _CreateLinearFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
+            CreateLinearFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
 
 #ifdef _DEBUG
             memset(row0, 0xCD, sizeof(XMVECTOR)*width);
@@ -1136,7 +1140,7 @@ namespace
                     {
                         u0 = toY.u0;
 
-                        if (!_LoadScanlineLinear(row0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(row0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
                             return E_FAIL;
                     }
                     else
@@ -1152,7 +1156,7 @@ namespace
                 {
                     u1 = toY.u1;
 
-                    if (!_LoadScanlineLinear(row1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                    if (!LoadScanlineLinear(row1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
                         return E_FAIL;
                 }
 
@@ -1163,7 +1167,7 @@ namespace
                     BILINEAR_INTERPOLATE(target[x], toX, toY, row0, row1)
                 }
 
-                if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                     return E_FAIL;
                 pDest += dest->rowPitch;
             }
@@ -1181,6 +1185,8 @@ namespace
     //--- 2D Cubic Filter ---
     HRESULT Generate2DMipsCubicFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!mipChain.GetImages())
             return E_INVALIDARG;
 
@@ -1226,10 +1232,10 @@ namespace
             size_t rowPitch = src->rowPitch;
 
             size_t nwidth = (width > 1) ? (width >> 1) : 1;
-            _CreateCubicFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
+            CreateCubicFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
 
             size_t nheight = (height > 1) ? (height >> 1) : 1;
-            _CreateCubicFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
+            CreateCubicFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
 
 #ifdef _DEBUG
             memset(row0, 0xCD, sizeof(XMVECTOR)*width);
@@ -1254,7 +1260,7 @@ namespace
                     {
                         u0 = toY.u0;
 
-                        if (!_LoadScanlineLinear(row0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(row0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
                             return E_FAIL;
                     }
                     else if (toY.u0 == u1)
@@ -1287,7 +1293,7 @@ namespace
                     {
                         u1 = toY.u1;
 
-                        if (!_LoadScanlineLinear(row1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(row1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
                             return E_FAIL;
                     }
                     else if (toY.u1 == u2)
@@ -1313,7 +1319,7 @@ namespace
                     {
                         u2 = toY.u2;
 
-                        if (!_LoadScanlineLinear(row2, width, pSrc + (rowPitch * u2), rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(row2, width, pSrc + (rowPitch * u2), rowPitch, src->format, filter))
                             return E_FAIL;
                     }
                     else
@@ -1330,7 +1336,7 @@ namespace
                 {
                     u3 = toY.u3;
 
-                    if (!_LoadScanlineLinear(row3, width, pSrc + (rowPitch * u3), rowPitch, src->format, filter))
+                    if (!LoadScanlineLinear(row3, width, pSrc + (rowPitch * u3), rowPitch, src->format, filter))
                         return E_FAIL;
                 }
 
@@ -1348,7 +1354,7 @@ namespace
                     CUBIC_INTERPOLATE(target[x], toY.x, C0, C1, C2, C3)
                 }
 
-                if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                     return E_FAIL;
                 pDest += dest->rowPitch;
             }
@@ -1367,10 +1373,10 @@ namespace
     //--- 2D Triangle Filter ---
     HRESULT Generate2DMipsTriangleFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!mipChain.GetImages())
             return E_INVALIDARG;
-
-        using namespace TriangleFilter;
 
         // This assumes that the base image is already placed into the mipChain at the top level... (see _Setup2DMips)
 
@@ -1411,12 +1417,12 @@ namespace
             uint8_t* pDest = dest->pixels;
 
             size_t nwidth = (width > 1) ? (width >> 1) : 1;
-            HRESULT hr = _Create(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
+            HRESULT hr = CreateTriangleFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
             if (FAILED(hr))
                 return hr;
 
             size_t nheight = (height > 1) ? (height >> 1) : 1;
-            hr = _Create(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
+            hr = CreateTriangleFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
             if (FAILED(hr))
                 return hr;
 
@@ -1483,7 +1489,7 @@ namespace
                 if ((pSrc + rowPitch) > pEndSrc)
                     return E_FAIL;
 
-                if (!_LoadScanlineLinear(row, width, pSrc, rowPitch, src->format, filter))
+                if (!LoadScanlineLinear(row, width, pSrc, rowPitch, src->format, filter))
                     return E_FAIL;
 
                 pSrc += rowPitch;
@@ -1555,7 +1561,7 @@ namespace
                         }
 
                         // This performs any required clamping
-                        if (!_StoreScanlineLinear(pDest + (dest->rowPitch * v), dest->rowPitch, dest->format, pAccSrc, dest->width, filter))
+                        if (!StoreScanlineLinear(pDest + (dest->rowPitch * v), dest->rowPitch, dest->format, pAccSrc, dest->width, filter))
                             return E_FAIL;
 
                         // Put row on freelist to reuse it's allocated scanline
@@ -1698,7 +1704,7 @@ namespace
                     {
                         if ((lasty ^ sy) >> 16)
                         {
-                            if (!_LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
+                            if (!LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
                                 return E_FAIL;
                             lasty = sy;
                         }
@@ -1710,7 +1716,7 @@ namespace
                             sx += xinc;
                         }
 
-                        if (!_StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
+                        if (!StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
                             return E_FAIL;
                         pDest += dest->rowPitch;
 
@@ -1747,7 +1753,7 @@ namespace
                 {
                     if ((lasty ^ sy) >> 16)
                     {
-                        if (!_LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
+                        if (!LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
                             return E_FAIL;
                         lasty = sy;
                     }
@@ -1759,7 +1765,7 @@ namespace
                         sx += xinc;
                     }
 
-                    if (!_StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
+                    if (!StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
                         return E_FAIL;
                     pDest += dest->rowPitch;
 
@@ -1784,6 +1790,8 @@ namespace
     //--- 3D Box Filter ---
     HRESULT Generate3DMipsBoxFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
 
@@ -1860,24 +1868,24 @@ namespace
 
                     for (size_t y = 0; y < nheight; ++y)
                     {
-                        if (!_LoadScanlineLinear(urow0, width, pSrc1, aRowPitch, srca->format, filter))
+                        if (!LoadScanlineLinear(urow0, width, pSrc1, aRowPitch, srca->format, filter))
                             return E_FAIL;
                         pSrc1 += aRowPitch;
 
                         if (urow0 != urow1)
                         {
-                            if (!_LoadScanlineLinear(urow1, width, pSrc1, aRowPitch, srca->format, filter))
+                            if (!LoadScanlineLinear(urow1, width, pSrc1, aRowPitch, srca->format, filter))
                                 return E_FAIL;
                             pSrc1 += aRowPitch;
                         }
 
-                        if (!_LoadScanlineLinear(vrow0, width, pSrc2, bRowPitch, srcb->format, filter))
+                        if (!LoadScanlineLinear(vrow0, width, pSrc2, bRowPitch, srcb->format, filter))
                             return E_FAIL;
                         pSrc2 += bRowPitch;
 
                         if (vrow0 != vrow1)
                         {
-                            if (!_LoadScanlineLinear(vrow1, width, pSrc2, bRowPitch, srcb->format, filter))
+                            if (!LoadScanlineLinear(vrow1, width, pSrc2, bRowPitch, srcb->format, filter))
                                 return E_FAIL;
                             pSrc2 += bRowPitch;
                         }
@@ -1890,7 +1898,7 @@ namespace
                                 vrow0[x2], vrow1[x2], vrow2[x2], vrow3[x2])
                         }
 
-                        if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                        if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                             return E_FAIL;
                         pDest += dest->rowPitch;
                     }
@@ -1915,13 +1923,13 @@ namespace
 
                 for (size_t y = 0; y < nheight; ++y)
                 {
-                    if (!_LoadScanlineLinear(urow0, width, pSrc, rowPitch, src->format, filter))
+                    if (!LoadScanlineLinear(urow0, width, pSrc, rowPitch, src->format, filter))
                         return E_FAIL;
                     pSrc += rowPitch;
 
                     if (urow0 != urow1)
                     {
-                        if (!_LoadScanlineLinear(urow1, width, pSrc, rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(urow1, width, pSrc, rowPitch, src->format, filter))
                             return E_FAIL;
                         pSrc += rowPitch;
                     }
@@ -1933,7 +1941,7 @@ namespace
                         AVERAGE4(target[x], urow0[x2], urow1[x2], urow2[x2], urow3[x2])
                     }
 
-                    if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                    if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                         return E_FAIL;
                     pDest += dest->rowPitch;
                 }
@@ -1956,6 +1964,8 @@ namespace
     //--- 3D Linear Filter ---
     HRESULT Generate3DMipsLinearFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
 
@@ -1990,10 +2000,10 @@ namespace
         for (size_t level = 1; level < levels; ++level)
         {
             size_t nwidth = (width > 1) ? (width >> 1) : 1;
-            _CreateLinearFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
+            CreateLinearFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
 
             size_t nheight = (height > 1) ? (height >> 1) : 1;
-            _CreateLinearFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
+            CreateLinearFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
 
 #ifdef _DEBUG
             memset(urow0, 0xCD, sizeof(XMVECTOR)*width);
@@ -2006,7 +2016,7 @@ namespace
             {
                 // 3D linear filter
                 size_t ndepth = depth >> 1;
-                _CreateLinearFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, lfZ);
+                CreateLinearFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, lfZ);
 
                 for (size_t slice = 0; slice < ndepth; ++slice)
                 {
@@ -2036,8 +2046,8 @@ namespace
                             {
                                 u0 = toY.u0;
 
-                                if (!_LoadScanlineLinear(urow0, width, srca->pixels + (srca->rowPitch * u0), srca->rowPitch, srca->format, filter)
-                                    || !_LoadScanlineLinear(vrow0, width, srcb->pixels + (srcb->rowPitch * u0), srcb->rowPitch, srcb->format, filter))
+                                if (!LoadScanlineLinear(urow0, width, srca->pixels + (srca->rowPitch * u0), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(vrow0, width, srcb->pixels + (srcb->rowPitch * u0), srcb->rowPitch, srcb->format, filter))
                                     return E_FAIL;
                             }
                             else
@@ -2054,8 +2064,8 @@ namespace
                         {
                             u1 = toY.u1;
 
-                            if (!_LoadScanlineLinear(urow1, width, srca->pixels + (srca->rowPitch * u1), srca->rowPitch, srca->format, filter)
-                                || !_LoadScanlineLinear(vrow1, width, srcb->pixels + (srcb->rowPitch * u1), srcb->rowPitch, srcb->format, filter))
+                            if (!LoadScanlineLinear(urow1, width, srca->pixels + (srca->rowPitch * u1), srca->rowPitch, srca->format, filter)
+                                || !LoadScanlineLinear(vrow1, width, srcb->pixels + (srcb->rowPitch * u1), srcb->rowPitch, srcb->format, filter))
                                 return E_FAIL;
                         }
 
@@ -2066,7 +2076,7 @@ namespace
                             TRILINEAR_INTERPOLATE(target[x], toX, toY, toZ, urow0, urow1, vrow0, vrow1)
                         }
 
-                        if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                        if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                             return E_FAIL;
                         pDest += dest->rowPitch;
                     }
@@ -2099,7 +2109,7 @@ namespace
                         {
                             u0 = toY.u0;
 
-                            if (!_LoadScanlineLinear(urow0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                            if (!LoadScanlineLinear(urow0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
                                 return E_FAIL;
                         }
                         else
@@ -2115,7 +2125,7 @@ namespace
                     {
                         u1 = toY.u1;
 
-                        if (!_LoadScanlineLinear(urow1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(urow1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
                             return E_FAIL;
                     }
 
@@ -2126,7 +2136,7 @@ namespace
                         BILINEAR_INTERPOLATE(target[x], toX, toY, urow0, urow1)
                     }
 
-                    if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                    if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                         return E_FAIL;
                     pDest += dest->rowPitch;
                 }
@@ -2149,6 +2159,8 @@ namespace
     //--- 3D Cubic Filter ---
     HRESULT Generate3DMipsCubicFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
 
@@ -2192,10 +2204,10 @@ namespace
         for (size_t level = 1; level < levels; ++level)
         {
             size_t nwidth = (width > 1) ? (width >> 1) : 1;
-            _CreateCubicFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
+            CreateCubicFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
 
             size_t nheight = (height > 1) ? (height >> 1) : 1;
-            _CreateCubicFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
+            CreateCubicFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
 
 #ifdef _DEBUG
             for (size_t j = 0; j < 4; ++j)
@@ -2211,7 +2223,7 @@ namespace
             {
                 // 3D cubic filter
                 size_t ndepth = depth >> 1;
-                _CreateCubicFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, (filter & TEX_FILTER_MIRROR_W) != 0, cfZ);
+                CreateCubicFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, (filter & TEX_FILTER_MIRROR_W) != 0, cfZ);
 
                 for (size_t slice = 0; slice < ndepth; ++slice)
                 {
@@ -2246,10 +2258,10 @@ namespace
                             {
                                 u0 = toY.u0;
 
-                                if (!_LoadScanlineLinear(urow[0], width, srca->pixels + (srca->rowPitch * u0), srca->rowPitch, srca->format, filter)
-                                    || !_LoadScanlineLinear(urow[1], width, srcb->pixels + (srcb->rowPitch * u0), srcb->rowPitch, srcb->format, filter)
-                                    || !_LoadScanlineLinear(urow[2], width, srcc->pixels + (srcc->rowPitch * u0), srcc->rowPitch, srcc->format, filter)
-                                    || !_LoadScanlineLinear(urow[3], width, srcd->pixels + (srcd->rowPitch * u0), srcd->rowPitch, srcd->format, filter))
+                                if (!LoadScanlineLinear(urow[0], width, srca->pixels + (srca->rowPitch * u0), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(urow[1], width, srcb->pixels + (srcb->rowPitch * u0), srcb->rowPitch, srcb->format, filter)
+                                    || !LoadScanlineLinear(urow[2], width, srcc->pixels + (srcc->rowPitch * u0), srcc->rowPitch, srcc->format, filter)
+                                    || !LoadScanlineLinear(urow[3], width, srcd->pixels + (srcd->rowPitch * u0), srcd->rowPitch, srcd->format, filter))
                                     return E_FAIL;
                             }
                             else if (toY.u0 == u1)
@@ -2291,10 +2303,10 @@ namespace
                             {
                                 u1 = toY.u1;
 
-                                if (!_LoadScanlineLinear(vrow[0], width, srca->pixels + (srca->rowPitch * u1), srca->rowPitch, srca->format, filter)
-                                    || !_LoadScanlineLinear(vrow[1], width, srcb->pixels + (srcb->rowPitch * u1), srcb->rowPitch, srcb->format, filter)
-                                    || !_LoadScanlineLinear(vrow[2], width, srcc->pixels + (srcc->rowPitch * u1), srcc->rowPitch, srcc->format, filter)
-                                    || !_LoadScanlineLinear(vrow[3], width, srcd->pixels + (srcd->rowPitch * u1), srcd->rowPitch, srcd->format, filter))
+                                if (!LoadScanlineLinear(vrow[0], width, srca->pixels + (srca->rowPitch * u1), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(vrow[1], width, srcb->pixels + (srcb->rowPitch * u1), srcb->rowPitch, srcb->format, filter)
+                                    || !LoadScanlineLinear(vrow[2], width, srcc->pixels + (srcc->rowPitch * u1), srcc->rowPitch, srcc->format, filter)
+                                    || !LoadScanlineLinear(vrow[3], width, srcd->pixels + (srcd->rowPitch * u1), srcd->rowPitch, srcd->format, filter))
                                     return E_FAIL;
                             }
                             else if (toY.u1 == u2)
@@ -2326,10 +2338,10 @@ namespace
                             {
                                 u2 = toY.u2;
 
-                                if (!_LoadScanlineLinear(srow[0], width, srca->pixels + (srca->rowPitch * u2), srca->rowPitch, srca->format, filter)
-                                    || !_LoadScanlineLinear(srow[1], width, srcb->pixels + (srcb->rowPitch * u2), srcb->rowPitch, srcb->format, filter)
-                                    || !_LoadScanlineLinear(srow[2], width, srcc->pixels + (srcc->rowPitch * u2), srcc->rowPitch, srcc->format, filter)
-                                    || !_LoadScanlineLinear(srow[3], width, srcd->pixels + (srcd->rowPitch * u2), srcd->rowPitch, srcd->format, filter))
+                                if (!LoadScanlineLinear(srow[0], width, srca->pixels + (srca->rowPitch * u2), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(srow[1], width, srcb->pixels + (srcb->rowPitch * u2), srcb->rowPitch, srcb->format, filter)
+                                    || !LoadScanlineLinear(srow[2], width, srcc->pixels + (srcc->rowPitch * u2), srcc->rowPitch, srcc->format, filter)
+                                    || !LoadScanlineLinear(srow[3], width, srcd->pixels + (srcd->rowPitch * u2), srcd->rowPitch, srcd->format, filter))
                                     return E_FAIL;
                             }
                             else
@@ -2349,10 +2361,10 @@ namespace
                         {
                             u3 = toY.u3;
 
-                            if (!_LoadScanlineLinear(trow[0], width, srca->pixels + (srca->rowPitch * u3), srca->rowPitch, srca->format, filter)
-                                || !_LoadScanlineLinear(trow[1], width, srcb->pixels + (srcb->rowPitch * u3), srcb->rowPitch, srcb->format, filter)
-                                || !_LoadScanlineLinear(trow[2], width, srcc->pixels + (srcc->rowPitch * u3), srcc->rowPitch, srcc->format, filter)
-                                || !_LoadScanlineLinear(trow[3], width, srcd->pixels + (srcd->rowPitch * u3), srcd->rowPitch, srcd->format, filter))
+                            if (!LoadScanlineLinear(trow[0], width, srca->pixels + (srca->rowPitch * u3), srca->rowPitch, srca->format, filter)
+                                || !LoadScanlineLinear(trow[1], width, srcb->pixels + (srcb->rowPitch * u3), srcb->rowPitch, srcb->format, filter)
+                                || !LoadScanlineLinear(trow[2], width, srcc->pixels + (srcc->rowPitch * u3), srcc->rowPitch, srcc->format, filter)
+                                || !LoadScanlineLinear(trow[3], width, srcd->pixels + (srcd->rowPitch * u3), srcd->rowPitch, srcd->format, filter))
                                 return E_FAIL;
                         }
 
@@ -2376,7 +2388,7 @@ namespace
                             CUBIC_INTERPOLATE(target[x], toZ.x, D[0], D[1], D[2], D[3])
                         }
 
-                        if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                        if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                             return E_FAIL;
                         pDest += dest->rowPitch;
                     }
@@ -2412,7 +2424,7 @@ namespace
                         {
                             u0 = toY.u0;
 
-                            if (!_LoadScanlineLinear(urow[0], width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                            if (!LoadScanlineLinear(urow[0], width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
                                 return E_FAIL;
                         }
                         else if (toY.u0 == u1)
@@ -2445,7 +2457,7 @@ namespace
                         {
                             u1 = toY.u1;
 
-                            if (!_LoadScanlineLinear(vrow[0], width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                            if (!LoadScanlineLinear(vrow[0], width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
                                 return E_FAIL;
                         }
                         else if (toY.u1 == u2)
@@ -2471,7 +2483,7 @@ namespace
                         {
                             u2 = toY.u2;
 
-                            if (!_LoadScanlineLinear(srow[0], width, pSrc + (rowPitch * u2), rowPitch, src->format, filter))
+                            if (!LoadScanlineLinear(srow[0], width, pSrc + (rowPitch * u2), rowPitch, src->format, filter))
                                 return E_FAIL;
                         }
                         else
@@ -2488,7 +2500,7 @@ namespace
                     {
                         u3 = toY.u3;
 
-                        if (!_LoadScanlineLinear(trow[0], width, pSrc + (rowPitch * u3), rowPitch, src->format, filter))
+                        if (!LoadScanlineLinear(trow[0], width, pSrc + (rowPitch * u3), rowPitch, src->format, filter))
                             return E_FAIL;
                     }
 
@@ -2505,7 +2517,7 @@ namespace
                         CUBIC_INTERPOLATE(target[x], toY.x, C0, C1, C2, C3)
                     }
 
-                    if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                    if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
                         return E_FAIL;
                     pDest += dest->rowPitch;
                 }
@@ -2528,10 +2540,10 @@ namespace
     //--- 3D Triangle Filter ---
     HRESULT Generate3DMipsTriangleFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
     {
+        using namespace DirectX::Filters;
+
         if (!depth || !mipChain.GetImages())
             return E_INVALIDARG;
-
-        using namespace TriangleFilter;
 
         // This assumes that the base images are already placed into the mipChain at the top level... (see _Setup3DMips)
 
@@ -2559,17 +2571,17 @@ namespace
         for (size_t level = 1; level < levels; ++level)
         {
             size_t nwidth = (width > 1) ? (width >> 1) : 1;
-            HRESULT hr = _Create(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
+            HRESULT hr = CreateTriangleFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
             if (FAILED(hr))
                 return hr;
 
             size_t nheight = (height > 1) ? (height >> 1) : 1;
-            hr = _Create(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
+            hr = CreateTriangleFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
             if (FAILED(hr))
                 return hr;
 
             size_t ndepth = (depth > 1) ? (depth >> 1) : 1;
-            hr = _Create(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, tfZ);
+            hr = CreateTriangleFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, tfZ);
             if (FAILED(hr))
                 return hr;
 
@@ -2649,7 +2661,7 @@ namespace
                     if ((pSrc + rowPitch) > pEndSrc)
                         return E_FAIL;
 
-                    if (!_LoadScanlineLinear(row, width, pSrc, rowPitch, src->format, filter))
+                    if (!LoadScanlineLinear(row, width, pSrc, rowPitch, src->format, filter))
                         return E_FAIL;
 
                     pSrc += rowPitch;
@@ -2738,7 +2750,7 @@ namespace
                             }
 
                             // This performs any required clamping
-                            if (!_StoreScanlineLinear(pDest, dest->rowPitch, dest->format, pAccSrc, dest->width, filter))
+                            if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, pAccSrc, dest->width, filter))
                                 return E_FAIL;
 
                             pDest += dest->rowPitch;
@@ -2790,7 +2802,7 @@ HRESULT DirectX::GenerateMipMaps(
     if (!baseImage.pixels)
         return E_POINTER;
 
-    if (!_CalculateMipLevels(baseImage.width, baseImage.height, levels))
+    if (!CalculateMipLevels(baseImage.width, baseImage.height, levels))
         return E_INVALIDARG;
 
     if (levels <= 1)
@@ -2809,7 +2821,7 @@ HRESULT DirectX::GenerateMipMaps(
     bool usewic = UseWICFiltering(baseImage.format, filter);
 
     WICPixelFormatGUID pfGUID = {};
-    bool wicpf = (usewic) ? _DXGIToWIC(baseImage.format, pfGUID, true) : false;
+    bool wicpf = (usewic) ? DXGIToWIC(baseImage.format, pfGUID, true) : false;
 
     if (usewic && !wicpf)
     {
@@ -2854,7 +2866,7 @@ HRESULT DirectX::GenerateMipMaps(
                 // Case 2: Base image format is not supported by WIC, so we have to convert, generate, and convert back
                 assert(baseImage.format != DXGI_FORMAT_R32G32B32A32_FLOAT);
                 ScratchImage temp;
-                hr = _ConvertToR32G32B32A32(baseImage, temp);
+                hr = ConvertToR32G32B32A32(baseImage, temp);
                 if (FAILED(hr))
                     return hr;
 
@@ -2875,7 +2887,7 @@ HRESULT DirectX::GenerateMipMaps(
 
                 temp.Release();
 
-                return _ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), baseImage.format, mipChain);
+                return ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), baseImage.format, mipChain);
             }
         }
 
@@ -2984,7 +2996,7 @@ HRESULT DirectX::GenerateMipMaps(
         || IsCompressed(metadata.format) || IsTypeless(metadata.format) || IsPlanar(metadata.format) || IsPalettized(metadata.format))
         return HRESULT_E_NOT_SUPPORTED;
 
-    if (!_CalculateMipLevels(metadata.width, metadata.height, levels))
+    if (!CalculateMipLevels(metadata.width, metadata.height, levels))
         return E_INVALIDARG;
 
     if (levels <= 1)
@@ -3024,7 +3036,7 @@ HRESULT DirectX::GenerateMipMaps(
     bool usewic = !metadata.IsPMAlpha() && UseWICFiltering(metadata.format, filter);
 
     WICPixelFormatGUID pfGUID = {};
-    bool wicpf = (usewic) ? _DXGIToWIC(metadata.format, pfGUID, true) : false;
+    bool wicpf = (usewic) ? DXGIToWIC(metadata.format, pfGUID, true) : false;
 
     if (usewic && !wicpf)
     {
@@ -3090,7 +3102,7 @@ HRESULT DirectX::GenerateMipMaps(
                 for (size_t item = 0; item < metadata.arraySize; ++item)
                 {
                     ScratchImage temp;
-                    hr = _ConvertToR32G32B32A32(baseImages[item], temp);
+                    hr = ConvertToR32G32B32A32(baseImages[item], temp);
                     if (FAILED(hr))
                         return hr;
 
@@ -3103,7 +3115,7 @@ HRESULT DirectX::GenerateMipMaps(
                         return hr;
                 }
 
-                return _ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), metadata.format, mipChain);
+                return ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), metadata.format, mipChain);
             }
         }
 
@@ -3220,7 +3232,7 @@ HRESULT DirectX::GenerateMipMaps3D(
     size_t width = baseImages[0].width;
     size_t height = baseImages[0].height;
 
-    if (!_CalculateMipLevels3D(width, height, depth, levels))
+    if (!CalculateMipLevels3D(width, height, depth, levels))
         return E_INVALIDARG;
 
     if (levels <= 1)
@@ -3328,7 +3340,7 @@ HRESULT DirectX::GenerateMipMaps3D(
         || IsCompressed(metadata.format) || IsTypeless(metadata.format) || IsPlanar(metadata.format) || IsPalettized(metadata.format))
         return HRESULT_E_NOT_SUPPORTED;
 
-    if (!_CalculateMipLevels3D(metadata.width, metadata.height, metadata.depth, levels))
+    if (!CalculateMipLevels3D(metadata.width, metadata.height, metadata.depth, levels))
         return E_INVALIDARG;
 
     if (levels <= 1)

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -12,6 +12,7 @@
 #include "DirectXTexP.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -101,11 +102,11 @@ namespace
         for (size_t h = 0; h < image1.height; ++h)
         {
             XMVECTOR* ptr1 = scanline.get();
-            if (!_LoadScanline(ptr1, width, pSrc1, rowPitch1, image1.format))
+            if (!LoadScanline(ptr1, width, pSrc1, rowPitch1, image1.format))
                 return E_FAIL;
 
             XMVECTOR* ptr2 = scanline.get() + width;
-            if (!_LoadScanline(ptr2, width, pSrc2, rowPitch2, image2.format))
+            if (!LoadScanline(ptr2, width, pSrc2, rowPitch2, image2.format))
                 return E_FAIL;
 
             for (size_t i = 0; i < width; ++i)
@@ -198,7 +199,7 @@ namespace
 
         for (size_t h = 0; h < image.height; ++h)
         {
-            if (!_LoadScanline(scanline.get(), width, pSrc, rowPitch, image.format))
+            if (!LoadScanline(scanline.get(), width, pSrc, rowPitch, image.format))
                 return E_FAIL;
 
             pixelFunc(scanline.get(), width, h);
@@ -242,7 +243,7 @@ namespace
 
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanline(sScanline, width, pSrc, spitch, srcImage.format))
+            if (!LoadScanline(sScanline, width, pSrc, spitch, srcImage.format))
                 return E_FAIL;
 
 #ifdef _DEBUG
@@ -251,7 +252,7 @@ namespace
 
             pixelFunc(dScanline, sScanline, width, h);
 
-            if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, dScanline, width))
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, dScanline, width))
                 return E_FAIL;
 
             pSrc += spitch;
@@ -364,12 +365,12 @@ HRESULT DirectX::CopyRectangle(
         if (((pSrc + copyS) > pEndSrc) || ((pDest + copyD) > pEndDest))
             return E_FAIL;
 
-        if (!_LoadScanline(scanline.get(), srcRect.w, pSrc, copyS, srcImage.format))
+        if (!LoadScanline(scanline.get(), srcRect.w, pSrc, copyS, srcImage.format))
             return E_FAIL;
 
-        _ConvertScanline(scanline.get(), srcRect.w, dstImage.format, srcImage.format, filter);
+        ConvertScanline(scanline.get(), srcRect.w, dstImage.format, srcImage.format, filter);
 
-        if (!_StoreScanline(pDest, copyD, dstImage.format, scanline.get(), srcRect.w))
+        if (!StoreScanline(pDest, copyD, dstImage.format, scanline.get(), srcRect.w))
             return E_FAIL;
 
         pSrc += srcImage.rowPitch;

--- a/DirectXTex/DirectXTexNormalMaps.cpp
+++ b/DirectXTex/DirectXTexNormalMaps.cpp
@@ -12,6 +12,7 @@
 #include "DirectXTexP.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 namespace
 {
@@ -79,7 +80,7 @@ namespace
         if (!srcImage.pixels || !normalMap.pixels)
             return E_INVALIDARG;
 
-        const uint32_t convFlags = _GetConvertFlags(format);
+        const uint32_t convFlags = GetConvertFlags(format);
         if (!convFlags)
             return E_FAIL;
 
@@ -117,7 +118,7 @@ namespace
         const uint8_t* pSrc = srcImage.pixels;
 
         // Read first scanline row into 'row1'
-        if (!_LoadScanline(row1, width, pSrc, rowPitch, srcImage.format))
+        if (!LoadScanline(row1, width, pSrc, rowPitch, srcImage.format))
             return E_FAIL;
 
         // Setup 'row0'
@@ -129,7 +130,7 @@ namespace
         else
         {
             // Read last row (Wrap V)
-            if (!_LoadScanline(row0, width, pSrc + (rowPitch * (height - 1)), rowPitch, srcImage.format))
+            if (!LoadScanline(row0, width, pSrc + (rowPitch * (height - 1)), rowPitch, srcImage.format))
                 return E_FAIL;
         }
 
@@ -144,7 +145,7 @@ namespace
             // Load next scanline of source image
             if (y < (height - 1))
             {
-                if (!_LoadScanline(row2, width, pSrc, rowPitch, srcImage.format))
+                if (!LoadScanline(row2, width, pSrc, rowPitch, srcImage.format))
                     return E_FAIL;
             }
             else
@@ -152,13 +153,13 @@ namespace
                 if (flags & CNMAP_MIRROR_V)
                 {
                     // Use last row of source image
-                    if (!_LoadScanline(row2, width, srcImage.pixels + (rowPitch * (height - 1)), rowPitch, srcImage.format))
+                    if (!LoadScanline(row2, width, srcImage.pixels + (rowPitch * (height - 1)), rowPitch, srcImage.format))
                         return E_FAIL;
                 }
                 else
                 {
                     // Use first row of source image (Wrap V)
-                    if (!_LoadScanline(row2, width, srcImage.pixels, rowPitch, srcImage.format))
+                    if (!LoadScanline(row2, width, srcImage.pixels, rowPitch, srcImage.format))
                         return E_FAIL;
                 }
             }
@@ -227,7 +228,7 @@ namespace
                 }
             }
 
-            if (!_StoreScanline(pDest, normalMap.rowPitch, format, target, width))
+            if (!StoreScanline(pDest, normalMap.rowPitch, format, target, width))
                 return E_FAIL;
 
             // Cycle buffers

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -407,13 +407,6 @@ namespace DirectX
             _In_ DXGI_FORMAT outFormat, _In_ DXGI_FORMAT inFormat, _In_ TEX_FILTER_FLAGS flags) noexcept;
 
         //---------------------------------------------------------------------------------
-        // DDS helper functions
-        HRESULT __cdecl EncodeDDSHeader(
-            _In_ const TexMetadata& metadata, DDS_FLAGS flags,
-            _Out_writes_bytes_to_opt_(maxsize, required) void* pDestination, _In_ size_t maxsize,
-            _Out_ size_t& required) noexcept;
-
-        //---------------------------------------------------------------------------------
         // Misc helper functions
         bool IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept;
         bool CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept;

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -203,25 +203,28 @@ using WICPixelFormatGUID = GUID;
 #define E_NOT_SUFFICIENT_BUFFER static_cast<HRESULT>(0x8007007AL)
 #endif
 
+//-------------------------------------------------------------------------------------
 namespace DirectX
 {
-    //---------------------------------------------------------------------------------
-    // WIC helper functions
-#ifdef WIN32
-    DXGI_FORMAT __cdecl _WICToDXGI(_In_ const GUID& guid) noexcept;
-    bool __cdecl _DXGIToWIC(_In_ DXGI_FORMAT format, _Out_ GUID& guid, _In_ bool ignoreRGBvsBGR = false) noexcept;
-
-    TEX_FILTER_FLAGS __cdecl _CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept;
-
-    inline WICBitmapDitherType __cdecl _GetWICDither(_In_ TEX_FILTER_FLAGS flags) noexcept
+    namespace Internal
     {
-        static_assert(TEX_FILTER_DITHER == 0x10000, "TEX_FILTER_DITHER* flag values don't match mask");
+        //-----------------------------------------------------------------------------
+        // WIC helper functions
+#ifdef WIN32
+        DXGI_FORMAT __cdecl WICToDXGI(_In_ const GUID& guid) noexcept;
+        bool __cdecl DXGIToWIC(_In_ DXGI_FORMAT format, _Out_ GUID& guid, _In_ bool ignoreRGBvsBGR = false) noexcept;
 
-        static_assert(static_cast<int>(TEX_FILTER_DITHER) == static_cast<int>(WIC_FLAGS_DITHER), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
-        static_assert(static_cast<int>(TEX_FILTER_DITHER_DIFFUSION) == static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
+        TEX_FILTER_FLAGS __cdecl CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept;
 
-        switch (flags & TEX_FILTER_DITHER_MASK)
+        inline WICBitmapDitherType __cdecl GetWICDither(_In_ TEX_FILTER_FLAGS flags) noexcept
         {
+            static_assert(TEX_FILTER_DITHER == 0x10000, "TEX_FILTER_DITHER* flag values don't match mask");
+
+            static_assert(static_cast<int>(TEX_FILTER_DITHER) == static_cast<int>(WIC_FLAGS_DITHER), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
+            static_assert(static_cast<int>(TEX_FILTER_DITHER_DIFFUSION) == static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
+
+            switch (flags & TEX_FILTER_DITHER_MASK)
+            {
             case TEX_FILTER_DITHER:
                 return WICBitmapDitherTypeOrdered4x4;
 
@@ -230,35 +233,35 @@ namespace DirectX
 
             default:
                 return WICBitmapDitherTypeNone;
+            }
         }
-    }
 
-    inline WICBitmapDitherType __cdecl _GetWICDither(_In_ WIC_FLAGS flags) noexcept
-    {
-        switch (flags & TEX_FILTER_DITHER_MASK)
+        inline WICBitmapDitherType __cdecl GetWICDither(_In_ WIC_FLAGS flags) noexcept
         {
-        case WIC_FLAGS_DITHER:
-            return WICBitmapDitherTypeOrdered4x4;
+            switch (flags & TEX_FILTER_DITHER_MASK)
+            {
+            case WIC_FLAGS_DITHER:
+                return WICBitmapDitherTypeOrdered4x4;
 
-        case WIC_FLAGS_DITHER_DIFFUSION:
-            return WICBitmapDitherTypeErrorDiffusion;
+            case WIC_FLAGS_DITHER_DIFFUSION:
+                return WICBitmapDitherTypeErrorDiffusion;
 
-        default:
-            return WICBitmapDitherTypeNone;
+            default:
+                return WICBitmapDitherTypeNone;
+            }
         }
-    }
 
-    inline WICBitmapInterpolationMode __cdecl _GetWICInterp(_In_ WIC_FLAGS flags) noexcept
-    {
-        static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
-
-        static_assert(static_cast<int>(TEX_FILTER_POINT) == static_cast<int>(WIC_FLAGS_FILTER_POINT), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
-        static_assert(static_cast<int>(TEX_FILTER_LINEAR) == static_cast<int>(WIC_FLAGS_FILTER_LINEAR), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
-        static_assert(static_cast<int>(TEX_FILTER_CUBIC) == static_cast<int>(WIC_FLAGS_FILTER_CUBIC), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
-        static_assert(static_cast<int>(TEX_FILTER_FANT) == static_cast<int>(WIC_FLAGS_FILTER_FANT), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
-
-        switch (flags & TEX_FILTER_MODE_MASK)
+        inline WICBitmapInterpolationMode __cdecl GetWICInterp(_In_ WIC_FLAGS flags) noexcept
         {
+            static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+
+            static_assert(static_cast<int>(TEX_FILTER_POINT) == static_cast<int>(WIC_FLAGS_FILTER_POINT), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+            static_assert(static_cast<int>(TEX_FILTER_LINEAR) == static_cast<int>(WIC_FLAGS_FILTER_LINEAR), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+            static_assert(static_cast<int>(TEX_FILTER_CUBIC) == static_cast<int>(WIC_FLAGS_FILTER_CUBIC), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+            static_assert(static_cast<int>(TEX_FILTER_FANT) == static_cast<int>(WIC_FLAGS_FILTER_FANT), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+
+            switch (flags & TEX_FILTER_MODE_MASK)
+            {
             case TEX_FILTER_POINT:
                 return WICBitmapInterpolationModeNearestNeighbor;
 
@@ -271,137 +274,159 @@ namespace DirectX
             case TEX_FILTER_FANT:
             default:
                 return WICBitmapInterpolationModeFant;
+            }
         }
-    }
 
-    inline WICBitmapInterpolationMode __cdecl _GetWICInterp(_In_ TEX_FILTER_FLAGS flags) noexcept
-    {
-        switch (flags & TEX_FILTER_MODE_MASK)
+        inline WICBitmapInterpolationMode __cdecl GetWICInterp(_In_ TEX_FILTER_FLAGS flags) noexcept
         {
-        case TEX_FILTER_POINT:
-            return WICBitmapInterpolationModeNearestNeighbor;
+            switch (flags & TEX_FILTER_MODE_MASK)
+            {
+            case TEX_FILTER_POINT:
+                return WICBitmapInterpolationModeNearestNeighbor;
 
-        case TEX_FILTER_LINEAR:
-            return WICBitmapInterpolationModeLinear;
+            case TEX_FILTER_LINEAR:
+                return WICBitmapInterpolationModeLinear;
 
-        case TEX_FILTER_CUBIC:
-            return WICBitmapInterpolationModeCubic;
+            case TEX_FILTER_CUBIC:
+                return WICBitmapInterpolationModeCubic;
 
-        case TEX_FILTER_FANT:
-        default:
-            return WICBitmapInterpolationModeFant;
+            case TEX_FILTER_FANT:
+            default:
+                return WICBitmapInterpolationModeFant;
+            }
         }
-    }
 #endif // WIN32
 
-    //---------------------------------------------------------------------------------
-    // Image helper functions
-    _Success_(return) bool __cdecl _DetermineImageArray(
-        _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
-        _Out_ size_t& nImages, _Out_ size_t& pixelSize) noexcept;
+        //---------------------------------------------------------------------------------
+        // Image helper functions
+        _Success_(return) bool __cdecl DetermineImageArray(
+            _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
+            _Out_ size_t& nImages, _Out_ size_t& pixelSize) noexcept;
 
-    _Success_(return) bool __cdecl _SetupImageArray(
-        _In_reads_bytes_(pixelSize) uint8_t *pMemory, _In_ size_t pixelSize,
-        _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
-        _Out_writes_(nImages) Image* images, _In_ size_t nImages) noexcept;
+        _Success_(return) bool __cdecl SetupImageArray(
+            _In_reads_bytes_(pixelSize) uint8_t* pMemory, _In_ size_t pixelSize,
+            _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
+            _Out_writes_(nImages) Image* images, _In_ size_t nImages) noexcept;
 
-    //---------------------------------------------------------------------------------
-    // Conversion helper functions
+        //---------------------------------------------------------------------------------
+        // Conversion helper functions
 
-    enum TEXP_SCANLINE_FLAGS : uint32_t
-    {
-        TEXP_SCANLINE_NONE          = 0,
-        TEXP_SCANLINE_SETALPHA      = 0x1,  // Set alpha channel to known opaque value
-        TEXP_SCANLINE_LEGACY        = 0x2,  // Enables specific legacy format conversion cases
-    };
+        enum TEXP_SCANLINE_FLAGS : uint32_t
+        {
+            TEXP_SCANLINE_NONE = 0,
+            TEXP_SCANLINE_SETALPHA = 0x1,  // Set alpha channel to known opaque value
+            TEXP_SCANLINE_LEGACY = 0x2,  // Enables specific legacy format conversion cases
+        };
 
-    enum CONVERT_FLAGS : uint32_t
-    {
-        CONVF_FLOAT     = 0x1,
-        CONVF_UNORM     = 0x2,
-        CONVF_UINT      = 0x4,
-        CONVF_SNORM     = 0x8,
-        CONVF_SINT      = 0x10,
-        CONVF_DEPTH     = 0x20,
-        CONVF_STENCIL   = 0x40,
-        CONVF_SHAREDEXP = 0x80,
-        CONVF_BGR       = 0x100,
-        CONVF_XR        = 0x200,
-        CONVF_PACKED    = 0x400,
-        CONVF_BC        = 0x800,
-        CONVF_YUV       = 0x1000,
-        CONVF_POS_ONLY  = 0x2000,
-        CONVF_R         = 0x10000,
-        CONVF_G         = 0x20000,
-        CONVF_B         = 0x40000,
-        CONVF_A         = 0x80000,
-        CONVF_RGB_MASK  = 0x70000,
-        CONVF_RGBA_MASK = 0xF0000,
-    };
+        enum CONVERT_FLAGS : uint32_t
+        {
+            CONVF_FLOAT = 0x1,
+            CONVF_UNORM = 0x2,
+            CONVF_UINT = 0x4,
+            CONVF_SNORM = 0x8,
+            CONVF_SINT = 0x10,
+            CONVF_DEPTH = 0x20,
+            CONVF_STENCIL = 0x40,
+            CONVF_SHAREDEXP = 0x80,
+            CONVF_BGR = 0x100,
+            CONVF_XR = 0x200,
+            CONVF_PACKED = 0x400,
+            CONVF_BC = 0x800,
+            CONVF_YUV = 0x1000,
+            CONVF_POS_ONLY = 0x2000,
+            CONVF_R = 0x10000,
+            CONVF_G = 0x20000,
+            CONVF_B = 0x40000,
+            CONVF_A = 0x80000,
+            CONVF_RGB_MASK = 0x70000,
+            CONVF_RGBA_MASK = 0xF0000,
+        };
 
-    uint32_t __cdecl _GetConvertFlags(_In_ DXGI_FORMAT format) noexcept;
+        uint32_t __cdecl GetConvertFlags(_In_ DXGI_FORMAT format) noexcept;
 
-    void __cdecl _CopyScanline(
-        _When_(pDestination == pSource, _Inout_updates_bytes_(outSize))
-        _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
-        void* pDestination, _In_ size_t outSize,
-        _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
-        _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
+        void __cdecl CopyScanline(
+            _When_(pDestination == pSource, _Inout_updates_bytes_(outSize))
+            _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
+            void* pDestination, _In_ size_t outSize,
+            _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
+            _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
 
-    void __cdecl _SwizzleScanline(
-        _When_(pDestination == pSource, _In_)
-        _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
-        void* pDestination, _In_ size_t outSize,
-        _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
-        _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
+        void __cdecl SwizzleScanline(
+            _When_(pDestination == pSource, _In_)
+            _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
+            void* pDestination, _In_ size_t outSize,
+            _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
+            _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
 
-    _Success_(return) bool __cdecl _ExpandScanline(
-        _Out_writes_bytes_(outSize) void* pDestination, _In_ size_t outSize,
-        _In_ DXGI_FORMAT outFormat,
-        _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
-        _In_ DXGI_FORMAT inFormat, _In_ uint32_t tflags) noexcept;
+        _Success_(return) bool __cdecl ExpandScanline(
+            _Out_writes_bytes_(outSize) void* pDestination, _In_ size_t outSize,
+            _In_ DXGI_FORMAT outFormat,
+            _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
+            _In_ DXGI_FORMAT inFormat, _In_ uint32_t tflags) noexcept;
 
-    _Success_(return) bool __cdecl _LoadScanline(
-        _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,
-        _In_reads_bytes_(size) const void* pSource, _In_ size_t size, _In_ DXGI_FORMAT format) noexcept;
+        _Success_(return) bool __cdecl LoadScanline(
+            _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,
+            _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+            _In_ DXGI_FORMAT format) noexcept;
 
-    _Success_(return) bool __cdecl _LoadScanlineLinear(
-        _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,
-        _In_reads_bytes_(size) const void* pSource, _In_ size_t size, _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS flags) noexcept;
+        _Success_(return) bool __cdecl LoadScanlineLinear(
+            _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,
+            _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+            _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS flags) noexcept;
 
-    _Success_(return) bool __cdecl _StoreScanline(
-        _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
-        _In_reads_(count) const XMVECTOR* pSource, _In_ size_t count, _In_ float threshold = 0) noexcept;
+        _Success_(return) bool __cdecl StoreScanline(
+            _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
+            _In_reads_(count) const XMVECTOR* pSource, _In_ size_t count, _In_ float threshold = 0) noexcept;
 
-    _Success_(return) bool __cdecl _StoreScanlineLinear(
-        _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
-        _Inout_updates_all_(count) XMVECTOR* pSource, _In_ size_t count, _In_ TEX_FILTER_FLAGS flags, _In_ float threshold = 0) noexcept;
+        _Success_(return) bool __cdecl StoreScanlineLinear(
+            _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
+            _Inout_updates_all_(count) XMVECTOR* pSource, _In_ size_t count,
+            _In_ TEX_FILTER_FLAGS flags, _In_ float threshold = 0) noexcept;
 
-    _Success_(return) bool __cdecl _StoreScanlineDither(
-        _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
-        _Inout_updates_all_(count) XMVECTOR* pSource, _In_ size_t count, _In_ float threshold, size_t y, size_t z,
-        _Inout_updates_all_opt_(count + 2) XMVECTOR* pDiffusionErrors) noexcept;
+        _Success_(return) bool __cdecl StoreScanlineDither(
+            _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
+            _Inout_updates_all_(count) XMVECTOR* pSource, _In_ size_t count,
+            _In_ float threshold, size_t y, size_t z,
+            _Inout_updates_all_opt_(count + 2) XMVECTOR* pDiffusionErrors) noexcept;
 
-    HRESULT __cdecl _ConvertToR32G32B32A32(_In_ const Image& srcImage, _Inout_ ScratchImage& image) noexcept;
+        HRESULT __cdecl ConvertToR32G32B32A32(_In_ const Image& srcImage, _Inout_ ScratchImage& image) noexcept;
 
-    HRESULT __cdecl _ConvertFromR32G32B32A32(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept;
-    HRESULT __cdecl _ConvertFromR32G32B32A32(_In_ const Image& srcImage, _In_ DXGI_FORMAT format, _Inout_ ScratchImage& image) noexcept;
-    HRESULT __cdecl _ConvertFromR32G32B32A32(
-        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
-        _In_ DXGI_FORMAT format, _Out_ ScratchImage& result) noexcept;
+        HRESULT __cdecl ConvertFromR32G32B32A32(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept;
+        HRESULT __cdecl ConvertFromR32G32B32A32(
+            _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _Inout_ ScratchImage& image) noexcept;
+        HRESULT __cdecl ConvertFromR32G32B32A32(
+            _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+            _In_ DXGI_FORMAT format, _Out_ ScratchImage& result) noexcept;
 
-    HRESULT __cdecl _ConvertToR16G16B16A16(_In_ const Image& srcImage, _Inout_ ScratchImage& image) noexcept;
+        HRESULT __cdecl ConvertToR16G16B16A16(_In_ const Image& srcImage, _Inout_ ScratchImage& image) noexcept;
 
-    HRESULT __cdecl _ConvertFromR16G16B16A16(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept;
+        HRESULT __cdecl ConvertFromR16G16B16A16(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept;
 
-    void __cdecl _ConvertScanline(
-        _Inout_updates_all_(count) XMVECTOR* pBuffer, _In_ size_t count,
-        _In_ DXGI_FORMAT outFormat, _In_ DXGI_FORMAT inFormat, _In_ TEX_FILTER_FLAGS flags) noexcept;
+        void __cdecl ConvertScanline(
+            _Inout_updates_all_(count) XMVECTOR* pBuffer, _In_ size_t count,
+            _In_ DXGI_FORMAT outFormat, _In_ DXGI_FORMAT inFormat, _In_ TEX_FILTER_FLAGS flags) noexcept;
 
-    //---------------------------------------------------------------------------------
-    // DDS helper functions
-    HRESULT __cdecl _EncodeDDSHeader(
-        _In_ const TexMetadata& metadata, DDS_FLAGS flags,
-        _Out_writes_bytes_to_opt_(maxsize, required) void* pDestination, _In_ size_t maxsize, _Out_ size_t& required) noexcept;
+        //---------------------------------------------------------------------------------
+        // DDS helper functions
+        HRESULT __cdecl EncodeDDSHeader(
+            _In_ const TexMetadata& metadata, DDS_FLAGS flags,
+            _Out_writes_bytes_to_opt_(maxsize, required) void* pDestination, _In_ size_t maxsize,
+            _Out_ size_t& required) noexcept;
 
-} // namespace
+        //---------------------------------------------------------------------------------
+        // Misc helper functions
+        bool IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept;
+        bool CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept;
+        bool CalculateMipLevels3D(_In_ size_t width, _In_ size_t height, _In_ size_t depth,
+            _Inout_ size_t& mipLevels) noexcept;
+
+#ifdef WIN32
+        HRESULT ResizeSeparateColorAndAlpha(_In_ IWICImagingFactory* pWIC,
+            _In_ bool iswic2,
+            _In_ IWICBitmap* original,
+            _In_ size_t newWidth, _In_ size_t newHeight, _In_ TEX_FILTER_FLAGS filter,
+            _Inout_ const Image* img) noexcept;
+#endif
+
+    } // namespace Internal
+} // namespace DirectX

--- a/DirectXTex/DirectXTexPMAlpha.cpp
+++ b/DirectXTex/DirectXTexPMAlpha.cpp
@@ -12,6 +12,7 @@
 #include "DirectXTexP.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 namespace
 {
@@ -42,7 +43,7 @@ namespace
 
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+            if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
                 return E_FAIL;
 
             XMVECTOR* ptr = scanline.get();
@@ -54,7 +55,7 @@ namespace
                 *(ptr++) = XMVectorSelect(v, alpha, g_XMSelect1110);
             }
 
-            if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
                 return E_FAIL;
 
             pSrc += srcImage.rowPitch;
@@ -87,7 +88,7 @@ namespace
 
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, filter))
+            if (!LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, filter))
                 return E_FAIL;
 
             XMVECTOR* ptr = scanline.get();
@@ -99,7 +100,7 @@ namespace
                 *(ptr++) = XMVectorSelect(v, alpha, g_XMSelect1110);
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, filter))
+            if (!StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, filter))
                 return E_FAIL;
 
             pSrc += srcImage.rowPitch;
@@ -127,7 +128,7 @@ namespace
 
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+            if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
                 return E_FAIL;
 
             XMVECTOR* ptr = scanline.get();
@@ -142,7 +143,7 @@ namespace
                 *(ptr++) = XMVectorSelect(v, alpha, g_XMSelect1110);
             }
 
-            if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
                 return E_FAIL;
 
             pSrc += srcImage.rowPitch;
@@ -175,7 +176,7 @@ namespace
 
         for (size_t h = 0; h < srcImage.height; ++h)
         {
-            if (!_LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, filter))
+            if (!LoadScanlineLinear(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format, filter))
                 return E_FAIL;
 
             XMVECTOR* ptr = scanline.get();
@@ -190,7 +191,7 @@ namespace
                 *(ptr++) = XMVectorSelect(v, alpha, g_XMSelect1110);
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, filter))
+            if (!StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width, filter))
                 return E_FAIL;
 
             pSrc += srcImage.rowPitch;

--- a/DirectXTex/DirectXTexResize.cpp
+++ b/DirectXTex/DirectXTexResize.cpp
@@ -14,15 +14,8 @@
 #include "filters.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 using Microsoft::WRL::ComPtr;
-
-#ifdef WIN32
-namespace DirectX
-{
-    extern HRESULT _ResizeSeparateColorAndAlpha(_In_ IWICImagingFactory* pWIC, _In_ bool iswic2, _In_ IWICBitmap* original,
-        _In_ size_t newWidth, _In_ size_t newHeight, _In_ TEX_FILTER_FLAGS filter, _Inout_ const Image* img) noexcept;
-}
-#endif
 
 namespace
 {
@@ -72,7 +65,7 @@ namespace
 
         if ((filter & TEX_FILTER_SEPARATE_ALPHA) && supportsTransparency)
         {
-            hr = _ResizeSeparateColorAndAlpha(pWIC, iswic2, source.Get(), destImage.width, destImage.height, filter, &destImage);
+            hr = ResizeSeparateColorAndAlpha(pWIC, iswic2, source.Get(), destImage.width, destImage.height, filter, &destImage);
             if (FAILED(hr))
                 return hr;
         }
@@ -83,7 +76,9 @@ namespace
             if (FAILED(hr))
                 return hr;
 
-            hr = scaler->Initialize(source.Get(), static_cast<UINT>(destImage.width), static_cast<UINT>(destImage.height), _GetWICInterp(filter));
+            hr = scaler->Initialize(source.Get(),
+                static_cast<UINT>(destImage.width), static_cast<UINT>(destImage.height),
+                GetWICInterp(filter));
             if (FAILED(hr))
                 return hr;
 
@@ -114,7 +109,8 @@ namespace
                     return E_UNEXPECTED;
                 }
 
-                hr = FC->Initialize(scaler.Get(), pfGUID, _GetWICDither(filter), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+                hr = FC->Initialize(scaler.Get(), pfGUID, GetWICDither(filter), nullptr,
+                    0, WICBitmapPaletteTypeMedianCut);
                 if (FAILED(hr))
                     return hr;
 
@@ -141,7 +137,7 @@ namespace
         assert(srcImage.format == destImage.format);
 
         ScratchImage temp;
-        HRESULT hr = _ConvertToR32G32B32A32(srcImage, temp);
+        HRESULT hr = ConvertToR32G32B32A32(srcImage, temp);
         if (FAILED(hr))
             return hr;
 
@@ -164,7 +160,7 @@ namespace
 
         temp.Release();
 
-        hr = _ConvertFromR32G32B32A32(*tdest, destImage);
+        hr = ConvertFromR32G32B32A32(*tdest, destImage);
         if (FAILED(hr))
             return hr;
 
@@ -281,7 +277,7 @@ namespace
         {
             if ((lasty ^ sy) >> 16)
             {
-                if (!_LoadScanline(row, srcImage.width, pSrc + (rowPitch * (sy >> 16)), rowPitch, srcImage.format))
+                if (!LoadScanline(row, srcImage.width, pSrc + (rowPitch * (sy >> 16)), rowPitch, srcImage.format))
                     return E_FAIL;
                 lasty = sy;
             }
@@ -293,7 +289,7 @@ namespace
                 sx += xinc;
             }
 
-            if (!_StoreScanline(pDest, destImage.rowPitch, destImage.format, target, destImage.width))
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, target, destImage.width))
                 return E_FAIL;
             pDest += destImage.rowPitch;
 
@@ -307,6 +303,8 @@ namespace
     //--- Box Filter ---
     HRESULT ResizeBoxFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
+        using namespace DirectX::Filters;
+
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
 
@@ -338,13 +336,13 @@ namespace
 
         for (size_t y = 0; y < destImage.height; ++y)
         {
-            if (!_LoadScanlineLinear(urow0, srcImage.width, pSrc, rowPitch, srcImage.format, filter))
+            if (!LoadScanlineLinear(urow0, srcImage.width, pSrc, rowPitch, srcImage.format, filter))
                 return E_FAIL;
             pSrc += rowPitch;
 
             if (urow0 != urow1)
             {
-                if (!_LoadScanlineLinear(urow1, srcImage.width, pSrc, rowPitch, srcImage.format, filter))
+                if (!LoadScanlineLinear(urow1, srcImage.width, pSrc, rowPitch, srcImage.format, filter))
                     return E_FAIL;
                 pSrc += rowPitch;
             }
@@ -356,7 +354,7 @@ namespace
                 AVERAGE4(target[x], urow0[x2], urow1[x2], urow2[x2], urow3[x2])
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, target, destImage.width, filter))
+            if (!StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, target, destImage.width, filter))
                 return E_FAIL;
             pDest += destImage.rowPitch;
         }
@@ -368,6 +366,8 @@ namespace
     //--- Linear Filter ---
     HRESULT ResizeLinearFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
+        using namespace DirectX::Filters;
+
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
 
@@ -383,8 +383,8 @@ namespace
         LinearFilter* lfX = lf.get();
         LinearFilter* lfY = lf.get() + destImage.width;
 
-        _CreateLinearFilter(srcImage.width, destImage.width, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
-        _CreateLinearFilter(srcImage.height, destImage.height, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
+        CreateLinearFilter(srcImage.width, destImage.width, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
+        CreateLinearFilter(srcImage.height, destImage.height, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
 
         XMVECTOR* target = scanline.get();
 
@@ -414,7 +414,7 @@ namespace
                 {
                     u0 = toY.u0;
 
-                    if (!_LoadScanlineLinear(row0, srcImage.width, pSrc + (rowPitch * u0), rowPitch, srcImage.format, filter))
+                    if (!LoadScanlineLinear(row0, srcImage.width, pSrc + (rowPitch * u0), rowPitch, srcImage.format, filter))
                         return E_FAIL;
                 }
                 else
@@ -430,7 +430,7 @@ namespace
             {
                 u1 = toY.u1;
 
-                if (!_LoadScanlineLinear(row1, srcImage.width, pSrc + (rowPitch * u1), rowPitch, srcImage.format, filter))
+                if (!LoadScanlineLinear(row1, srcImage.width, pSrc + (rowPitch * u1), rowPitch, srcImage.format, filter))
                     return E_FAIL;
             }
 
@@ -441,7 +441,7 @@ namespace
                 BILINEAR_INTERPOLATE(target[x], toX, toY, row0, row1)
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, target, destImage.width, filter))
+            if (!StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, target, destImage.width, filter))
                 return E_FAIL;
             pDest += destImage.rowPitch;
         }
@@ -453,6 +453,8 @@ namespace
     //--- Cubic Filter ---
     HRESULT ResizeCubicFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
+        using namespace DirectX::Filters;
+
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
 
@@ -468,8 +470,8 @@ namespace
         CubicFilter* cfX = cf.get();
         CubicFilter* cfY = cf.get() + destImage.width;
 
-        _CreateCubicFilter(srcImage.width, destImage.width, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
-        _CreateCubicFilter(srcImage.height, destImage.height, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
+        CreateCubicFilter(srcImage.width, destImage.width, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
+        CreateCubicFilter(srcImage.height, destImage.height, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
 
         XMVECTOR* target = scanline.get();
 
@@ -506,7 +508,7 @@ namespace
                 {
                     u0 = toY.u0;
 
-                    if (!_LoadScanlineLinear(row0, srcImage.width, pSrc + (rowPitch * u0), rowPitch, srcImage.format, filter))
+                    if (!LoadScanlineLinear(row0, srcImage.width, pSrc + (rowPitch * u0), rowPitch, srcImage.format, filter))
                         return E_FAIL;
                 }
                 else if (toY.u0 == u1)
@@ -539,7 +541,7 @@ namespace
                 {
                     u1 = toY.u1;
 
-                    if (!_LoadScanlineLinear(row1, srcImage.width, pSrc + (rowPitch * u1), rowPitch, srcImage.format, filter))
+                    if (!LoadScanlineLinear(row1, srcImage.width, pSrc + (rowPitch * u1), rowPitch, srcImage.format, filter))
                         return E_FAIL;
                 }
                 else if (toY.u1 == u2)
@@ -565,7 +567,7 @@ namespace
                 {
                     u2 = toY.u2;
 
-                    if (!_LoadScanlineLinear(row2, srcImage.width, pSrc + (rowPitch * u2), rowPitch, srcImage.format, filter))
+                    if (!LoadScanlineLinear(row2, srcImage.width, pSrc + (rowPitch * u2), rowPitch, srcImage.format, filter))
                         return E_FAIL;
                 }
                 else
@@ -582,7 +584,7 @@ namespace
             {
                 u3 = toY.u3;
 
-                if (!_LoadScanlineLinear(row3, srcImage.width, pSrc + (rowPitch * u3), rowPitch, srcImage.format, filter))
+                if (!LoadScanlineLinear(row3, srcImage.width, pSrc + (rowPitch * u3), rowPitch, srcImage.format, filter))
                     return E_FAIL;
             }
 
@@ -600,7 +602,7 @@ namespace
                 CUBIC_INTERPOLATE(target[x], toY.x, C0, C1, C2, C3)
             }
 
-            if (!_StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, target, destImage.width, filter))
+            if (!StoreScanlineLinear(pDest, destImage.rowPitch, destImage.format, target, destImage.width, filter))
                 return E_FAIL;
             pDest += destImage.rowPitch;
         }
@@ -612,10 +614,10 @@ namespace
     //--- Triangle Filter ---
     HRESULT ResizeTriangleFilter(const Image& srcImage, TEX_FILTER_FLAGS filter, const Image& destImage) noexcept
     {
+        using namespace DirectX::Filters;
+
         assert(srcImage.pixels && destImage.pixels);
         assert(srcImage.format == destImage.format);
-
-        using namespace TriangleFilter;
 
         // Allocate initial temporary space (1 scanline, accumulation rows, plus X and Y filters)
         auto scanline = make_AlignedArrayXMVECTOR(srcImage.width);
@@ -629,12 +631,12 @@ namespace
         TriangleRow * rowFree = nullptr;
 
         std::unique_ptr<Filter> tfX;
-        HRESULT hr = _Create(srcImage.width, destImage.width, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
+        HRESULT hr = CreateTriangleFilter(srcImage.width, destImage.width, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
         if (FAILED(hr))
             return hr;
 
         std::unique_ptr<Filter> tfY;
-        hr = _Create(srcImage.height, destImage.height, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
+        hr = CreateTriangleFilter(srcImage.height, destImage.height, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
         if (FAILED(hr))
             return hr;
 
@@ -701,7 +703,7 @@ namespace
             if ((pSrc + rowPitch) > pEndSrc)
                 return E_FAIL;
 
-            if (!_LoadScanlineLinear(row, srcImage.width, pSrc, rowPitch, srcImage.format, filter))
+            if (!LoadScanlineLinear(row, srcImage.width, pSrc, rowPitch, srcImage.format, filter))
                 return E_FAIL;
 
             pSrc += rowPitch;
@@ -773,7 +775,7 @@ namespace
                     }
 
                     // This performs any required clamping
-                    if (!_StoreScanlineLinear(pDest + (destImage.rowPitch * v), destImage.rowPitch, destImage.format, pAccSrc, destImage.width, filter))
+                    if (!StoreScanlineLinear(pDest + (destImage.rowPitch * v), destImage.rowPitch, destImage.format, pAccSrc, destImage.width, filter))
                         return E_FAIL;
 
                     // Put row on freelist to reuse it's allocated scanline
@@ -866,7 +868,7 @@ HRESULT DirectX::Resize(
     bool usewic = UseWICFiltering(srcImage.format, filter);
 
     WICPixelFormatGUID pfGUID = {};
-    bool wicpf = (usewic) ? _DXGIToWIC(srcImage.format, pfGUID, true) : false;
+    bool wicpf = (usewic) ? DXGIToWIC(srcImage.format, pfGUID, true) : false;
 
     if (usewic && !wicpf)
     {
@@ -953,7 +955,7 @@ HRESULT DirectX::Resize(
     bool usewic = !metadata.IsPMAlpha() && UseWICFiltering(metadata.format, filter);
 
     WICPixelFormatGUID pfGUID = {};
-    bool wicpf = (usewic) ? _DXGIToWIC(metadata.format, pfGUID, true) : false;
+    bool wicpf = (usewic) ? DXGIToWIC(metadata.format, pfGUID, true) : false;
 
     if (usewic && !wicpf)
     {

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -20,6 +20,7 @@
 //
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 
 namespace
 {
@@ -270,7 +271,7 @@ namespace
 
         for (size_t y = 0; y < image->height; ++y)
         {
-            _CopyScanline(pPixels, image->rowPitch, pPixels, image->rowPitch, image->format, TEXP_SCANLINE_SETALPHA);
+            CopyScanline(pPixels, image->rowPitch, pPixels, image->rowPitch, image->format, TEXP_SCANLINE_SETALPHA);
             pPixels += image->rowPitch;
         }
 
@@ -1792,7 +1793,7 @@ HRESULT DirectX::LoadFromTGAFile(
 
             for (size_t h = 0; h < img->height; ++h)
             {
-                _SwizzleScanline(pPixels, rowPitch, pPixels, rowPitch, mdata.format, tflags);
+                SwizzleScanline(pPixels, rowPitch, pPixels, rowPitch, mdata.format, tflags);
                 pPixels += rowPitch;
             }
         }
@@ -2115,11 +2116,11 @@ HRESULT DirectX::SaveToTGAMemory(
         }
         else if (convFlags & CONV_FLAGS_SWIZZLE)
         {
-            _SwizzleScanline(dPtr, rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
+            SwizzleScanline(dPtr, rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
         }
         else
         {
-            _CopyScanline(dPtr, rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
+            CopyScanline(dPtr, rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
         }
 
         dPtr += rowPitch;
@@ -2268,11 +2269,11 @@ HRESULT DirectX::SaveToTGAFile(
             }
             else if (convFlags & CONV_FLAGS_SWIZZLE)
             {
-                _SwizzleScanline(temp.get(), rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
+                SwizzleScanline(temp.get(), rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
             }
             else
             {
-                _CopyScanline(temp.get(), rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
+                CopyScanline(temp.get(), rowPitch, pPixels, image.rowPitch, image.format, TEXP_SCANLINE_NONE);
             }
 
             pPixels += image.rowPitch;

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -133,7 +133,7 @@ namespace
 //=====================================================================================
 
 _Use_decl_annotations_
-DXGI_FORMAT DirectX::_WICToDXGI(const GUID& guid) noexcept
+DXGI_FORMAT DirectX::Internal::WICToDXGI(const GUID& guid) noexcept
 {
     for (size_t i = 0; i < std::size(g_WICFormats); ++i)
     {
@@ -153,7 +153,7 @@ DXGI_FORMAT DirectX::_WICToDXGI(const GUID& guid) noexcept
 }
 
 _Use_decl_annotations_
-bool DirectX::_DXGIToWIC(DXGI_FORMAT format, GUID& guid, bool ignoreRGBvsBGR) noexcept
+bool DirectX::Internal::DXGIToWIC(DXGI_FORMAT format, GUID& guid, bool ignoreRGBvsBGR) noexcept
 {
     switch (format)
     {
@@ -213,7 +213,7 @@ bool DirectX::_DXGIToWIC(DXGI_FORMAT format, GUID& guid, bool ignoreRGBvsBGR) no
     return false;
 }
 
-TEX_FILTER_FLAGS DirectX::_CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept
+TEX_FILTER_FLAGS DirectX::Internal::CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept
 {
     TEX_FILTER_FLAGS srgb = TEX_FILTER_DEFAULT;
 

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -12,6 +12,7 @@
 #include "DirectXTexP.h"
 
 using namespace DirectX;
+using namespace DirectX::Internal;
 using Microsoft::WRL::ComPtr;
 
 namespace
@@ -99,7 +100,7 @@ namespace
 
         *alphaMode = TEX_ALPHA_MODE_UNKNOWN;
 
-        DXGI_FORMAT format = _WICToDXGI(pixelFormat);
+        DXGI_FORMAT format = WICToDXGI(pixelFormat);
 
         if (format == DXGI_FORMAT_UNKNOWN)
         {
@@ -132,7 +133,7 @@ namespace
                         if (pConvert)
                             memcpy_s(pConvert, sizeof(WICPixelFormatGUID), &g_WICConvert[i].target, sizeof(GUID));
 
-                        format = _WICToDXGI(g_WICConvert[i].target);
+                        format = WICToDXGI(g_WICConvert[i].target);
                         assert(format != DXGI_FORMAT_UNKNOWN);
                         *alphaMode = g_WICConvert[i].alphaMode;
                         break;
@@ -712,7 +713,8 @@ namespace
                 return E_UNEXPECTED;
             }
 
-            hr = FC->Initialize(frame, convertGUID, _GetWICDither(flags), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+            hr = FC->Initialize(frame, convertGUID, GetWICDither(flags), nullptr,
+                0, WICBitmapPaletteTypeMedianCut);
             if (FAILED(hr))
                 return hr;
 
@@ -747,7 +749,7 @@ namespace
             return E_NOINTERFACE;
 
         WICPixelFormatGUID sourceGUID;
-        if (!_DXGIToWIC(metadata.format, sourceGUID))
+        if (!DXGIToWIC(metadata.format, sourceGUID))
             return E_FAIL;
 
         for (size_t index = 0; index < metadata.arraySize; ++index)
@@ -797,7 +799,8 @@ namespace
                         return E_UNEXPECTED;
                     }
 
-                    hr = FC->Initialize(frame.Get(), sourceGUID, _GetWICDither(flags), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+                    hr = FC->Initialize(frame.Get(), sourceGUID, GetWICDither(flags), nullptr,
+                        0, WICBitmapPaletteTypeMedianCut);
                     if (FAILED(hr))
                         return hr;
 
@@ -814,7 +817,9 @@ namespace
                 if (FAILED(hr))
                     return hr;
 
-                hr = scaler->Initialize(frame.Get(), static_cast<UINT>(metadata.width), static_cast<UINT>(metadata.height), _GetWICInterp(flags));
+                hr = scaler->Initialize(frame.Get(),
+                    static_cast<UINT>(metadata.width), static_cast<UINT>(metadata.height),
+                    GetWICInterp(flags));
                 if (FAILED(hr))
                     return hr;
 
@@ -845,7 +850,8 @@ namespace
                         return E_UNEXPECTED;
                     }
 
-                    hr = FC->Initialize(scaler.Get(), sourceGUID, _GetWICDither(flags), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+                    hr = FC->Initialize(scaler.Get(), sourceGUID, GetWICDither(flags), nullptr,
+                        0, WICBitmapPaletteTypeMedianCut);
                     if (FAILED(hr))
                         return hr;
 
@@ -978,7 +984,7 @@ namespace
             return E_POINTER;
 
         WICPixelFormatGUID pfGuid;
-        if (!_DXGIToWIC(image.format, pfGuid))
+        if (!DXGIToWIC(image.format, pfGuid))
             return HRESULT_E_NOT_SUPPORTED;
 
         HRESULT hr = frame->Initialize(props);
@@ -1041,7 +1047,8 @@ namespace
                 return E_UNEXPECTED;
             }
 
-            hr = FC->Initialize(source.Get(), targetGuid, _GetWICDither(flags), nullptr, 0, WICBitmapPaletteTypeMedianCut);
+            hr = FC->Initialize(source.Get(), targetGuid, GetWICDither(flags), nullptr,
+                0, WICBitmapPaletteTypeMedianCut);
             if (FAILED(hr))
                 return hr;
 

--- a/DirectXTex/d3dx12.h
+++ b/DirectXTex/d3dx12.h
@@ -2463,16 +2463,16 @@ template <typename InnerStructType, D3D12_PIPELINE_STATE_SUBOBJECT_TYPE Type, ty
 class alignas(void*) CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT
 {
 private:
-    D3D12_PIPELINE_STATE_SUBOBJECT_TYPE _Type;
-    InnerStructType _Inner;
+    D3D12_PIPELINE_STATE_SUBOBJECT_TYPE pssType;
+    InnerStructType pssInner;
 public:
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT() noexcept : _Type(Type), _Inner(DefaultArg()) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) noexcept : _Type(Type), _Inner(i) {}
-    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) noexcept { _Type = Type; _Inner = i; return *this; }
-    operator InnerStructType const&() const noexcept { return _Inner; }
-    operator InnerStructType&() noexcept { return _Inner; }
-    InnerStructType* operator&() noexcept { return &_Inner; }
-    InnerStructType const* operator&() const noexcept { return &_Inner; }
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT() noexcept : pssType(Type), pssInner(DefaultArg()) {}
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT(InnerStructType const& i) noexcept : pssType(Type), pssInner(i) {}
+    CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT& operator=(InnerStructType const& i) noexcept { pssType = Type; pssInner = i; return *this; }
+    operator InnerStructType const&() const noexcept { return pssInner; }
+    operator InnerStructType&() noexcept { return pssInner; }
+    InnerStructType* operator&() noexcept { return &pssInner; }
+    InnerStructType const* operator&() const noexcept { return &pssInner; }
 };
 #pragma warning(pop)
 typedef CD3DX12_PIPELINE_STATE_STREAM_SUBOBJECT< D3D12_PIPELINE_STATE_FLAGS,         D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS>                             CD3DX12_PIPELINE_STATE_STREAM_FLAGS;

--- a/DirectXTex/filters.h
+++ b/DirectXTex/filters.h
@@ -16,15 +16,17 @@
 
 #include "scoped.h"
 
+
 namespace DirectX
 {
+    namespace Filters
+    {
+        //-------------------------------------------------------------------------------------
+        // Box filtering helpers
+        //-------------------------------------------------------------------------------------
 
-//-------------------------------------------------------------------------------------
-// Box filtering helpers
-//-------------------------------------------------------------------------------------
-
-XMGLOBALCONST XMVECTORF32 g_boxScale   = { { { 0.25f, 0.25f, 0.25f, 0.25f } } };
-XMGLOBALCONST XMVECTORF32 g_boxScale3D = { { { 0.125f, 0.125f, 0.125f, 0.125f } } };
+        XMGLOBALCONST XMVECTORF32 g_boxScale = { { { 0.25f, 0.25f, 0.25f, 0.25f } } };
+        XMGLOBALCONST XMVECTORF32 g_boxScale3D = { { { 0.125f, 0.125f, 0.125f, 0.125f } } };
 
 #define AVERAGE4( res, p0, p1, p2, p3 ) \
 { \
@@ -47,55 +49,55 @@ XMGLOBALCONST XMVECTORF32 g_boxScale3D = { { { 0.125f, 0.125f, 0.125f, 0.125f } 
 }
 
 
-//-------------------------------------------------------------------------------------
-// Linear filtering helpers
-//-------------------------------------------------------------------------------------
+        //-------------------------------------------------------------------------------------
+        // Linear filtering helpers
+        //-------------------------------------------------------------------------------------
 
-struct LinearFilter
-{
-    size_t  u0;
-    float   weight0;
-    size_t  u1;
-    float   weight1;
-};
-
-inline void _CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _Out_writes_(dest) LinearFilter* lf) noexcept
-{
-    assert(source > 0);
-    assert(dest > 0);
-    assert(lf != nullptr);
-
-    float scale = float(source) / float(dest);
-
-    // Mirror is the same case as clamp for linear
-
-    for (size_t u = 0; u < dest; ++u)
-    {
-        float srcB = (float(u) + 0.5f) * scale + 0.5f;
-
-        ptrdiff_t isrcB = ptrdiff_t(srcB);
-        ptrdiff_t isrcA = isrcB - 1;
-
-        float weight = 1.0f + float(isrcB) - srcB;
-
-        if (isrcA < 0)
+        struct LinearFilter
         {
-            isrcA = (wrap) ? (ptrdiff_t(source) - 1) : 0;
-        }
+            size_t  u0;
+            float   weight0;
+            size_t  u1;
+            float   weight1;
+        };
 
-        if (size_t(isrcB) >= source)
+        inline void CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _Out_writes_(dest) LinearFilter* lf) noexcept
         {
-            isrcB = (wrap) ? 0 : (ptrdiff_t(source) - 1);
+            assert(source > 0);
+            assert(dest > 0);
+            assert(lf != nullptr);
+
+            float scale = float(source) / float(dest);
+
+            // Mirror is the same case as clamp for linear
+
+            for (size_t u = 0; u < dest; ++u)
+            {
+                float srcB = (float(u) + 0.5f) * scale + 0.5f;
+
+                ptrdiff_t isrcB = ptrdiff_t(srcB);
+                ptrdiff_t isrcA = isrcB - 1;
+
+                float weight = 1.0f + float(isrcB) - srcB;
+
+                if (isrcA < 0)
+                {
+                    isrcA = (wrap) ? (ptrdiff_t(source) - 1) : 0;
+                }
+
+                if (size_t(isrcB) >= source)
+                {
+                    isrcB = (wrap) ? 0 : (ptrdiff_t(source) - 1);
+                }
+
+                auto& entry = lf[u];
+                entry.u0 = size_t(isrcA);
+                entry.weight0 = weight;
+
+                entry.u1 = size_t(isrcB);
+                entry.weight1 = 1.0f - weight;
+            }
         }
-
-        auto& entry = lf[u];
-        entry.u0 = size_t(isrcA);
-        entry.weight0 = weight;
-
-        entry.u1 = size_t(isrcB);
-        entry.weight1 = 1.0f - weight;
-    }
-}
 
 #define BILINEAR_INTERPOLATE( res, x, y, r0, r1 ) \
     res = XMVectorAdd(XMVectorScale(XMVectorAdd(XMVectorScale((r0)[ x.u0 ], x.weight0), XMVectorScale((r0)[ x.u1 ], x.weight1)), y.weight0), \
@@ -110,82 +112,82 @@ inline void _CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool 
     res = XMVectorAdd(XMVectorScale(XMVectorAdd(a0, a1), z.weight0), XMVectorScale(XMVectorAdd(a2, a3), z.weight1)); \
 }
 
-//-------------------------------------------------------------------------------------
-// Cubic filtering helpers
-//-------------------------------------------------------------------------------------
+        //-------------------------------------------------------------------------------------
+        // Cubic filtering helpers
+        //-------------------------------------------------------------------------------------
 
-XMGLOBALCONST XMVECTORF32 g_cubicThird = { { { 1.f / 3.f, 1.f / 3.f, 1.f / 3.f, 1.f / 3.f } } };
-XMGLOBALCONST XMVECTORF32 g_cubicSixth = { { { 1.f / 6.f, 1.f / 6.f, 1.f / 6.f, 1.f / 6.f } } };
-XMGLOBALCONST XMVECTORF32 g_cubicHalf  = { { { 1.f / 2.f, 1.f / 2.f, 1.f / 2.f, 1.f / 2.f } } };
+        XMGLOBALCONST XMVECTORF32 g_cubicThird = { { { 1.f / 3.f, 1.f / 3.f, 1.f / 3.f, 1.f / 3.f } } };
+        XMGLOBALCONST XMVECTORF32 g_cubicSixth = { { { 1.f / 6.f, 1.f / 6.f, 1.f / 6.f, 1.f / 6.f } } };
+        XMGLOBALCONST XMVECTORF32 g_cubicHalf = { { { 1.f / 2.f, 1.f / 2.f, 1.f / 2.f, 1.f / 2.f } } };
 
-inline ptrdiff_t bounduvw(ptrdiff_t u, ptrdiff_t maxu, bool wrap, bool mirror) noexcept
-{
-    if (wrap)
-    {
-        if (u < 0)
+        inline ptrdiff_t bounduvw(ptrdiff_t u, ptrdiff_t maxu, bool wrap, bool mirror) noexcept
         {
-            u = maxu + u + 1;
+            if (wrap)
+            {
+                if (u < 0)
+                {
+                    u = maxu + u + 1;
+                }
+                else if (u > maxu)
+                {
+                    u = u - maxu - 1;
+                }
+            }
+            else if (mirror)
+            {
+                if (u < 0)
+                {
+                    u = (-u) - 1;
+                }
+                else if (u > maxu)
+                {
+                    u = maxu - (u - maxu - 1);
+                }
+            }
+
+            // Handles clamp, but also a safety factor for degenerate images for wrap/mirror
+            u = std::min<ptrdiff_t>(u, maxu);
+            u = std::max<ptrdiff_t>(u, 0);
+
+            return u;
         }
-        else if (u > maxu)
+
+        struct CubicFilter
         {
-            u = u - maxu - 1;
-        }
-    }
-    else if (mirror)
-    {
-        if (u < 0)
+            size_t  u0;
+            size_t  u1;
+            size_t  u2;
+            size_t  u3;
+            float   x;
+        };
+
+        inline void CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _In_ bool mirror, _Out_writes_(dest) CubicFilter* cf) noexcept
         {
-            u = (-u) - 1;
+            assert(source > 0);
+            assert(dest > 0);
+            assert(cf != nullptr);
+
+            float scale = float(source) / float(dest);
+
+            for (size_t u = 0; u < dest; ++u)
+            {
+                float srcB = (float(u) + 0.5f) * scale - 0.5f;
+
+                ptrdiff_t isrcB = bounduvw(ptrdiff_t(srcB), ptrdiff_t(source) - 1, wrap, mirror);
+                ptrdiff_t isrcA = bounduvw(isrcB - 1, ptrdiff_t(source) - 1, wrap, mirror);
+                ptrdiff_t isrcC = bounduvw(isrcB + 1, ptrdiff_t(source) - 1, wrap, mirror);
+                ptrdiff_t isrcD = bounduvw(isrcB + 2, ptrdiff_t(source) - 1, wrap, mirror);
+
+                auto& entry = cf[u];
+                entry.u0 = size_t(isrcA);
+                entry.u1 = size_t(isrcB);
+                entry.u2 = size_t(isrcC);
+                entry.u3 = size_t(isrcD);
+
+                float x = srcB - float(isrcB);
+                entry.x = x;
+            }
         }
-        else if (u > maxu)
-        {
-            u = maxu - (u - maxu - 1);
-        }
-    }
-
-    // Handles clamp, but also a safety factor for degenerate images for wrap/mirror
-    u = std::min<ptrdiff_t>(u, maxu);
-    u = std::max<ptrdiff_t>(u, 0);
-
-    return u;
-}
-
-struct CubicFilter
-{
-    size_t  u0;
-    size_t  u1;
-    size_t  u2;
-    size_t  u3;
-    float   x;
-};
-
-inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _In_ bool mirror, _Out_writes_(dest) CubicFilter* cf) noexcept
-{
-    assert(source > 0);
-    assert(dest > 0);
-    assert(cf != nullptr);
-
-    float scale = float(source) / float(dest);
-
-    for (size_t u = 0; u < dest; ++u)
-    {
-        float srcB = (float(u) + 0.5f) * scale - 0.5f;
-
-        ptrdiff_t isrcB = bounduvw(ptrdiff_t(srcB), ptrdiff_t(source) - 1, wrap, mirror);
-        ptrdiff_t isrcA = bounduvw(isrcB - 1, ptrdiff_t(source) - 1, wrap, mirror);
-        ptrdiff_t isrcC = bounduvw(isrcB + 1, ptrdiff_t(source) - 1, wrap, mirror);
-        ptrdiff_t isrcD = bounduvw(isrcB + 2, ptrdiff_t(source) - 1, wrap, mirror);
-
-        auto& entry = cf[u];
-        entry.u0 = size_t(isrcA);
-        entry.u1 = size_t(isrcB);
-        entry.u2 = size_t(isrcC);
-        entry.u3 = size_t(isrcD);
-
-        float x = srcB - float(isrcB);
-        entry.x = x;
-    }
-}
 
 #define CUBIC_INTERPOLATE( res, dx, p0, p1, p2, p3 ) \
 { \
@@ -205,219 +207,216 @@ inline void _CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool w
 }
 
 
-//-------------------------------------------------------------------------------------
-// Triangle filtering helpers
-//-------------------------------------------------------------------------------------
+        //-------------------------------------------------------------------------------------
+        // Triangle filtering helpers
+        //-------------------------------------------------------------------------------------
 
-namespace TriangleFilter
-{
-    struct FilterTo
-    {
-        size_t      u;
-        float       weight;
-    };
-
-    struct FilterFrom
-    {
-        size_t      count;
-        size_t      sizeInBytes;
-        FilterTo    to[1]; // variable-sized array
-    };
-
-    struct Filter
-    {
-        size_t      sizeInBytes;
-        size_t      totalSize;
-        FilterFrom  from[1]; // variable-sized array
-    };
-
-    struct TriangleRow
-    {
-        size_t                      remaining;
-        TriangleRow*                next;
-        ScopedAlignedArrayXMVECTOR  scanline;
-
-        TriangleRow() noexcept : remaining(0), next(nullptr) {}
-    };
-
-    constexpr size_t TF_FILTER_SIZE = sizeof(Filter) - sizeof(FilterFrom);
-    constexpr size_t TF_FROM_SIZE = sizeof(FilterFrom) - sizeof(FilterTo);
-    constexpr size_t TF_TO_SIZE = sizeof(FilterTo);
-
-    constexpr float TF_EPSILON = 0.00001f;
-
-    inline HRESULT _Create(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _Inout_ std::unique_ptr<Filter>& tf) noexcept
-    {
-        assert(source > 0);
-        assert(dest > 0);
-
-        float scale = float(dest) / float(source);
-        float scaleInv = 0.5f / scale;
-
-        // Determine storage required for filter and allocate memory if needed
-        size_t totalSize = TF_FILTER_SIZE + TF_FROM_SIZE + TF_TO_SIZE;
-        float repeat = (wrap) ? 1.f : 0.f;
-
-        for (size_t u = 0; u < source; ++u)
+        struct FilterTo
         {
-            float src = float(u) - 0.5f;
-            float destMin = src * scale;
-            float destMax = destMin + scale;
-            float t = destMax - destMin + repeat + 1.f;
-            totalSize += TF_FROM_SIZE + TF_TO_SIZE + size_t(t) * TF_TO_SIZE * 2;
-        }
+            size_t      u;
+            float       weight;
+        };
 
-        uint8_t* pFilter = nullptr;
-
-        if (tf)
+        struct FilterFrom
         {
-            // See if existing filter memory block is large enough to reuse
-            if (tf->totalSize >= totalSize)
+            size_t      count;
+            size_t      sizeInBytes;
+            FilterTo    to[1]; // variable-sized array
+        };
+
+        struct Filter
+        {
+            size_t      sizeInBytes;
+            size_t      totalSize;
+            FilterFrom  from[1]; // variable-sized array
+        };
+
+        struct TriangleRow
+        {
+            size_t                      remaining;
+            TriangleRow* next;
+            ScopedAlignedArrayXMVECTOR  scanline;
+
+            TriangleRow() noexcept : remaining(0), next(nullptr) {}
+        };
+
+        constexpr size_t TF_FILTER_SIZE = sizeof(Filter) - sizeof(FilterFrom);
+        constexpr size_t TF_FROM_SIZE = sizeof(FilterFrom) - sizeof(FilterTo);
+        constexpr size_t TF_TO_SIZE = sizeof(FilterTo);
+
+        constexpr float TF_EPSILON = 0.00001f;
+
+        inline HRESULT CreateTriangleFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _Inout_ std::unique_ptr<Filter>& tf) noexcept
+        {
+            assert(source > 0);
+            assert(dest > 0);
+
+            float scale = float(dest) / float(source);
+            float scaleInv = 0.5f / scale;
+
+            // Determine storage required for filter and allocate memory if needed
+            size_t totalSize = TF_FILTER_SIZE + TF_FROM_SIZE + TF_TO_SIZE;
+            float repeat = (wrap) ? 1.f : 0.f;
+
+            for (size_t u = 0; u < source; ++u)
             {
-                pFilter = reinterpret_cast<uint8_t*>(tf.get());
-            }
-            else
-            {
-                // Need to reallocate filter memory block
-                tf.reset(nullptr);
-            }
-        }
-
-        if (!tf)
-        {
-            // Allocate filter memory block
-            pFilter = new (std::nothrow) uint8_t[totalSize];
-            if (!pFilter)
-                return E_OUTOFMEMORY;
-
-            tf.reset(reinterpret_cast<Filter*>(pFilter));
-            tf->totalSize = totalSize;
-        }
-
-        assert(pFilter != nullptr);
-        _Analysis_assume_(pFilter != nullptr);
-
-        // Filter setup
-        size_t sizeInBytes = TF_FILTER_SIZE;
-        size_t accumU = 0;
-        float accumWeight = 0.f;
-
-        for (size_t u = 0; u < source; ++u)
-        {
-            // Setup from entry
-            size_t sizeFrom = sizeInBytes;
-            auto pFrom = reinterpret_cast<FilterFrom*>(pFilter + sizeInBytes);
-            sizeInBytes += TF_FROM_SIZE;
-
-            if (sizeInBytes > totalSize)
-                return E_FAIL;
-
-            size_t toCount = 0;
-
-            // Perform two passes to capture the influences from both sides
-            for (size_t j = 0; j < 2; ++j)
-            {
-                float src = float(u + j) - 0.5f;
-
+                float src = float(u) - 0.5f;
                 float destMin = src * scale;
                 float destMax = destMin + scale;
+                float t = destMax - destMin + repeat + 1.f;
+                totalSize += TF_FROM_SIZE + TF_TO_SIZE + size_t(t) * TF_TO_SIZE * 2;
+            }
 
-                if (!wrap)
+            uint8_t* pFilter = nullptr;
+
+            if (tf)
+            {
+                // See if existing filter memory block is large enough to reuse
+                if (tf->totalSize >= totalSize)
                 {
-                    // Clamp
-                    if (destMin < 0.f)
-                        destMin = 0.f;
-                    if (destMax > float(dest))
-                        destMax = float(dest);
+                    pFilter = reinterpret_cast<uint8_t*>(tf.get());
                 }
-
-                for (auto k = static_cast<ptrdiff_t>(floorf(destMin)); float(k) < destMax; ++k)
+                else
                 {
-                    float d0 = float(k);
-                    float d1 = d0 + 1.f;
-
-                    size_t u0;
-                    if (k < 0)
-                    {
-                        // Handle wrap
-                        u0 = size_t(k + ptrdiff_t(dest));
-                    }
-                    else if (k >= ptrdiff_t(dest))
-                    {
-                        // Handle wrap
-                        u0 = size_t(k - ptrdiff_t(dest));
-                    }
-                    else
-                    {
-                        u0 = size_t(k);
-                    }
-
-                    // Save previous accumulated weight (if any)
-                    if (u0 != accumU)
-                    {
-                        if (accumWeight > TF_EPSILON)
-                        {
-                            auto pTo = reinterpret_cast<FilterTo*>(pFilter + sizeInBytes);
-                            sizeInBytes += TF_TO_SIZE;
-                            ++toCount;
-
-                            if (sizeInBytes > totalSize)
-                                return E_FAIL;
-
-                            pTo->u = accumU;
-                            pTo->weight = accumWeight;
-                        }
-
-                        accumWeight = 0.f;
-                        accumU = u0;
-                    }
-
-                    // Clip destination
-                    if (d0 < destMin)
-                        d0 = destMin;
-                    if (d1 > destMax)
-                        d1 = destMax;
-
-                    // Calculate average weight over destination pixel
-
-                    float weight;
-                    if (!wrap && src < 0.f)
-                        weight = 1.f;
-                    else if (!wrap && ((src + 1.f) >= float(source)))
-                        weight = 0.f;
-                    else
-                        weight = (d0 + d1) * scaleInv - src;
-
-                    accumWeight += (d1 - d0) * (j ? (1.f - weight) : weight);
+                    // Need to reallocate filter memory block
+                    tf.reset(nullptr);
                 }
             }
 
-            // Store accumulated weight
-            if (accumWeight > TF_EPSILON)
+            if (!tf)
             {
-                auto pTo = reinterpret_cast<FilterTo*>(pFilter + sizeInBytes);
-                sizeInBytes += TF_TO_SIZE;
-                ++toCount;
+                // Allocate filter memory block
+                pFilter = new (std::nothrow) uint8_t[totalSize];
+                if (!pFilter)
+                    return E_OUTOFMEMORY;
+
+                tf.reset(reinterpret_cast<Filter*>(pFilter));
+                tf->totalSize = totalSize;
+            }
+
+            assert(pFilter != nullptr);
+            _Analysis_assume_(pFilter != nullptr);
+
+            // Filter setup
+            size_t sizeInBytes = TF_FILTER_SIZE;
+            size_t accumU = 0;
+            float accumWeight = 0.f;
+
+            for (size_t u = 0; u < source; ++u)
+            {
+                // Setup from entry
+                size_t sizeFrom = sizeInBytes;
+                auto pFrom = reinterpret_cast<FilterFrom*>(pFilter + sizeInBytes);
+                sizeInBytes += TF_FROM_SIZE;
 
                 if (sizeInBytes > totalSize)
                     return E_FAIL;
 
-                pTo->u = accumU;
-                pTo->weight = accumWeight;
+                size_t toCount = 0;
+
+                // Perform two passes to capture the influences from both sides
+                for (size_t j = 0; j < 2; ++j)
+                {
+                    float src = float(u + j) - 0.5f;
+
+                    float destMin = src * scale;
+                    float destMax = destMin + scale;
+
+                    if (!wrap)
+                    {
+                        // Clamp
+                        if (destMin < 0.f)
+                            destMin = 0.f;
+                        if (destMax > float(dest))
+                            destMax = float(dest);
+                    }
+
+                    for (auto k = static_cast<ptrdiff_t>(floorf(destMin)); float(k) < destMax; ++k)
+                    {
+                        float d0 = float(k);
+                        float d1 = d0 + 1.f;
+
+                        size_t u0;
+                        if (k < 0)
+                        {
+                            // Handle wrap
+                            u0 = size_t(k + ptrdiff_t(dest));
+                        }
+                        else if (k >= ptrdiff_t(dest))
+                        {
+                            // Handle wrap
+                            u0 = size_t(k - ptrdiff_t(dest));
+                        }
+                        else
+                        {
+                            u0 = size_t(k);
+                        }
+
+                        // Save previous accumulated weight (if any)
+                        if (u0 != accumU)
+                        {
+                            if (accumWeight > TF_EPSILON)
+                            {
+                                auto pTo = reinterpret_cast<FilterTo*>(pFilter + sizeInBytes);
+                                sizeInBytes += TF_TO_SIZE;
+                                ++toCount;
+
+                                if (sizeInBytes > totalSize)
+                                    return E_FAIL;
+
+                                pTo->u = accumU;
+                                pTo->weight = accumWeight;
+                            }
+
+                            accumWeight = 0.f;
+                            accumU = u0;
+                        }
+
+                        // Clip destination
+                        if (d0 < destMin)
+                            d0 = destMin;
+                        if (d1 > destMax)
+                            d1 = destMax;
+
+                        // Calculate average weight over destination pixel
+
+                        float weight;
+                        if (!wrap && src < 0.f)
+                            weight = 1.f;
+                        else if (!wrap && ((src + 1.f) >= float(source)))
+                            weight = 0.f;
+                        else
+                            weight = (d0 + d1) * scaleInv - src;
+
+                        accumWeight += (d1 - d0) * (j ? (1.f - weight) : weight);
+                    }
+                }
+
+                // Store accumulated weight
+                if (accumWeight > TF_EPSILON)
+                {
+                    auto pTo = reinterpret_cast<FilterTo*>(pFilter + sizeInBytes);
+                    sizeInBytes += TF_TO_SIZE;
+                    ++toCount;
+
+                    if (sizeInBytes > totalSize)
+                        return E_FAIL;
+
+                    pTo->u = accumU;
+                    pTo->weight = accumWeight;
+                }
+
+                accumWeight = 0.f;
+
+                // Finalize from entry
+                pFrom->count = toCount;
+                pFrom->sizeInBytes = sizeInBytes - sizeFrom;
             }
 
-            accumWeight = 0.f;
+            tf->sizeInBytes = sizeInBytes;
 
-            // Finalize from entry
-            pFrom->count = toCount;
-            pFrom->sizeInBytes = sizeInBytes - sizeFrom;
+            return S_OK;
         }
 
-        tf->sizeInBytes = sizeInBytes;
-
-        return S_OK;
-    }
-
-} // namespace TriangleFilter
-
+    } // namespace Filters
 } // namespace DirectX

--- a/ScreenGrab/ScreenGrab11.cpp
+++ b/ScreenGrab/ScreenGrab11.cpp
@@ -768,7 +768,7 @@ namespace
 #endif
     }
 
-    IWICImagingFactory* _GetWIC() noexcept
+    IWICImagingFactory* GetWIC() noexcept
     {
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -1022,7 +1022,7 @@ HRESULT DirectX::SaveWICTextureToFile(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 

--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -863,7 +863,7 @@ namespace
             ifactory)) ? TRUE : FALSE;
     }
 
-    IWICImagingFactory2* _GetWIC() noexcept
+    IWICImagingFactory2* GetWIC() noexcept
     {
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -1200,7 +1200,7 @@ HRESULT DirectX::SaveWICTextureToFile(
         return HRESULT_E_NOT_SUPPORTED;
     }
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 

--- a/ScreenGrab/ScreenGrab9.cpp
+++ b/ScreenGrab/ScreenGrab9.cpp
@@ -549,7 +549,7 @@ namespace
 #endif
     }
 
-    IWICImagingFactory* _GetWIC()
+    IWICImagingFactory* GetWIC()
     {
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -770,7 +770,7 @@ HRESULT DirectX::SaveWICTextureToFile(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 

--- a/WICTextureLoader/WICTextureLoader11.cpp
+++ b/WICTextureLoader/WICTextureLoader11.cpp
@@ -216,7 +216,7 @@ namespace
 #endif
     }
 
-    IWICImagingFactory* _GetWIC() noexcept
+    IWICImagingFactory* GetWIC() noexcept
     {
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -234,7 +234,7 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
-    DXGI_FORMAT _WICToDXGI(const GUID& guid) noexcept
+    DXGI_FORMAT WICToDXGI(const GUID& guid) noexcept
     {
         for (size_t i = 0; i < std::size(g_WICFormats); ++i)
         {
@@ -254,9 +254,9 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
-    size_t _WICBitsPerPixel(REFGUID targetGuid) noexcept
+    size_t WICBitsPerPixel(REFGUID targetGuid) noexcept
     {
-        auto pWIC = _GetWIC();
+        auto pWIC = GetWIC();
         if (!pWIC)
             return 0;
 
@@ -449,7 +449,7 @@ namespace
 
         size_t bpp = 0;
 
-        DXGI_FORMAT format = _WICToDXGI(pixelFormat);
+        DXGI_FORMAT format = WICToDXGI(pixelFormat);
         if (format == DXGI_FORMAT_UNKNOWN)
         {
             if (memcmp(&GUID_WICPixelFormat96bppRGBFixedPoint, &pixelFormat, sizeof(WICPixelFormatGUID)) == 0)
@@ -477,9 +477,9 @@ namespace
                     {
                         memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &g_WICConvert[i].target, sizeof(GUID));
 
-                        format = _WICToDXGI(g_WICConvert[i].target);
+                        format = WICToDXGI(g_WICConvert[i].target);
                         assert(format != DXGI_FORMAT_UNKNOWN);
-                        bpp = _WICBitsPerPixel(convertGUID);
+                        bpp = WICBitsPerPixel(convertGUID);
                         break;
                     }
                 }
@@ -490,7 +490,7 @@ namespace
         }
         else
         {
-            bpp = _WICBitsPerPixel(pixelFormat);
+            bpp = WICBitsPerPixel(pixelFormat);
         }
 
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
@@ -609,7 +609,7 @@ namespace
         else if (twidth != width || theight != height)
         {
             // Resize
-            auto pWIC = _GetWIC();
+            auto pWIC = GetWIC();
             if (!pWIC)
                 return E_NOINTERFACE;
 
@@ -660,7 +660,7 @@ namespace
         else
         {
             // Format conversion but no resize
-            auto pWIC = _GetWIC();
+            auto pWIC = GetWIC();
             if (!pWIC)
                 return E_NOINTERFACE;
 
@@ -921,7 +921,7 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
     if (wicDataSize > UINT32_MAX)
         return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 
@@ -1055,7 +1055,7 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
         return E_INVALIDARG;
     }
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -177,7 +177,7 @@ namespace
             ifactory)) ? TRUE : FALSE;
     }
 
-    IWICImagingFactory2* _GetWIC() noexcept
+    IWICImagingFactory2* GetWIC() noexcept
     {
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -253,7 +253,7 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
-    DXGI_FORMAT _WICToDXGI(const GUID& guid) noexcept
+    DXGI_FORMAT WICToDXGI(const GUID& guid) noexcept
     {
         for (size_t i = 0; i < std::size(g_WICFormats); ++i)
         {
@@ -265,9 +265,9 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
-    size_t _WICBitsPerPixel(REFGUID targetGuid) noexcept
+    size_t WICBitsPerPixel(REFGUID targetGuid) noexcept
     {
-        auto pWIC = _GetWIC();
+        auto pWIC = GetWIC();
         if (!pWIC)
             return 0;
 
@@ -398,7 +398,7 @@ namespace
 
         size_t bpp = 0;
 
-        DXGI_FORMAT format = _WICToDXGI(pixelFormat);
+        DXGI_FORMAT format = WICToDXGI(pixelFormat);
         if (format == DXGI_FORMAT_UNKNOWN)
         {
             for (size_t i = 0; i < std::size(g_WICConvert); ++i)
@@ -407,9 +407,9 @@ namespace
                 {
                     memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &g_WICConvert[i].target, sizeof(GUID));
 
-                    format = _WICToDXGI(g_WICConvert[i].target);
+                    format = WICToDXGI(g_WICConvert[i].target);
                     assert(format != DXGI_FORMAT_UNKNOWN);
-                    bpp = _WICBitsPerPixel(convertGUID);
+                    bpp = WICBitsPerPixel(convertGUID);
                     break;
                 }
             }
@@ -419,7 +419,7 @@ namespace
         }
         else
         {
-            bpp = _WICBitsPerPixel(pixelFormat);
+            bpp = WICBitsPerPixel(pixelFormat);
         }
 
         if (loadFlags & WIC_LOADER_FORCE_RGBA32)
@@ -510,7 +510,7 @@ namespace
         else if (twidth != width || theight != height)
         {
             // Resize
-            auto pWIC = _GetWIC();
+            auto pWIC = GetWIC();
             if (!pWIC)
                 return E_NOINTERFACE;
 
@@ -561,7 +561,7 @@ namespace
         else
         {
             // Format conversion but no resize
-            auto pWIC = _GetWIC();
+            auto pWIC = GetWIC();
             if (!pWIC)
                 return E_NOINTERFACE;
 
@@ -708,7 +708,7 @@ HRESULT DirectX::LoadWICTextureFromMemoryEx(
     if (wicDataSize > UINT32_MAX)
         return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 
@@ -789,7 +789,7 @@ HRESULT DirectX::LoadWICTextureFromFileEx(
     if (!d3dDevice || !fileName || !texture)
         return E_INVALIDARG;
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -197,7 +197,7 @@ namespace
 #endif
     }
 
-    IWICImagingFactory* _GetWIC() noexcept
+    IWICImagingFactory* GetWIC() noexcept
     {
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -215,7 +215,7 @@ namespace
     }
 
     //---------------------------------------------------------------------------------
-    D3DFORMAT _WICToD3D9(const GUID& guid) noexcept
+    D3DFORMAT WICToD3D9(const GUID& guid) noexcept
     {
         for (size_t i = 0; i < std::size(g_WICFormats); ++i)
         {
@@ -331,7 +331,7 @@ namespace
         WICPixelFormatGUID convertGUID;
         memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &pixelFormat, sizeof(GUID));
 
-        D3DFORMAT format = _WICToD3D9(pixelFormat);
+        D3DFORMAT format = WICToD3D9(pixelFormat);
         if (format == D3DFMT_UNKNOWN)
         {
             for (size_t i = 0; i < std::size(g_WICConvert); ++i)
@@ -340,7 +340,7 @@ namespace
                 {
                     memcpy_s(&convertGUID, sizeof(WICPixelFormatGUID), &g_WICConvert[i].target, sizeof(GUID));
 
-                    format = _WICToD3D9(g_WICConvert[i].target);
+                    format = WICToD3D9(g_WICConvert[i].target);
                     assert(format != D3DFMT_UNKNOWN);
                     break;
                 }
@@ -417,7 +417,7 @@ namespace
         else if (twidth != width || theight != height)
         {
             // Resize
-            auto pWIC = _GetWIC();
+            auto pWIC = GetWIC();
             if (!pWIC)
                 return E_NOINTERFACE;
 
@@ -484,7 +484,7 @@ namespace
         else
         {
             // Format conversion but no resize
-            auto pWIC = _GetWIC();
+            auto pWIC = GetWIC();
             if (!pWIC)
                 return E_NOINTERFACE;
 
@@ -569,7 +569,7 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
     if (wicDataSize > UINT32_MAX)
         return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 
@@ -627,7 +627,7 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
     if (!d3dDevice || !fileName || !texture)
         return E_INVALIDARG;
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 


### PR DESCRIPTION
Per the C++ Standard:

> the identifiers that begin with an underscore followed by an uppercase letter are reserved;

I had this in my backlog for some time, but never got around to it until now. Clang v13 (which is in VS 2022 Update 1) has added a new warning for this case: ``-Wreserved-identifier``

In addition, I've made the ``EncodeDDSHeader`` function public per request.
