### PR TITLE
Add support for new DXGI 16bpp format

### DIFF
--- a/DirectXTex/DirectXTex.inl
+++ b/DirectXTex/DirectXTex.inl
@@ -46,7 +46,7 @@ constexpr TEX_COMPRESS_FLAGS operator|(TEX_FILTER_FLAGS a, TEX_COMPRESS_FLAGS b)
 _Use_decl_annotations_
 constexpr bool __cdecl IsValid(DXGI_FORMAT fmt) noexcept
 {
-    return (static_cast<size_t>(fmt) >= 1 && static_cast<size_t>(fmt) <= 190);
+    return (static_cast<size_t>(fmt) >= 1 && static_cast<size_t>(fmt) <= 191);
 }
 
 _Use_decl_annotations_
@@ -110,27 +110,6 @@ inline bool __cdecl IsSRGB(DXGI_FORMAT fmt) noexcept
     case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
     case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
     case DXGI_FORMAT_BC7_UNORM_SRGB:
-        return true;
-
-    default:
-        return false;
-    }
-}
-
-_Use_decl_annotations_
-inline bool __cdecl IsBGR(DXGI_FORMAT fmt) noexcept
-{
-    switch (fmt)
-    {
-    case DXGI_FORMAT_B5G6R5_UNORM:
-    case DXGI_FORMAT_B5G5R5A1_UNORM:
-    case DXGI_FORMAT_B8G8R8A8_UNORM:
-    case DXGI_FORMAT_B8G8R8X8_UNORM:
-    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
-    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
-    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
-    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
-    case DXGI_FORMAT_B4G4R4A4_UNORM:
         return true;
 
     default:

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -187,6 +187,8 @@ using WICPixelFormatGUID = GUID;
 
 #define XBOX_DXGI_FORMAT_R4G4_UNORM DXGI_FORMAT(190)
 
+#define WIN11_DXGI_FORMAT_A4B4G4R4_UNORM DXGI_FORMAT(191)
+
 #if defined(__MINGW32__) && !defined(E_BOUNDS)
 #define E_BOUNDS static_cast<HRESULT>(0x8000000BL)
 #endif

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -456,6 +456,30 @@ bool DirectX::IsDepthStencil(DXGI_FORMAT fmt) noexcept
 
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
+bool DirectX::IsBGR(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
 bool DirectX::IsTypeless(DXGI_FORMAT fmt, bool partialTypeless) noexcept
 {
     switch (static_cast<int>(fmt))
@@ -551,6 +575,7 @@ bool DirectX::HasAlpha(DXGI_FORMAT fmt) noexcept
     case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
     case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
     case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         return true;
 
     default:
@@ -667,6 +692,7 @@ size_t DirectX::BitsPerPixel(DXGI_FORMAT fmt) noexcept
     case DXGI_FORMAT_B4G4R4A4_UNORM:
     case WIN10_DXGI_FORMAT_P208:
     case WIN10_DXGI_FORMAT_V208:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         return 16;
 
     case DXGI_FORMAT_NV12:
@@ -867,6 +893,7 @@ size_t DirectX::BitsPerColor(DXGI_FORMAT fmt) noexcept
 
     case DXGI_FORMAT_B4G4R4A4_UNORM:
     case XBOX_DXGI_FORMAT_R4G4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         return 4;
 
     case DXGI_FORMAT_R1_UNORM:

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -265,6 +265,9 @@ namespace
         // No support for legacy paletted video formats (AI44, IA44, P8, A8P8)
         DEFFMT(B4G4R4A4_UNORM),
 
+        // D3D11on12 format
+        { L"A4B4G4R4_UNORM", DXGI_FORMAT(191) },
+
         { nullptr, DXGI_FORMAT_UNKNOWN }
     };
 

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -309,6 +309,9 @@ namespace
         // No support for legacy paletted video formats (AI44, IA44, P8, A8P8)
         DEFFMT(B4G4R4A4_UNORM),
 
+        // D3D11on12 format
+        { L"A4B4G4R4_UNORM", DXGI_FORMAT(191) },
+
         { nullptr, DXGI_FORMAT_UNKNOWN }
     };
 

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -218,6 +218,9 @@ const SValue g_pFormats[] =
     DEFFMT(Y216),
     DEFFMT(B4G4R4A4_UNORM),
 
+    // D3D11on12 format
+    { L"A4B4G4R4_UNORM", DXGI_FORMAT(191) },
+
     { nullptr, DXGI_FORMAT_UNKNOWN }
 };
 


### PR DESCRIPTION
In the *DirectX Agility SDK* 1.610, there is a new DXGI format ``DXGI_FORMAT_A4B4G4R4_UNORM`` to support D3D11on12. This PR adds support to DirectXTex for this format.

> Since there is no Direct3D 9 direct-equivalent format, this format is always read/written in DDS files using the `DX10` extension header.