### PR TITLE
Update Xbox variant for changes for May 2023

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,13 @@ if(MSVC)
       endforeach()
     endif()
 
+    if((MSVC_VERSION GREATER_EQUAL 1924)
+       AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)))
+      foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+        target_compile_options(${t} PRIVATE /ZH:SHA_256)
+      endforeach()
+    endif()
+
     if((MSVC_VERSION GREATER_EQUAL 1928)
        AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
        AND NOT ENABLE_OPENEXR_SUPPORT
@@ -495,12 +502,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
         target_compile_options(${t} PRIVATE /Gy /Gw)
       endforeach()
-    endif()
-
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
-        foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-          target_compile_options(${t} PRIVATE /ZH:SHA_256)
-        endforeach()
     endif()
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.26)

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -575,8 +575,9 @@ namespace DirectX
         TEX_FILTER_RGB_COPY_RED = 0x1000,
         TEX_FILTER_RGB_COPY_GREEN = 0x2000,
         TEX_FILTER_RGB_COPY_BLUE = 0x4000,
-        // When converting RGB to R, defaults to using grayscale. These flags indicate copying a specific channel instead
-        // When converting RGB to RG, defaults to copying RED | GREEN. These flags control which channels are selected instead.
+        TEX_FILTER_RGB_COPY_ALPHA = 0x8000,
+        // When converting RGB(A) to R, defaults to using grayscale. These flags indicate copying a specific channel instead
+        // When converting RGB(A) to RG, defaults to copying RED | GREEN. These flags control which channels are selected instead.
 
         TEX_FILTER_DITHER = 0x10000,
         // Use ordered 4x4 dithering for any required conversions

--- a/DirectXTex/DirectXTex.inl
+++ b/DirectXTex/DirectXTex.inl
@@ -46,7 +46,7 @@ constexpr TEX_COMPRESS_FLAGS operator|(TEX_FILTER_FLAGS a, TEX_COMPRESS_FLAGS b)
 _Use_decl_annotations_
 constexpr bool __cdecl IsValid(DXGI_FORMAT fmt) noexcept
 {
-    return (static_cast<size_t>(fmt) >= 1 && static_cast<size_t>(fmt) <= 190);
+    return (static_cast<size_t>(fmt) >= 1 && static_cast<size_t>(fmt) <= 191);
 }
 
 _Use_decl_annotations_
@@ -110,27 +110,6 @@ inline bool __cdecl IsSRGB(DXGI_FORMAT fmt) noexcept
     case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
     case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
     case DXGI_FORMAT_BC7_UNORM_SRGB:
