### PR TITLE
CMake updated to use /Zc:inline and /Zc:lambda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,12 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         endforeach()
     endif()
 
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.28)
+        foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+          target_compile_options(${t} PRIVATE /Zc:lambda)
+        endforeach()
+    endif()
+
     if(BC_USE_OPENMP)
         target_compile_options(${PROJECT_NAME} PRIVATE /openmp /Zc:twoPhase-)
         if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ elseif(MINGW)
     endforeach()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus)
+      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline)
     endforeach()
 
     if(ENABLE_CODE_ANALYSIS)


### PR DESCRIPTION
The ``/Zc:inline`` switch enforces C++11 rules on inline visibility which reduces redundant comdats in each OBJ file (i.e. all the DirectXMath inline functions you *didn't* call in that translation unit). This switch is on by default with MSBuild, but is *not* on by default for command-line builds. This update adds this switch to CMake builds as well.

This reduces the size of the Release obj/lib files in half.

There's also a ``/Zc:lambda`` conformance switch for VS 2019 16.8 or later which I'm enabling for coverage.
