### PR TITLE
Add support for HEIF and WEBP to command-line tools

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -819,6 +819,7 @@ namespace DirectX
         WIC_CODEC_GIF,              // Graphics Interchange Format  (.gif)
         WIC_CODEC_WMP,              // Windows Media Photo / HD Photo / JPEG XR (.hdp, .jxr, .wdp)
         WIC_CODEC_ICO,              // Windows Icon (.ico)
+        WIC_CODEC_HEIF,             // HEIF (requires https://aka.ms/heif to be installed)
     };
 
     REFGUID __cdecl GetWICCodec(_In_ WICCodecs codec) noexcept;

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -819,7 +819,7 @@ namespace DirectX
         WIC_CODEC_GIF,              // Graphics Interchange Format  (.gif)
         WIC_CODEC_WMP,              // Windows Media Photo / HD Photo / JPEG XR (.hdp, .jxr, .wdp)
         WIC_CODEC_ICO,              // Windows Icon (.ico)
-        WIC_CODEC_HEIF,             // HEIF (requires https://aka.ms/heif to be installed)
+        WIC_CODEC_HEIF,             // High Efficiency Image File (.heif, .heic)
     };
 
     REFGUID __cdecl GetWICCodec(_In_ WICCodecs codec) noexcept;

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -270,6 +270,10 @@ REFGUID DirectX::GetWICCodec(WICCodecs codec) noexcept
     case WIC_CODEC_ICO:
         return GUID_ContainerFormatIco;
 