-        return true;
-
-    default:
-        return false;
-    }
-}
-
-_Use_decl_annotations_
-inline bool __cdecl IsBGR(DXGI_FORMAT fmt) noexcept
-{
-    switch (fmt)
-    {
-    case DXGI_FORMAT_B5G6R5_UNORM:
-    case DXGI_FORMAT_B5G5R5A1_UNORM:
-    case DXGI_FORMAT_B8G8R8A8_UNORM:
-    case DXGI_FORMAT_B8G8R8X8_UNORM:
-    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
-    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
-    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
-    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
-    case DXGI_FORMAT_B4G4R4A4_UNORM:
         return true;
 
     default:

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -378,14 +378,24 @@ void DirectX::Internal::CopyScanline(
 
             //-----------------------------------------------------------------------------
         case DXGI_FORMAT_B5G5R5A1_UNORM:
+        case DXGI_FORMAT_B4G4R4A4_UNORM:
+        case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
             if (inSize >= 2 && outSize >= 2)
             {
+                uint16_t alpha;
+                if (format == DXGI_FORMAT_B4G4R4A4_UNORM)
+                    alpha = 0xF000;
+                else if (format == WIN11_DXGI_FORMAT_A4B4G4R4_UNORM)
+                    alpha = 0x000F;
+                else
+                    alpha = 0x8000;
+
                 if (pDestination == pSource)
                 {
                     auto dPtr = static_cast<uint16_t*>(pDestination);
                     for (size_t count = 0; count < (outSize - 1); count += 2)
                     {
-                        *(dPtr++) |= 0x8000;
+                        *(dPtr++) |= alpha;
                     }
                 }
                 else
@@ -395,7 +405,7 @@ void DirectX::Internal::CopyScanline(
                     const size_t size = std::min<size_t>(outSize, inSize);
                     for (size_t count = 0; count < (size - 1); count += 2)
                     {
-                        *(dPtr++) = uint16_t(*(sPtr++) | 0x8000);
+                        *(dPtr++) = uint16_t(*(sPtr++) | alpha);
                     }
                 }
             }
@@ -404,31 +414,6 @@ void DirectX::Internal::CopyScanline(
             //-----------------------------------------------------------------------------
         case DXGI_FORMAT_A8_UNORM:
             memset(pDestination, 0xff, outSize);
-            return;
-
-            //-----------------------------------------------------------------------------
-        case DXGI_FORMAT_B4G4R4A4_UNORM:
-            if (inSize >= 2 && outSize >= 2)
-            {
-                if (pDestination == pSource)
-                {
-                    auto dPtr = static_cast<uint16_t*>(pDestination);
-                    for (size_t count = 0; count < (outSize - 1); count += 2)
-                    {
-                        *(dPtr++) |= 0xF000;
-                    }
-                }
-                else
-                {
-                    const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
-                    uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
-                    const size_t size = std::min<size_t>(outSize, inSize);
-                    for (size_t count = 0; count < (size - 1); count += 2)
-                    {
-                        *(dPtr++) = uint16_t(*(sPtr++) | 0xF000);
-                    }
-                }
-            }
             return;
         }
     }
@@ -631,7 +616,7 @@ bool DirectX::Internal::ExpandScanline(
     assert(IsValid(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
     assert(IsValid(inFormat) && !IsPlanar(inFormat) && !IsPalettized(inFormat));
 
-    switch (inFormat)
+    switch (static_cast<int>(inFormat))
     {
     case DXGI_FORMAT_B5G6R5_UNORM:
         if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
@@ -700,6 +685,31 @@ bool DirectX::Internal::ExpandScanline(
                 uint32_t t2 = uint32_t(((t & 0x00f0) << 8) | ((t & 0x00f0) << 4));
                 uint32_t t3 = uint32_t(((t & 0x000f) << 20) | ((t & 0x000f) << 16));
                 uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf000) << 16) | ((t & 0xf000) << 12));
+
+                *(dPtr++) = t1 | t2 | t3 | ta;
+            }
+            return true;
+        }
+        return false;
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+            return false;
+
+        // DXGI_FORMAT_A4B4G4R4_UNORM -> DXGI_FORMAT_R8G8B8A8_UNORM
+        if (inSize >= 2 && outSize >= 4)
+        {
+            const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+            for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+            {
+                const uint16_t t = *(sPtr++);
+
+                uint32_t t1 = uint32_t(((t & 0xf000) >> 8) | ((t & 0xf000) >> 12));
+                uint32_t t2 = uint32_t((t & 0x0f00) | ((t & 0x0f00) << 4));
+                uint32_t t3 = uint32_t(((t & 0x00f0) << 16) | ((t & 0x00f0) << 12));
+                uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0x000f) << 28) | ((t & 0x000f) << 24));
 
                 *(dPtr++) = t1 | t2 | t3 | ta;
             }
@@ -1501,6 +1511,22 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
                 v = XMVectorMultiply(v, s_Scale);
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSwizzle<2, 1, 0, 3>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            static const XMVECTORF32 s_Scale = { { { 1.f / 15.f, 1.f / 15.f, 1.f / 15.f, 1.f / 15.f } } };
+            const XMUNIBBLE4 * __restrict sPtr = static_cast<const XMUNIBBLE4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUNIBBLE4) + 1); icount += sizeof(XMUNIBBLE4))
+            {
+                XMVECTOR v = XMLoadUNibble4(sPtr++);
+                v = XMVectorMultiply(v, s_Scale);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSwizzle<3, 2, 1, 0>(v);
             }
             return true;
         }
