### PR TITLE
CMake update to use /ZH:SHA_256 for clang v16 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,13 @@ if(MSVC)
       endforeach()
     endif()
 
+    if((MSVC_VERSION GREATER_EQUAL 1924)
+       AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)))
+      foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+        target_compile_options(${t} PRIVATE /ZH:SHA_256)
+      endforeach()
+    endif()
+
     if((MSVC_VERSION GREATER_EQUAL 1928)
        AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
        AND NOT ENABLE_OPENEXR_SUPPORT
@@ -443,12 +450,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
         target_compile_options(${t} PRIVATE /Gy /Gw)
       endforeach()
-    endif()
-
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
-        foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-          target_compile_options(${t} PRIVATE /ZH:SHA_256)
-        endforeach()
     endif()
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.26)


### PR DESCRIPTION
Support for "SHA256" hashing of PDBs is required for SDL compliance, and is supported by VS 2019 or later. Support for this switch was added to clang/LLVM for Windows v16 which is coming in VS 2022 17.6.