### PR TITLE
January 31, 2023 [Xbox Variant]

### DIFF
--- a/.nuget/directxtex_desktop_2019.nuspec
+++ b/.nuget/directxtex_desktop_2019.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 or Visual Studio 2022 and supports Windows 7 / DirectX 11.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the December 15, 2022 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the January 31, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxtex_desktop_win10.nuspec
+++ b/.nuget/directxtex_desktop_win10.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 or Visual Studio 2022 and supports Windows 10 / Windows 11 including both DirectX 11 and DirectX 12.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the December 15, 2022 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the January 31, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxtex_uwp.nuspec
+++ b/.nuget/directxtex_uwp.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Universal Windows Platform apps on Windows 10 / Windows 11 using Visual Studio 2019 or Visual Studio 2022.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the December 15, 2022 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the January 31, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required (VERSION 3.20)
 
-set(DIRECTXTEX_VERSION 1.9.7)
+set(DIRECTXTEX_VERSION 1.9.8)
 
 project (DirectXTex
   VERSION ${DIRECTXTEX_VERSION}

--- a/DDSTextureLoader/DDSTextureLoader11.cpp
+++ b/DDSTextureLoader/DDSTextureLoader11.cpp
@@ -552,12 +552,22 @@ namespace
 
         case DXGI_FORMAT_NV12:
         case DXGI_FORMAT_420_OPAQUE:
+            if ((height % 2) != 0)
+            {
+                // Requires a height alignment of 2.
+                return E_INVALIDARG;
+            }
             planar = true;
             bpe = 2;
             break;
 
         case DXGI_FORMAT_P010:
         case DXGI_FORMAT_P016:
+            if ((height % 2) != 0)
+            {
+                // Requires a height alignment of 2.
+                return E_INVALIDARG;
+            }
             planar = true;
             bpe = 4;
             break;
@@ -1353,6 +1363,34 @@ namespace
 
             switch (d3d10ext->dxgiFormat)
             {
+            case DXGI_FORMAT_NV12:
+            case DXGI_FORMAT_P010:
+            case DXGI_FORMAT_P016:
+            case DXGI_FORMAT_420_OPAQUE:
+                if ((d3d10ext->resourceDimension != D3D11_RESOURCE_DIMENSION_TEXTURE2D)
+                    || (width % 2) != 0 || (height % 2) != 0)
+                {
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
+
+            case DXGI_FORMAT_YUY2:
+            case DXGI_FORMAT_Y210:
+            case DXGI_FORMAT_Y216:
+            case DXGI_FORMAT_P208:
+                if ((width % 2) != 0)
+                {
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
+
+            case DXGI_FORMAT_NV11:
+                if ((width % 4) != 0)
+                {
+                    return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+                }
+                break;
+
             case DXGI_FORMAT_AI44:
             case DXGI_FORMAT_IA44:
             case DXGI_FORMAT_P8:

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -631,6 +631,15 @@ namespace
 
         case DXGI_FORMAT_NV12:
         case DXGI_FORMAT_420_OPAQUE:
+            if ((height % 2) != 0)
+            {
+                // Requires a height alignment of 2.
+                return E_INVALIDARG;
+            }
+            planar = true;
+            bpe = 2;
+            break;
+
         case DXGI_FORMAT_P208:
             planar = true;
             bpe = 2;
@@ -638,6 +647,11 @@ namespace
 
         case DXGI_FORMAT_P010:
         case DXGI_FORMAT_P016:
+            if ((height % 2) != 0)
+            {
+                // Requires a height alignment of 2.
+                return E_INVALIDARG;
+            }
             planar = true;
             bpe = 4;
             break;
@@ -1269,7 +1283,7 @@ namespace
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
+            D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_ID3D12Resource, reinterpret_cast<void**>(texture));
         if (SUCCEEDED(hr))
@@ -1325,11 +1339,47 @@ namespace
 
             switch (d3d10ext->dxgiFormat)
             {
+            case DXGI_FORMAT_NV12:
+            case DXGI_FORMAT_P010:
+            case DXGI_FORMAT_P016:
+            case DXGI_FORMAT_420_OPAQUE:
+                if ((d3d10ext->resourceDimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+                    || (width % 2) != 0 || (height % 2) != 0)
+                {
+                    return HRESULT_E_NOT_SUPPORTED;
+                }
+                break;
+
+            case DXGI_FORMAT_YUY2:
+            case DXGI_FORMAT_Y210:
+            case DXGI_FORMAT_Y216:
+            case DXGI_FORMAT_P208:
+                if ((width % 2) != 0)
+                {
+                    return HRESULT_E_NOT_SUPPORTED;
+                }
+                break;
+
+            case DXGI_FORMAT_NV11:
+                if ((width % 4) != 0)
+                {
+                    return HRESULT_E_NOT_SUPPORTED;
+                }
+                break;
+
             case DXGI_FORMAT_AI44:
             case DXGI_FORMAT_IA44:
             case DXGI_FORMAT_P8:
             case DXGI_FORMAT_A8P8:
                 return HRESULT_E_NOT_SUPPORTED;
+
+            case DXGI_FORMAT_V208:
+                if ((d3d10ext->resourceDimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D)
+                    || (height % 2) != 0)
+                {
+                    return HRESULT_E_NOT_SUPPORTED;
+                }
+                break;
 
             default:
                 if (BitsPerPixel(d3d10ext->dxgiFormat) == 0)

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -47,7 +47,7 @@ struct IWICImagingFactory;
 struct IWICMetadataQueryReader;
 #endif
 
-#define DIRECTX_TEX_VERSION 196
+#define DIRECTX_TEX_VERSION 198
 
 
 namespace DirectX

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -4799,21 +4799,33 @@ namespace
         {
         case DXGI_FORMAT_NV12:
             assert(destImage.format == DXGI_FORMAT_YUY2);
+            if ((srcImage.width % 2) != 0 || (srcImage.height % 2) != 0)
+                return E_INVALIDARG;
+
             CONVERT_420_TO_422(uint8_t, XMUBYTEN4);
             return S_OK;
 
         case DXGI_FORMAT_P010:
             assert(destImage.format == DXGI_FORMAT_Y210);
+            if ((srcImage.width % 2) != 0 || (srcImage.height % 2) != 0)
+                return E_INVALIDARG;
+
             CONVERT_420_TO_422(uint16_t, XMUSHORTN4);
             return S_OK;
 
         case DXGI_FORMAT_P016:
             assert(destImage.format == DXGI_FORMAT_Y216);
+            if ((srcImage.width % 2) != 0 || (srcImage.height % 2) != 0)
+                return E_INVALIDARG;
+
             CONVERT_420_TO_422(uint16_t, XMUSHORTN4);
             return S_OK;
 
         case DXGI_FORMAT_NV11:
             assert(destImage.format == DXGI_FORMAT_YUY2);
+            if ((srcImage.width % 4) != 0)
+                return E_INVALIDARG;
+
             // Convert 4:1:1 to 4:2:2
             {
                 const size_t rowPitch = srcImage.rowPitch;

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -219,6 +219,9 @@ bool DirectX::IsSupportedTexture(
     if (!IsValid(fmt))
         return false;
 
+    const size_t iWidth = metadata.width;
+    const size_t iHeight = metadata.height;
+
     switch (fmt)
     {
     case DXGI_FORMAT_BC4_TYPELESS:
@@ -241,6 +244,49 @@ bool DirectX::IsSupportedTexture(
             return false;
         break;
 
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_P016:
+    case DXGI_FORMAT_420_OPAQUE:
+        if ((metadata.dimension != TEX_DIMENSION_TEXTURE2D)
+            || (iWidth % 2) != 0 || (iHeight % 2) != 0)
+        {
+            return false;
+        }
+        break;
+
+    case DXGI_FORMAT_YUY2:
+    case DXGI_FORMAT_Y210:
+    case DXGI_FORMAT_Y216:
+    case WIN10_DXGI_FORMAT_P208:
+        if ((iWidth % 2) != 0)
+        {
+            return false;
+        }
+        break;
+
+    case DXGI_FORMAT_NV11:
+        if ((iWidth % 4) != 0)
+        {
+            return false;
+        }
+        break;
+
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_P8:
+    case DXGI_FORMAT_A8P8:
+        // Legacy video stream formats are not supported by Direct3D.
+        return false;
+
+    case WIN10_DXGI_FORMAT_V208:
+        if ((metadata.dimension != TEX_DIMENSION_TEXTURE2D)
+            || (iHeight % 2) != 0)
+        {
+            return false;
+        }
+        break;
+
     default:
         break;
     }
@@ -251,8 +297,6 @@ bool DirectX::IsSupportedTexture(
 
     // Validate array size, dimension, and width/height
     const size_t arraySize = metadata.arraySize;
-    const size_t iWidth = metadata.width;
-    const size_t iHeight = metadata.height;
     const size_t iDepth = metadata.depth;
 
     // Most cases are known apriori based on feature level, but we use this for robustness to handle the few optional cases

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -335,14 +335,64 @@ bool DirectX::IsSupportedTexture(
     if (!IsValid(fmt))
         return false;
 
+    const size_t iWidth = metadata.width;
+    const size_t iHeight = metadata.height;
+
+    switch (fmt)
+    {
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_P016:
+    case DXGI_FORMAT_420_OPAQUE:
+        if ((metadata.dimension != TEX_DIMENSION_TEXTURE2D)
+            || (iWidth % 2) != 0 || (iHeight % 2) != 0)
+        {
+            return false;
+        }
+        break;
+
+    case DXGI_FORMAT_YUY2:
+    case DXGI_FORMAT_Y210:
+    case DXGI_FORMAT_Y216:
+    case WIN10_DXGI_FORMAT_P208:
+        if ((iWidth % 2) != 0)
+        {
+            return false;
+        }
+        break;
+
+    case DXGI_FORMAT_NV11:
+        if ((iWidth % 4) != 0)
+        {
+            return false;
+        }
+        break;
+
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_P8:
+    case DXGI_FORMAT_A8P8:
+        // Legacy video stream formats are not supported by Direct3D.
+        return false;
+
+    case WIN10_DXGI_FORMAT_V208:
+        if ((metadata.dimension != TEX_DIMENSION_TEXTURE2D)
+            || (iHeight % 2) != 0)
+        {
+            return false;
+        }
+        break;
+
+    default:
+        break;
+    }
+
     // Validate miplevel count
     if (metadata.mipLevels > D3D12_REQ_MIP_LEVELS)
         return false;
 
     // Validate array size, dimension, and width/height
     const size_t arraySize = metadata.arraySize;
-    const size_t iWidth = metadata.width;
-    const size_t iHeight = metadata.height;
     const size_t iDepth = metadata.depth;
 
     // Most cases are known apriori based on feature level, but we use this for robustness to handle the few optional cases
@@ -492,7 +542,11 @@ HRESULT DirectX::CreateTextureEx(
         &defaultHeapProperties,
         D3D12_HEAP_FLAG_NONE,
         &desc,
+    #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
         D3D12_RESOURCE_STATE_COPY_DEST,
+    #else
+        D3D12_RESOURCE_STATE_COMMON,
+    #endif
         nullptr,
         IID_GRAPHICS_PPV_ARGS(ppResource));
 

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -1256,8 +1256,9 @@ namespace
         }
 
         size_t pixelSize, nimages;
-        if (!DetermineImageArray(metadata, cpFlags, nimages, pixelSize))
-            return HRESULT_E_ARITHMETIC_OVERFLOW;
+        HRESULT hr = DetermineImageArray(metadata, cpFlags, nimages, pixelSize);
+        if (FAILED(hr))
+            return hr;
 
         if ((nimages == 0) || (nimages != image.GetImageCount()))
         {

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -310,7 +310,7 @@ namespace DirectX
 
         //---------------------------------------------------------------------------------
         // Image helper functions
-        _Success_(return) bool __cdecl DetermineImageArray(
+        HRESULT __cdecl DetermineImageArray(
             _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
             _Out_ size_t& nImages, _Out_ size_t& pixelSize) noexcept;
 

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -973,6 +973,11 @@ HRESULT DirectX::ComputePitch(DXGI_FORMAT fmt, size_t width, size_t height,
 
     case DXGI_FORMAT_NV12:
     case DXGI_FORMAT_420_OPAQUE:
+        if ((height % 2) != 0)
+        {
+            // Requires a height alignment of 2.
+            return E_INVALIDARG;
+        }
         assert(IsPlanar(fmt));
         pitch = ((uint64_t(width) + 1u) >> 1) * 2u;
         slice = pitch * (uint64_t(height) + ((uint64_t(height) + 1u) >> 1));
@@ -980,6 +985,20 @@ HRESULT DirectX::ComputePitch(DXGI_FORMAT fmt, size_t width, size_t height,
 
     case DXGI_FORMAT_P010:
     case DXGI_FORMAT_P016:
+        if ((height % 2) != 0)
+        {
+            // Requires a height alignment of 2.
+            return E_INVALIDARG;
+        }
+
+        #if (__cplusplus >= 201703L)
+            [[fallthrough]];
+        #elif defined(__clang__)
+            [[clang::fallthrough]];
+        #elif defined(_MSC_VER)
+            __fallthrough;
+        #endif
+
     case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
     case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
     case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
@@ -1001,6 +1020,11 @@ HRESULT DirectX::ComputePitch(DXGI_FORMAT fmt, size_t width, size_t height,
         break;
 
     case WIN10_DXGI_FORMAT_V208:
+        if ((height % 2) != 0)
+        {
+            // Requires a height alignment of 2.
+            return E_INVALIDARG;
+        }
         assert(IsPlanar(fmt));
         pitch = uint64_t(width);
         slice = pitch * (uint64_t(height) + (((uint64_t(height) + 1u) >> 1) * 2u));

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXT
 
 ## Release History
 
+### January 31, 2023
+* Fixed memory overwrite bug in **ConvertToSinglePlane** that can lead to a potential security issue for untrusted planar video format DDS files
+* Make sure ScratchImage zero-fills image memory
+* Fix DirectX12 GPU-validation warnings for texture loaders
+* Minor fix for non-Win32 builds
+* ddsview: Updated sample app with a ``-forcesrgb`` command-line switch
+
 ### December 15, 2022
 * ARM/ARM64 platform fix for 16bpp pixel conversion
 * Updated D3DX12 internal copy with latest changes from DirectX-Headers GitHub
@@ -277,7 +284,7 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXT
 ### July 26, 2017
 * Support for reading non-standard DDS files written by nVidia Texture Tools (NVTT)
 * Fix for **ComputeMSE** when using ``CMSE_IMAGE2_X2_BIAS``
-* Fix for WIC writer then codec target format requires a palette    
+* Fix for WIC writer then codec target format requires a palette
 * Code cleanup
 
 ### April 24, 2017

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                The MIT License (MIT)
 
-Copyright (c) 2011-2022 Microsoft Corp
+Copyright (c) 2011-2023 Microsoft Corp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkId=248926
 
 Copyright (c) Microsoft Corporation.
 
-**December 15, 2022**
+**January 31, 2023**
 
 This package contains DirectXTex, a shared source library for reading and writing ``.DDS`` files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes ``.TGA`` and ``.HDR`` readers and writers since these image file formats are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.
 

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -617,7 +617,7 @@ namespace
             &defaultHeapProperties,
             D3D12_HEAP_FLAG_NONE,
             &desc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
+            D3D12_RESOURCE_STATE_COMMON,
             nullptr,
             IID_ID3D12Resource,
             reinterpret_cast<void**>(&tex));

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -101,14 +101,13 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    # The error checks are commented out due to a bug with vcpkg not returning 0 on success.
     displayName: VCPKG install headers
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -203,9 +202,9 @@ jobs:
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0


### PR DESCRIPTION
* Fixed memory overwrite bug in **ConvertToSinglePlane** that can lead to a potential security issue for untrusted planar video format DDS files
* Make sure ScratchImage zero-fills image memory
* Fix DirectX12 GPU-validation warnings for texture loaders