@@ -2382,6 +2408,26 @@ bool DirectX::Internal::StoreScanline(
         }
         return false;
 
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            static const XMVECTORF32 s_Scale = { { { 15.f, 15.f, 15.f, 15.f } } };
+            XMUNIBBLE4 * __restrict dPtr = static_cast<XMUNIBBLE4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUNIBBLE4) + 1); icount += sizeof(XMUNIBBLE4))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorSwizzle<3, 2, 1, 0>(*sPtr++);
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+                v = XMVectorMultiplyAdd(v, s_Scale, g_XMOneHalf);
+#else
+                v = XMVectorMultiply(v, s_Scale);
+#endif
+                XMStoreUNibble4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
     case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
         // Xbox One specific 7e3 format with alpha
         if (size >= sizeof(XMUDECN4))
@@ -2760,7 +2806,7 @@ bool DirectX::Internal::StoreScanlineLinear(
 
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 
-    switch (format)
+    switch (static_cast<int>(format))
     {
     case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
     case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
@@ -2791,6 +2837,7 @@ bool DirectX::Internal::StoreScanlineLinear(
     case DXGI_FORMAT_B8G8R8A8_UNORM:
     case DXGI_FORMAT_B8G8R8X8_UNORM:
     case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         break;
 
     default:
@@ -2831,7 +2878,7 @@ bool DirectX::Internal::LoadScanlineLinear(
     DXGI_FORMAT format,
     TEX_FILTER_FLAGS flags) noexcept
 {
-    switch (format)
+    switch (static_cast<int>(format))
     {
     case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
     case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
@@ -2862,6 +2909,7 @@ bool DirectX::Internal::LoadScanlineLinear(
     case DXGI_FORMAT_B8G8R8A8_UNORM:
     case DXGI_FORMAT_B8G8R8X8_UNORM:
     case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         break;
 
     default:
@@ -2987,6 +3035,7 @@ namespace
         { XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT,  10, CONVF_FLOAT | CONVF_POS_ONLY | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
         { XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM,10, CONVF_SNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
         { XBOX_DXGI_FORMAT_R4G4_UNORM,               4, CONVF_UNORM | CONVF_R | CONVF_G },
+        { WIN11_DXGI_FORMAT_A4B4G4R4_UNORM,          4, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
     };
 
 #pragma prefast( suppress : 25004, "Signature must match bsearch" );
@@ -3231,8 +3280,8 @@ void DirectX::Internal::ConvertScanline(
             {
                 // !CONVF_DEPTH -> CONVF_DEPTH
 
-                // RGB -> Depth (red channel)
-                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE))
+                // RGB -> Depth (red channel or other specified channel)
+                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE | TEX_FILTER_RGB_COPY_ALPHA))
                 {
                 case TEX_FILTER_RGB_COPY_GREEN:
                     {
@@ -3253,6 +3302,18 @@ void DirectX::Internal::ConvertScanline(
                         {
                             const XMVECTOR v = *ptr;
                             const XMVECTOR v1 = XMVectorSplatZ(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                    break;
+
+                case TEX_FILTER_RGB_COPY_ALPHA:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatW(v);
                             *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
                         }
                     }
@@ -3525,6 +3586,7 @@ void DirectX::Internal::ConvertScanline(
         if (((out->flags & CONVF_RGBA_MASK) == CONVF_A) && !(in->flags & CONVF_A))
         {
             // !CONVF_A -> A format
+            // We ignore TEX_FILTER_RGB_COPY_ALPHA since there's no input alpha channel.
             switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE))
             {
             case TEX_FILTER_RGB_COPY_GREEN:
@@ -3620,8 +3682,8 @@ void DirectX::Internal::ConvertScanline(
         {
             if ((out->flags & CONVF_RGB_MASK) == CONVF_R)
             {
-                // RGB format -> R format
-                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE))
+                // RGB(A) format -> R format
+                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE | TEX_FILTER_RGB_COPY_ALPHA))
                 {
                 case TEX_FILTER_RGB_COPY_GREEN:
                     {
@@ -3642,6 +3704,18 @@ void DirectX::Internal::ConvertScanline(
                         {
                             const XMVECTOR v = *ptr;
                             const XMVECTOR v1 = XMVectorSplatZ(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                    }
+                    break;
+
+                case TEX_FILTER_RGB_COPY_ALPHA:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatW(v);
                             *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
                         }
                     }
@@ -3675,37 +3749,83 @@ void DirectX::Internal::ConvertScanline(
             }
             else if ((out->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G))
             {
-                // RGB format -> RG format
-                switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE)))
+                if ((flags & TEX_FILTER_RGB_COPY_ALPHA) && (in->flags & CONVF_A))
                 {
-                case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE)):
+                    // RGBA -> RG format
+                    switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE | TEX_FILTER_RGB_COPY_ALPHA)))
                     {
-                        XMVECTOR* ptr = pBuffer;
-                        for (size_t i = 0; i < count; ++i)
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_ALPHA)):
+                    default:
                         {
-                            const XMVECTOR v = *ptr;
-                            const XMVECTOR v1 = XMVectorSwizzle<0, 2, 0, 2>(v);
-                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<0, 3, 0, 3>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
                         }
-                    }
-                    break;
+                        break;
 
-                case (static_cast<int>(TEX_FILTER_RGB_COPY_GREEN) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE)):
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_GREEN) | static_cast<int>(TEX_FILTER_RGB_COPY_ALPHA)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<1, 3, 1, 3>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_BLUE) | static_cast<int>(TEX_FILTER_RGB_COPY_ALPHA)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<2, 3, 2, 3>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+                    }
+                }
+                else
+                {
+                    // RGB format -> RG format
+                    switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE)))
                     {
-                        XMVECTOR* ptr = pBuffer;
-                        for (size_t i = 0; i < count; ++i)
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE)):
                         {
-                            const XMVECTOR v = *ptr;
-                            const XMVECTOR v1 = XMVectorSwizzle<1, 2, 3, 0>(v);
-                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<0, 2, 0, 2>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
                         }