+    case WIC_CODEC_HEIF:
+        // This requires installing https://aka.ms/heif
+        return GUID_ContainerFormatHeif;
+
     default:
         return GUID_NULL;
     }

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -1569,7 +1569,7 @@ HRESULT DirectX::SaveToWICFile(
     if (FAILED(hr))
     {
         stream.Reset();
-        DeleteFileW(szFile);
+        std::ignore = DeleteFileW(szFile);
         return hr;
     }
 
@@ -1611,7 +1611,7 @@ HRESULT DirectX::SaveToWICFile(
     if (FAILED(hr))
     {
         stream.Reset();
-        DeleteFileW(szFile);
+        std::ignore = DeleteFileW(szFile);
         return hr;
     }
 

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -791,7 +791,14 @@ namespace
 #endif
 
         default:
-            return SaveToWICFile(img, WIC_FLAGS_NONE, GetWICCodec(static_cast<WICCodecs>(fileType)), szOutputFile);
+        {
+            HRESULT hr = SaveToWICFile(img, WIC_FLAGS_NONE, GetWICCodec(static_cast<WICCodecs>(fileType)), szOutputFile);
+            if ((hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */) && (fileType == WIC_CODEC_HEIF))
+            {
+                wprintf(L"\nINFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
+            }
+            return hr;
+        }
         }
     }
 

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -793,7 +793,7 @@ namespace
         default:
         {
             HRESULT hr = SaveToWICFile(img, WIC_FLAGS_NONE, GetWICCodec(static_cast<WICCodecs>(fileType)), szOutputFile);
-            if ((hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */) && (fileType == WIC_CODEC_HEIF))
+            if ((hr == static_cast<HRESULT>(0xc00d5212) /* MF_E_TOPO_CODEC_NOT_FOUND */) && (fileType == WIC_CODEC_HEIF))
             {
                 wprintf(L"\nINFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
             }
@@ -1483,7 +1483,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     if (FAILED(hr))
                     {
                         wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
-                        if (hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */)
+                        if (hr == static_cast<HRESULT>(0xc00d5212) /* MF_E_TOPO_CODEC_NOT_FOUND */)
                         {
                             if (_wcsicmp(ext, L".heic") == 0 || _wcsicmp(ext, L".heif") == 0)
                             {

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -1465,6 +1465,11 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 #endif
                 else
                 {
+                    // This supports the built-in native codecs as well as installed WIC codecs.
+                    //
+                    // .HEIC, .HEIF : install https://aka.ms/heif
+                    // .WEBP        : install https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg
+
                     // WIC shares the same filter values for mode and dither
                     static_assert(static_cast<int>(WIC_FLAGS_DITHER) == static_cast<int>(TEX_FILTER_DITHER), "WIC_FLAGS_* & TEX_FILTER_* should match");
                     static_assert(static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION) == static_cast<int>(TEX_FILTER_DITHER_DIFFUSION), "WIC_FLAGS_* & TEX_FILTER_* should match");

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -709,9 +709,8 @@ namespace
             swprintf_s(desc, L": %ls", errorText);
 
             size_t len = wcslen(desc);
-            if (len >= 2)
+            if (len >= 1)
             {
-                desc[len - 2] = 0;
                 desc[len - 1] = 0;
             }
 
@@ -1465,11 +1464,6 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 #endif
                 else
                 {
-                    // This supports the built-in native codecs as well as installed WIC codecs.
-                    //
-                    // .HEIC, .HEIF : install https://aka.ms/heif
-                    // .WEBP        : install https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg
-
                     // WIC shares the same filter values for mode and dither
                     static_assert(static_cast<int>(WIC_FLAGS_DITHER) == static_cast<int>(TEX_FILTER_DITHER), "WIC_FLAGS_* & TEX_FILTER_* should match");
                     static_assert(static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION) == static_cast<int>(TEX_FILTER_DITHER_DIFFUSION), "WIC_FLAGS_* & TEX_FILTER_* should match");
@@ -1482,6 +1476,17 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     if (FAILED(hr))
                     {
                         wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
+                        if (hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */)
+                        {
+                            if (_wcsicmp(ext, L".heic") == 0 || _wcsicmp(ext, L".heif") == 0)
+                            {
+                                wprintf(L"INFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
+                            }
+                            else if (_wcsicmp(ext, L".webp") == 0)
+                            {
+                                wprintf(L"INFO: This format requires installing the WEBP Image Extensions - https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg\n");
+                            }
+                        }
                         return 1;
                     }
                 }

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -2119,7 +2119,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             {
                 wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 retVal = 1;
-                if (hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */)
+                if (hr == static_cast<HRESULT>(0xc00d5212) /* MF_E_TOPO_CODEC_NOT_FOUND */)
                 {
                     if (_wcsicmp(ext, L".heic") == 0 || _wcsicmp(ext, L".heif") == 0)
                     {
@@ -3703,7 +3703,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             {
                 wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 retVal = 1;
-                if ((hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */) && (FileType == WIC_CODEC_HEIF))
+                if ((hr == static_cast<HRESULT>(0xc00d5212) /* MF_E_TOPO_CODEC_NOT_FOUND */) && (FileType == WIC_CODEC_HEIF))
                 {
                     wprintf(L"INFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
                 }

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -443,6 +443,8 @@ namespace
     #ifdef USE_OPENEXR
         { L"exr",   CODEC_EXR      },
     #endif
+        { L"heic",  WIC_CODEC_HEIF },
+        { L"heif",  WIC_CODEC_HEIF },
         { nullptr,  CODEC_DDS      }
     };
 
@@ -2101,6 +2103,11 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 #endif
         else
         {
+            // This supports the built-in native codecs as well as installed WIC codecs.
+            //
+            // .HEIC, .HEIF : install https://aka.ms/heif
+            // .WEBP        : install https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg
+
             // WIC shares the same filter values for mode and dither
             static_assert(static_cast<int>(WIC_FLAGS_DITHER) == static_cast<int>(TEX_FILTER_DITHER), "WIC_FLAGS_* & TEX_FILTER_* should match");
             static_assert(static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION) == static_cast<int>(TEX_FILTER_DITHER_DIFFUSION), "WIC_FLAGS_* & TEX_FILTER_* should match");
@@ -3691,6 +3698,10 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             {
                 wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 retVal = 1;
+                if (hr == WINCODEC_ERR_COMPONENTNOTFOUND && FileType == WIC_CODEC_HEIF)
+                {
+                    wprintf(L"This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
+                }
                 continue;
             }
             wprintf(L"\n");

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -1002,9 +1002,8 @@ namespace
             swprintf_s(desc, L": %ls", errorText);
 
             size_t len = wcslen(desc);
-            if (len >= 2)
+            if (len >= 1)
             {
-                desc[len - 2] = 0;
                 desc[len - 1] = 0;
             }
 
@@ -2103,11 +2102,6 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 #endif
         else
         {
-            // This supports the built-in native codecs as well as installed WIC codecs.
-            //
-            // .HEIC, .HEIF : install https://aka.ms/heif
-            // .WEBP        : install https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg
-
             // WIC shares the same filter values for mode and dither
             static_assert(static_cast<int>(WIC_FLAGS_DITHER) == static_cast<int>(TEX_FILTER_DITHER), "WIC_FLAGS_* & TEX_FILTER_* should match");
             static_assert(static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION) == static_cast<int>(TEX_FILTER_DITHER_DIFFUSION), "WIC_FLAGS_* & TEX_FILTER_* should match");
@@ -2125,6 +2119,17 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             {
                 wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 retVal = 1;
+                if (hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */)
+                {
+                    if (_wcsicmp(ext, L".heic") == 0 || _wcsicmp(ext, L".heif") == 0)
+                    {
+                        wprintf(L"INFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
+                    }
+                    else if (_wcsicmp(ext, L".webp") == 0)
+                    {
+                        wprintf(L"INFO: This format requires installing the WEBP Image Extensions - https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg\n");
+                    }
+                }
                 continue;
             }
         }
@@ -3698,9 +3703,9 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             {
                 wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 retVal = 1;
-                if (hr == WINCODEC_ERR_COMPONENTNOTFOUND && FileType == WIC_CODEC_HEIF)
+                if ((hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */) && (FileType == WIC_CODEC_HEIF))
                 {
-                    wprintf(L"This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
+                    wprintf(L"INFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
                 }
                 continue;
             }

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -799,7 +799,7 @@ namespace
             static_assert(static_cast<int>(WIC_FLAGS_FILTER_FANT) == static_cast<int>(TEX_FILTER_FANT), "WIC_FLAGS_* & TEX_FILTER_* should match");
 
             HRESULT hr = LoadFromWICFile(fileName, dwFilter | WIC_FLAGS_ALL_FRAMES, &info, *image);
-            if (hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */)
+            if (hr == static_cast<HRESULT>(0xc00d5212) /* MF_E_TOPO_CODEC_NOT_FOUND */)
             {
                 if (_wcsicmp(ext, L".heic") == 0 || _wcsicmp(ext, L".heif") == 0)
                 {

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -791,6 +791,11 @@ namespace
 #endif
         else
         {
+            // This supports the built-in native codecs as well as installed WIC codecs.
+            //
+            // .HEIC, .HEIF : install https://aka.ms/heif
+            // .WEBP        : install https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg
+
             // WIC shares the same filter values for mode and dither
             static_assert(static_cast<int>(WIC_FLAGS_DITHER) == static_cast<int>(TEX_FILTER_DITHER), "WIC_FLAGS_* & TEX_FILTER_* should match");
             static_assert(static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION) == static_cast<int>(TEX_FILTER_DITHER_DIFFUSION), "WIC_FLAGS_* & TEX_FILTER_* should match");

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -712,9 +712,8 @@ namespace
             swprintf_s(desc, L": %ls", errorText);
 
             size_t len = wcslen(desc);
-            if (len >= 2)
+            if (len >= 1)
             {
-                desc[len - 2] = 0;
                 desc[len - 1] = 0;
             }
 
@@ -791,11 +790,6 @@ namespace
 #endif
         else
         {
-            // This supports the built-in native codecs as well as installed WIC codecs.
-            //
-            // .HEIC, .HEIF : install https://aka.ms/heif
-            // .WEBP        : install https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg
-
             // WIC shares the same filter values for mode and dither
             static_assert(static_cast<int>(WIC_FLAGS_DITHER) == static_cast<int>(TEX_FILTER_DITHER), "WIC_FLAGS_* & TEX_FILTER_* should match");
             static_assert(static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION) == static_cast<int>(TEX_FILTER_DITHER_DIFFUSION), "WIC_FLAGS_* & TEX_FILTER_* should match");
@@ -804,7 +798,19 @@ namespace
             static_assert(static_cast<int>(WIC_FLAGS_FILTER_CUBIC) == static_cast<int>(TEX_FILTER_CUBIC), "WIC_FLAGS_* & TEX_FILTER_* should match");
             static_assert(static_cast<int>(WIC_FLAGS_FILTER_FANT) == static_cast<int>(TEX_FILTER_FANT), "WIC_FLAGS_* & TEX_FILTER_* should match");
 
-            return LoadFromWICFile(fileName, dwFilter | WIC_FLAGS_ALL_FRAMES, &info, *image);
+            HRESULT hr = LoadFromWICFile(fileName, dwFilter | WIC_FLAGS_ALL_FRAMES, &info, *image);
+            if (hr == 0xc00d5212 /* MF_E_TOPO_CODEC_NOT_FOUND */)
+            {
+                if (_wcsicmp(ext, L".heic") == 0 || _wcsicmp(ext, L".heif") == 0)
+                {
+                    wprintf(L"\nINFO: This format requires installing the HEIF Image Extensions - https://aka.ms/heif\n");
+                }
+                else if (_wcsicmp(ext, L".webp") == 0)
+                {
+                    wprintf(L"\nINFO: This format requires installing the WEBP Image Extensions - https://www.microsoft.com/p/webp-image-extensions/9pg2dk419drg\n");
+                }
+            }
+            return hr;
         }
     }
 


### PR DESCRIPTION
HEIF/HEIC and WEBP are not supported by 'native' WIC codecs, but are supported by official Microsoft installable codecs from the Microsoft Store. This updates the command-line tools to support these.

> WEBP is only supported for reading. HEIF/HEIC is supported for read and write.
