### PR TITLE
Add .DDX Support

### DIFF
--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -437,6 +437,7 @@ namespace
         { L"jpeg",  WIC_CODEC_JPEG },
         { L"png",   WIC_CODEC_PNG  },
         { L"dds",   CODEC_DDS      },
+        { L"ddx",   CODEC_DDS      },
         { L"tga",   CODEC_TGA      },
         { L"hdr",   CODEC_HDR      },
         { L"tif",   WIC_CODEC_TIFF },
@@ -2069,7 +2070,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             return 1;
         }
 
-        if (_wcsicmp(ext, L".dds") == 0)
+        if (_wcsicmp(ext, L".dds") == 0 || _wcsicmp(ext, L".ddx") == 0)
         {
             DDS_FLAGS ddsFlags = DDS_FLAGS_ALLOW_LARGE_FILES;
             if (dwOptions & (uint64_t(1) << OPT_DDS_DWORD_ALIGN))


### PR DESCRIPTION
This proposes adding support for the `.DDX` file format you can find in some Xbox Arcade ported games like Halo Wars and Dungeon Defender.
The `.DDX` format is functionally identical to the `.DDS` format and does not require any changes to the `CODEC_DDS`.

The changes has been compiled and tested in the command-line tool `texconv.exe`

![image](https://user-images.githubusercontent.com/62443788/229278202-3ad42df3-9b05-4000-931f-e136de892cde.png)