-                    }
-                    break;
+                        break;
 
-                case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_GREEN)):
-                default:
-                    // Leave data unchanged and the store will handle this...
-                    break;
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_GREEN) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<1, 2, 3, 0>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_GREEN)):
+                    default:
+                        // Leave data unchanged and the store will handle this...
+                        break;
+                    }
                 }
             }
         }
@@ -4327,6 +4447,56 @@ bool DirectX::Internal::StoreScanlineDither(
 
     case DXGI_FORMAT_B4G4R4A4_UNORM:
         STORE_SCANLINE(XMUNIBBLE4, g_Scale4pc, true, true, uint8_t, 0xF, y, true)
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            XMUNIBBLE4 * __restrict dest = static_cast<XMUNIBBLE4*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorSaturate(sPtr[index]);
+                v = XMVectorSwizzle<3, 2, 1, 0>(v);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, g_Scale4pc);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, g_Scale4pc);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, g_Scale4pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                dPtr->x = uint8_t(static_cast<uint8_t>(tmp.x) & 0xF);
+                dPtr->y = uint8_t(static_cast<uint8_t>(tmp.y) & 0xF);
+                dPtr->z = uint8_t(static_cast<uint8_t>(tmp.z) & 0xF);
+                dPtr->w = uint8_t(static_cast<uint8_t>(tmp.w) & 0xF);
+            }
+            return true;
+        }
+        return false;
 
     case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
         STORE_SCANLINE(XMXDECN4, g_Scale9pc, false, true, uint16_t, 0x3FF, y, false)

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -187,6 +187,8 @@ using WICPixelFormatGUID = GUID;
 
 #define XBOX_DXGI_FORMAT_R4G4_UNORM DXGI_FORMAT(190)
 
