### PR TITLE
March 30, 2023

### DIFF
--- a/.nuget/directxtex_desktop_2019.nuspec
+++ b/.nuget/directxtex_desktop_2019.nuspec
@@ -7,10 +7,10 @@
         <authors>Microsoft</authors>
         <owners>microsoft,directxtk</owners>
         <summary>DirectXTex texture processing library</summary>
-        <description>This version is for Windows desktop applications using Visual Studio 2019 or Visual Studio 2022 and supports Windows 7 / DirectX 11.
+        <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 and supports Windows 7 / DirectX 11.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the January 31, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the March 30, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxtex_desktop_win10.nuspec
+++ b/.nuget/directxtex_desktop_win10.nuspec
@@ -7,10 +7,10 @@
         <authors>Microsoft</authors>
         <owners>microsoft,directxtk</owners>
         <summary>DirectXTex texture processing library</summary>
-        <description>This version is for Windows desktop applications using Visual Studio 2019 or Visual Studio 2022 and supports Windows 10 / Windows 11 including both DirectX 11 and DirectX 12.
+        <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 and supports Windows 10 / Windows 11 including both DirectX 11 and DirectX 12.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the January 31, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the March 30, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxtex_uwp.nuspec
+++ b/.nuget/directxtex_uwp.nuspec
@@ -7,10 +7,10 @@
         <authors>Microsoft</authors>
         <owners>microsoft,directxtk</owners>
         <summary>DirectXTex texture processing library</summary>
-        <description>This version is for Universal Windows Platform apps on Windows 10 / Windows 11 using Visual Studio 2019 or Visual Studio 2022.
+        <description>This version is for Universal Windows Platform apps on Windows 10 / Windows 11 using Visual Studio 2019 (16.11) or Visual Studio 2022.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the January 31, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the March 30, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,15 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXT
 
 ## Release History
 
+### March 30, 2023
+* Fix for `SRGB_IN` / `SRGB_OUT` flag handling for GPU BC7 compressor
+* Fix to clamp negative values when encoding with the GPU BC6H compressor
+* GPU BC6H/BC7 encoder updated to make optional use of DirectCompute 5.0
+* CMake project updates
+* Code review
+* Retired VS 2017 legacy Xbox One XDK projects
+* texassemble/texconv/texdiag: Updated to support Windows or UNIX-style path separators
+
 ### January 31, 2023
 * Fixed memory overwrite bug in **ConvertToSinglePlane** that can lead to a potential security issue for untrusted planar video format DDS files
 * Make sure ScratchImage zero-fills image memory

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkId=248926
 
 Copyright (c) Microsoft Corporation.
 
-**January 31, 2023**
+**March 30, 2023**
 
 This package contains DirectXTex, a shared source library for reading and writing ``.DDS`` files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes ``.TGA`` and ``.HDR`` readers and writers since these image file formats are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.
 


### PR DESCRIPTION
* Fix for `SRGB_IN` / `SRGB_OUT` flag handling for GPU BC7 compressor
* Fix to clamp negative values when encoding with the GPU BC6H compressor
* GPU BC6H/BC7 encoder updated to make optional use of DirectCompute 5.0
* CMake project updates
* Code review
* Retired VS 2017 legacy Xbox One XDK projects
* texassemble/texconv/texdiag: Updated to support Windows or UNIX-style path separators