### PR TITLE
tex tools: remove newlines from FORMAT_MESSAGE_FROM_SYSTEM

### DIFF
--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -752,6 +752,14 @@ namespace
 
             if (errorText)
                 LocalFree(errorText);
+
+            for (wchar_t* ptr = desc; *ptr != 0; ++ptr)
+            {
+                if (*ptr == L'\r' || *ptr == L'\n')
+                {
+                    *ptr = L' ';
+                }
+            }
         }
 
         return desc;

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -1047,6 +1047,14 @@ namespace
 
             if (errorText)
                 LocalFree(errorText);
+
+            for (wchar_t* ptr = desc; *ptr != 0; ++ptr)
+            {
+                if (*ptr == L'\r' || *ptr == L'\n')
+                {
+                    *ptr = L' ';
+                }
+            }
         }
 
         return desc;

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -751,6 +751,14 @@ namespace
 
             if (errorText)
                 LocalFree(errorText);
+
+            for(wchar_t* ptr = desc; *ptr != 0; ++ptr)
+            {
+                if (*ptr == L'\r' || *ptr == L'\n')
+                {
+                    *ptr = L' ';
+                }
+            }
         }
 
         return desc;


### PR DESCRIPTION
Fixed output from texassemble, texdiag, and texconv when getting an error string.