### PR TITLE
Add Spectre-mitigated libraries to the NuGet

### DIFF
--- a/.nuget/directxtex_desktop_2019.nuspec
+++ b/.nuget/directxtex_desktop_2019.nuspec
@@ -31,14 +31,26 @@ DirectXTex, a shared source library for reading and writing .DDS files, and perf
         <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019\x64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxtex_desktop_2019.targets" target="build\native" />
 

--- a/.nuget/directxtex_desktop_2019.targets
+++ b/.nuget/directxtex_desktop_2019.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxtex-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtex-LibPath>
+    <directxtex-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXTex_Spectre</directxtex-LibName>
+    <directxtex-LibName Condition="'$(directxtex-LibName)'==''">DirectXTex</directxtex-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxtex-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxtex-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/.nuget/directxtex_desktop_win10.nuspec
+++ b/.nuget/directxtex_desktop_win10.nuspec
@@ -31,20 +31,38 @@ DirectXTex, a shared source library for reading and writing .DDS files, and perf
         <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="DirectXTex\Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\ARM64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\Debug\*.lib" />
         <file target="native\lib\ARM64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\Debug\*.pdb" />
 
+        <file target="native\lib\ARM64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\DebugSpectre\*.lib" />
+        <file target="native\lib\ARM64\Debug" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\ARM64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\Release\*.lib" />
         <file target="native\lib\ARM64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\Release\*.pdb" />
+
+        <file target="native\lib\ARM64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\ARM64\Release" src="DirectXTex\Bin\Desktop_2019_Win10\ARM64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxtex_desktop_win10.targets" target="build\native" />
 

--- a/.nuget/directxtex_desktop_win10.targets
+++ b/.nuget/directxtex_desktop_win10.targets
@@ -16,12 +16,18 @@
 
   <PropertyGroup>
     <directxtex-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtex-LibPath>
+    <directxtex-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXTex_Spectre</directxtex-LibName>
+    <directxtex-LibName Condition="'$(directxtex-LibName)'==''">DirectXTex</directxtex-LibName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <directxtex-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtex-LibPath>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxtex-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxtex-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/DirectXTex/DirectXTex_Desktop_2019.vcxproj
+++ b/DirectXTex/DirectXTex_Desktop_2019.vcxproj
@@ -124,6 +124,11 @@
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTex_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/DirectXTex/DirectXTex_Desktop_2019_Win10.vcxproj
+++ b/DirectXTex/DirectXTex_Desktop_2019_Win10.vcxproj
@@ -179,6 +179,11 @@
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTex_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/DirectXTex/DirectXTex_Desktop_2022.vcxproj
+++ b/DirectXTex/DirectXTex_Desktop_2022.vcxproj
@@ -124,6 +124,11 @@
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTex_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
+++ b/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
@@ -179,6 +179,11 @@
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTex_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>


### PR DESCRIPTION
Customers using the BinSkim Microsoft security tool will get flagged when using static C++ libraries not built using ``/Qspectre``. This adds the alternative flavor of the libraries to the **directxtex_desktop_2019** and **directxtex_desktop_win10** versions of the NuGet package. The targets automatically selects the Spectre version when building with SpectreMitigations enabled.

> This will double the package size from 9 MB to ~18MB which is reasonable.