### PR TITLE
CMake code review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
     set(DIRECTX_ARCH arm64)
 endif()
 
+if(DEFINED XBOX_CONSOLE_TARGET)
+  set(BUILD_DX11 OFF)
+  set(BUILD_DX12 ON)
+endif()
+
 include(GNUInstallDirs)
 
 #--- Library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,6 @@ elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
     set(DIRECTX_ARCH arm64)
 endif()
 
-if(VCPKG_TARGET_IS_XBOX)
-    set(BUILD_DX11 OFF)
-    set(BUILD_DX12 ON)
-endif()
-
 include(GNUInstallDirs)
 
 #--- Library
@@ -171,15 +166,23 @@ if(NOT MINGW)
     target_precompile_headers(${PROJECT_NAME} PRIVATE DirectXTex/DirectXTexP.h)
 endif()
 
-if(MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
+if(MINGW OR (NOT WIN32))
     find_package(directxmath CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    find_package(directx-headers CONFIG REQUIRED)
+else()
+    find_package(directxmath CONFIG QUIET)
+    find_package(directx-headers CONFIG QUIET)
+endif()
 
-    if(NOT VCPKG_TARGET_IS_XBOX)
-        find_package(directx-headers CONFIG REQUIRED)
-        target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
-    endif()
+if(directxmath_FOUND)
+    message(STATUS "Using DirectXMath package")
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+endif()
+
+if(directx-headers_FOUND)
+    message(STATUS "Using DirectX-Headers package")
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
 endif()
 
 #--- Package
@@ -284,7 +287,7 @@ if(BUILD_SAMPLE AND BUILD_DX11 AND WIN32 AND (NOT WINDOWS_STORE))
   endif()
 endif()
 
-if(MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
+if(directxmath_FOUND)
   foreach(t IN LISTS TOOL_EXES)
     target_link_libraries(${t} Microsoft::DirectXMath)
   endforeach()


### PR DESCRIPTION
Minimize use of VCPKG specific variables, and use standard CMake logic instead.