+#define WIN11_DXGI_FORMAT_A4B4G4R4_UNORM DXGI_FORMAT(191)
+
 #if defined(__MINGW32__) && !defined(E_BOUNDS)
 #define E_BOUNDS static_cast<HRESULT>(0x8000000BL)
 #endif

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -456,6 +456,30 @@ bool DirectX::IsDepthStencil(DXGI_FORMAT fmt) noexcept
 
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
+bool DirectX::IsBGR(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
 bool DirectX::IsTypeless(DXGI_FORMAT fmt, bool partialTypeless) noexcept
 {
     switch (static_cast<int>(fmt))
@@ -551,6 +575,7 @@ bool DirectX::HasAlpha(DXGI_FORMAT fmt) noexcept
     case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
     case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
     case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         return true;
 
     default:
@@ -667,6 +692,7 @@ size_t DirectX::BitsPerPixel(DXGI_FORMAT fmt) noexcept
     case DXGI_FORMAT_B4G4R4A4_UNORM:
     case WIN10_DXGI_FORMAT_P208:
     case WIN10_DXGI_FORMAT_V208:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         return 16;
 
     case DXGI_FORMAT_NV12:
@@ -867,6 +893,7 @@ size_t DirectX::BitsPerColor(DXGI_FORMAT fmt) noexcept
 
     case DXGI_FORMAT_B4G4R4A4_UNORM:
     case XBOX_DXGI_FORMAT_R4G4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
         return 4;
 
     case DXGI_FORMAT_R1_UNORM:

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -265,6 +265,9 @@ namespace
         // No support for legacy paletted video formats (AI44, IA44, P8, A8P8)
         DEFFMT(B4G4R4A4_UNORM),
 
+        // D3D11on12 format
+        { L"A4B4G4R4_UNORM", DXGI_FORMAT(191) },
+
         { nullptr, DXGI_FORMAT_UNKNOWN }
     };
 
@@ -749,6 +752,14 @@ namespace
 
             if (errorText)
                 LocalFree(errorText);
+
+            for (wchar_t* ptr = desc; *ptr != 0; ++ptr)
+            {
+                if (*ptr == L'\r' || *ptr == L'\n')
+                {
+                    *ptr = L' ';
+                }
+            }
         }
 
         return desc;

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -309,6 +309,9 @@ namespace
         // No support for legacy paletted video formats (AI44, IA44, P8, A8P8)
         DEFFMT(B4G4R4A4_UNORM),
 
+        // D3D11on12 format
+        { L"A4B4G4R4_UNORM", DXGI_FORMAT(191) },
+
         { nullptr, DXGI_FORMAT_UNKNOWN }
     };
 
@@ -1044,6 +1047,14 @@ namespace
 
             if (errorText)
                 LocalFree(errorText);
+
+            for (wchar_t* ptr = desc; *ptr != 0; ++ptr)
+            {
+                if (*ptr == L'\r' || *ptr == L'\n')
+                {
+                    *ptr = L' ';
+                }
+            }
         }
 
         return desc;

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -218,6 +218,9 @@ const SValue g_pFormats[] =
     DEFFMT(Y216),
     DEFFMT(B4G4R4A4_UNORM),
 
+    // D3D11on12 format
+    { L"A4B4G4R4_UNORM", DXGI_FORMAT(191) },
+
     { nullptr, DXGI_FORMAT_UNKNOWN }
 };
 
@@ -748,6 +751,14 @@ namespace
 
             if (errorText)
                 LocalFree(errorText);
+
+            for(wchar_t* ptr = desc; *ptr != 0; ++ptr)
+            {
+                if (*ptr == L'\r' || *ptr == L'\n')
+                {
+                    *ptr = L' ';
+                }
+            }
         }
 
         return desc;

--- a/build/DirectXTex-GitHub-CMake-Xbox-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Xbox-Dev17.yml
@@ -43,12 +43,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTex-GitHub-CMake-Xbox-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Xbox-Dev17.yml
@@ -43,7 +43,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'

