### PR TITLE
Update CMake config file to include OpenMP

### DIFF
--- a/build/DirectXTex-config.cmake.in
+++ b/build/DirectXTex-config.cmake.in
@@ -3,6 +3,11 @@
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
 include(CMakeFindDependencyMacro)
 
+set(BC_USE_OPENMP @BC_USE_OPENMP@)
+if(BC_USE_OPENMP)
+    find_dependency(OpenMP)
+endif()
+
 set(ENABLE_OPENEXR_SUPPORT @ENABLE_OPENEXR_SUPPORT@)
 if(ENABLE_OPENEXR_SUPPORT)
     find_dependency(OpenEXR)


### PR DESCRIPTION
Now that the CMake file is using the OpenMP package, it needs a `find_dependency` in the config file.