### PR TITLE
texassemble updates for cubemap image generation

### DIFF
--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -73,6 +73,7 @@ namespace
         CMD_H_CROSS,
         CMD_V_CROSS,
         CMD_V_CROSS_FNZ,
+        CMD_H_TEE,
         CMD_H_STRIP,
         CMD_V_STRIP,
         CMD_MERGE,
@@ -136,6 +137,7 @@ namespace
         { L"h-cross",       CMD_H_CROSS },
         { L"v-cross",       CMD_V_CROSS },
         { L"v-cross-fnz",   CMD_V_CROSS_FNZ },
+        { L"h-tee",         CMD_H_TEE },
         { L"h-strip",       CMD_H_STRIP },
         { L"v-strip",       CMD_V_STRIP },
         { L"merge",         CMD_MERGE },
@@ -737,6 +739,7 @@ namespace
             L"   cubearray           create cubemap array\n"
             L"   h-cross or v-cross  create a cross image from a cubemap\n"
             L"   v-cross-fnz         create a cross image flipping the -Z face\n"
+            L"   h-tee               create a 'T' image from a cubemap\n"
             L"   h-strip or v-strip  create a strip image from a cubemap\n"
             L"   array-strip         creates a strip image from a 1D/2D array\n"
             L"   merge               create texture from rgb image and alpha image\n"
@@ -998,6 +1001,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     case CMD_H_CROSS:
     case CMD_V_CROSS:
     case CMD_V_CROSS_FNZ:
+    case CMD_H_TEE:
     case CMD_H_STRIP:
     case CMD_V_STRIP:
     case CMD_MERGE:
@@ -1006,7 +1010,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
         break;
 
     default:
-        wprintf(L"Must use one of: cube, volume, array, cubearray,\n   h-cross, v-cross, v-cross-fnz, h-strip, v-strip, array-strip\n   merge, gif\n\n");
+        wprintf(L"Must use one of: cube, volume, array, cubearray,\n   h-cross, v-cross, v-cross-fnz, h-tee, h-strip, v-strip,\n   array-strip, merge, gif\n\n");
         return 1;
     }
 
@@ -1139,6 +1143,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     case CMD_H_CROSS:
                     case CMD_V_CROSS:
                     case CMD_V_CROSS_FNZ:
+                    case CMD_H_TEE:
                     case CMD_H_STRIP:
                     case CMD_V_STRIP:
                     case CMD_MERGE:
@@ -1284,6 +1289,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     case CMD_H_CROSS:
     case CMD_V_CROSS:
     case CMD_V_CROSS_FNZ:
+    case CMD_H_TEE:
     case CMD_H_STRIP:
     case CMD_V_STRIP:
     case CMD_GIF:
@@ -1351,6 +1357,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 case CMD_H_CROSS:
                 case CMD_V_CROSS:
                 case CMD_V_CROSS_FNZ:
+                case CMD_H_TEE:
                 case CMD_H_STRIP:
                 case CMD_V_STRIP:
                 case CMD_ARRAY_STRIP:
@@ -1385,6 +1392,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             case CMD_H_CROSS:
             case CMD_V_CROSS:
             case CMD_V_CROSS_FNZ:
+            case CMD_H_TEE:
             case CMD_H_STRIP:
             case CMD_V_STRIP:
                 if (_wcsicmp(ext, L".dds") == 0)
@@ -1878,6 +1886,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     case CMD_H_CROSS:
     case CMD_V_CROSS:
     case CMD_V_CROSS_FNZ:
+    case CMD_H_TEE:
     case CMD_H_STRIP:
     case CMD_V_STRIP:
     case CMD_GIF:
@@ -1898,6 +1907,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     case CMD_H_CROSS:
     case CMD_V_CROSS:
     case CMD_V_CROSS_FNZ:
+    case CMD_H_TEE:
     case CMD_H_STRIP:
     case CMD_V_STRIP:
         {
@@ -1907,19 +1917,13 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             switch (dwCommand)
             {
             case CMD_H_CROSS:
-                //    +Y
-                // -X +Z +X -Z
-                //    -Y
+            case CMD_H_TEE:
                 twidth = width * 4;
                 theight = height * 3;
                 break;
 
             case CMD_V_CROSS:
             case CMD_V_CROSS_FNZ:
-                //    +Y
-                // -X +Z +X
-                //    -Y
-                //    -Z
                 twidth = width * 3;
                 theight = height * 4;
                 break;
@@ -2012,6 +2016,20 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                         {
                             flipRotate = TEX_FR_ROTATE180;
                         }
+                        break;
+                    }
+
+                case CMD_H_TEE:
+                    {
+                        // +Y
+                        // +Z +X -Z -X
+                        // -Y
+
+                        static const size_t s_offsetx[6] = { 1, 3, 0, 0, 0, 2 };
+                        static const size_t s_offsety[6] = { 1, 1, 0, 2, 1, 1 };
+
+                        offsetx = s_offsetx[index] * width;
+                        offsety = s_offsety[index] * height;
                         break;
                     }
 

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -1897,18 +1897,18 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             switch (dwCommand)
             {
             case CMD_H_CROSS:
-                //      posy
-                // negx posz posx negz
-                //      negy
+                //    +Y
+                // -X +Z +X -Z
+                //    -Y
                 twidth = width * 4;
                 theight = height * 3;
                 break;
 
             case CMD_V_CROSS:
-                //      posy
-                // posz posx negz
-                //      negy
-                //      negx
+                //    +Y
+                // -X +Z +X
+                //    -Y
+                //    -Z
                 twidth = width * 3;
                 theight = height * 4;
                 break;
@@ -1958,9 +1958,9 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 {
                 case CMD_H_CROSS:
                     {
-                        //      posy
-                        // negx posz posx negz
-                        //      negy
+                        //    +Y
+                        // -X +Z +X -Z
+                        //    -Y
 
                         static const size_t s_offsetx[6] = { 2, 0, 1, 1, 1, 3 };
                         static const size_t s_offsety[6] = { 1, 1, 0, 2, 1, 1 };
@@ -1972,13 +1972,12 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 
                 case CMD_V_CROSS:
                     {
-                        //      posy
-                        // posz posx negz
-                        //      negy
-                        //      negx
-
-                        static const size_t s_offsetx[6] = { 1, 1, 1, 1, 0, 2 };
-                        static const size_t s_offsety[6] = { 1, 3, 0, 2, 1, 1 };
+                        //    +Y
+                        // -X +Z +X
+                        //    -Y
+                        //    -Z
+                        static const size_t s_offsetx[6] = { 2, 0, 1, 1, 1, 1 };
+                        static const size_t s_offsety[6] = { 1, 1, 0, 2, 1, 3 };
 
                         offsetx = s_offsetx[index] * width;
                         offsety = s_offsety[index] * height;
@@ -1986,12 +1985,17 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     }
 
                 case CMD_H_STRIP:
-                    // posx, negx, posy, negy, posz, negz
+                    // +X -X +Y -Y +Z -Z
                     offsetx = index * width;
                     break;
 
                 case CMD_V_STRIP:
-                    // posx, negx, posy, negy, posz, negz
+                    // +X
+                    // -X
+                    // +Y
+                    // -Y
+                    // +Z
+                    // -Z
                     offsety = index * height;
                     break;
 


### PR DESCRIPTION
* Fixed layout issue with *v-cross* which was in the wrong order compared to the Unity reference
* Added *v-cross-fnz* variant which rotates the negative Z face 180 so it looks consistent with cross images from AMD CubeMapGen
* Added *h-tee* layout variant