--- a/build/DirectXTex-GitHub-CMake-Xbox.yml
+++ b/build/DirectXTex-GitHub-CMake-Xbox.yml
@@ -56,7 +56,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'

--- a/build/DirectXTex-GitHub-CMake-Xbox.yml
+++ b/build/DirectXTex-GitHub-CMake-Xbox.yml
@@ -56,12 +56,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTex-GitHub-GDK-Dev17.yml
+++ b/build/DirectXTex-GitHub-GDK-Dev17.yml
@@ -44,7 +44,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'

--- a/build/DirectXTex-GitHub-GDK-Dev17.yml
+++ b/build/DirectXTex-GitHub-GDK-Dev17.yml
@@ -44,12 +44,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTex-GitHub-GDK.yml
+++ b/build/DirectXTex-GitHub-GDK.yml
@@ -65,7 +65,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'

--- a/build/DirectXTex-GitHub-GDK.yml
+++ b/build/DirectXTex-GitHub-GDK.yml
@@ -65,12 +65,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTex-GitHub-SDK-prerelease.yml
+++ b/build/DirectXTex-GitHub-SDK-prerelease.yml
@@ -43,7 +43,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
@@ -163,7 +164,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: NuGet set package source to ADO feed
     inputs:

--- a/build/DirectXTex-GitHub-SDK-prerelease.yml
+++ b/build/DirectXTex-GitHub-SDK-prerelease.yml
@@ -43,12 +43,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -162,11 +163,12 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: NuGet set package source to ADO feed
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTex-GitHub-SDK-release.yml
+++ b/build/DirectXTex-GitHub-SDK-release.yml
@@ -43,7 +43,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
@@ -163,7 +164,8 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-    versionSpec: '6.5.x'
+    inputs:
+      versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: NuGet set package source to ADO feed
     inputs:

--- a/build/DirectXTex-GitHub-SDK-release.yml
+++ b/build/DirectXTex-GitHub-SDK-release.yml
@@ -43,12 +43,13 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     # We have to use a nuget.config to provide the feed for the 'nuget install' option.
     displayName: 'NuGet set package source to ADO feed'
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:
@@ -162,11 +163,12 @@ jobs:
     fetchTags: false
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
+    versionSpec: '6.5.x'
   - task: NuGetCommand@2
     displayName: NuGet set package source to ADO feed
     inputs:
       command: custom
-      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile NuGet.config
+      arguments: sources add -Name xboxgdk-DirectXTex -Source $(URL_FEED) -ConfigFile $(Build.SourcesDirectory)\NuGet.config
   - task: PowerShell@2
     displayName: 'Set nuget.config to single source'
     inputs:

--- a/build/DirectXTex-GitHub.yml
+++ b/build/DirectXTex-GitHub.yml
@@ -42,6 +42,9 @@ resources:
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
+variables:
+  Codeql.Enabled: true
+
 pool:
   vmImage: windows-2019
 

--- a/build/DirectXTex-config.cmake.in
+++ b/build/DirectXTex-config.cmake.in
@@ -3,6 +3,11 @@
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
 include(CMakeFindDependencyMacro)
 
+set(BC_USE_OPENMP @BC_USE_OPENMP@)
+if(BC_USE_OPENMP)
+    find_dependency(OpenMP)
+endif()
+
 set(ENABLE_OPENEXR_SUPPORT @ENABLE_OPENEXR_SUPPORT@)
 if(ENABLE_OPENEXR_SUPPORT)
     find_dependency(OpenEXR)


### PR DESCRIPTION
* ``TEX_FILTER_RGB_COPY_ALPHA`` flag
* Support for ``DXGI_FORMAT_A4B4G4R4_UNORM``
* GetErrorDesc fix for command-line tools
* CMake fix for OpenMP dependency and ``/ZH:SHA_256`` for clang v16

> Also need a workaround applied for a problem with NuGet 6.6 and NuGetCommand@2 using custom.