### PR TITLE
Add TEX_FILTER_RGB_COPY_ALPHA for RGBA to R and RGBA to RG convert

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -575,8 +575,9 @@ namespace DirectX
         TEX_FILTER_RGB_COPY_RED = 0x1000,
         TEX_FILTER_RGB_COPY_GREEN = 0x2000,
         TEX_FILTER_RGB_COPY_BLUE = 0x4000,
-        // When converting RGB to R, defaults to using grayscale. These flags indicate copying a specific channel instead
-        // When converting RGB to RG, defaults to copying RED | GREEN. These flags control which channels are selected instead.
+        TEX_FILTER_RGB_COPY_ALPHA = 0x8000,
+        // When converting RGB(A) to R, defaults to using grayscale. These flags indicate copying a specific channel instead
+        // When converting RGB(A) to RG, defaults to copying RED | GREEN. These flags control which channels are selected instead.
 
         TEX_FILTER_DITHER = 0x10000,
         // Use ordered 4x4 dithering for any required conversions


### PR DESCRIPTION
We already have filter flags for copying RED, GREEN, or BLUE channels for RGB to R conversions, as well as RED | GREEN, GREEN | BLUE, and RED | BLUE for RGB to RG conversions.

This adds a flag to allow RED, GREEN, BLUE, or ALPHA for RGBA to R conversions, and adds RED | ALPHA, GREEN | ALPHA, and BLUE | ALPHA combinations for RGBA to RG conversions.