### PR TITLE
CMake bug fixed if BUILD_DX11=OFF but BUILD_TOOLS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ install(FILES
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
 
 #--- Command-line tools
-if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
+if(BUILD_TOOLS AND BUILD_DX11 AND WIN32 AND (NOT WINDOWS_STORE))
   set(TOOL_EXES texassemble texconv texdiag)
 
   add_executable(texassemble
@@ -400,7 +400,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
     if(BC_USE_OPENMP)
         target_compile_options(${PROJECT_NAME} PRIVATE /openmp /Zc:twoPhase-)
-        if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
+        if(BUILD_TOOLS AND BUILD_DX11 AND WIN32 AND (NOT WINDOWS_STORE))
           target_compile_options(texconv PRIVATE /openmp /Zc:twoPhase-)
         endif()
     endif()
@@ -441,7 +441,7 @@ if(WIN32)
     endif()
 endif()
 
-if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
+if(BUILD_TOOLS AND BUILD_DX11 AND WIN32 AND (NOT WINDOWS_STORE))
   set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT texconv)
 endif()
 


### PR DESCRIPTION
Needed to support **directxtex** VCPKG port with a **dx11** feature that can be removed for scenarios where you don't want to use the FXC.EXE compiler.
