### PR TITLE
texconv: Added support for DXT5nm and RXGB DXT5 format variants

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -221,6 +221,9 @@ namespace DirectX
         DDS_FLAGS_FORCE_DX9_LEGACY = 0x40000,
         // Force use of legacy header for DDS writer (will fail if unable to write as such)
 
+        DDS_FLAGS_FORCE_DXT5_RXGB = 0x80000,
+        // Force use of 'RXGB' instead of 'DXT5' for DDS write of BC3_UNORM data
+
         DDS_FLAGS_ALLOW_LARGE_FILES = 0x1000000,
         // Enables the loader to read large dimension .dds files (i.e. greater than known hardware requirements)
     };

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -57,8 +57,6 @@ namespace
         DDS_PIXELFORMAT ddpf;
     };
 
-    const DDS_PIXELFORMAT DDSPF_DXT5_RXGB = { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'X', 'G', 'B'), 0, 0, 0, 0, 0 };
-
     const LegacyDDS g_LegacyDDSMap[] =
     {
         { DXGI_FORMAT_BC1_UNORM,          CONV_FLAGS_NONE,        DDSPF_DXT1 }, // D3DFMT_DXT1
@@ -78,7 +76,7 @@ namespace
         { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'G', 'x', 'R'), 0, 0, 0, 0, 0 } },
         { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G', 'X', 'R', 'B'), 0, 0, 0, 0, 0 } },
         { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G', 'R', 'X', 'B'), 0, 0, 0, 0, 0 } },
-        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        DDSPF_DXT5_RXGB },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'X', 'G', 'B'), 0, 0, 0, 0, 0 } },
         { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'R', 'G', 'X'), 0, 0, 0, 0, 0 } },
 
         { DXGI_FORMAT_BC4_UNORM,          CONV_FLAGS_NONE,        DDSPF_BC4_UNORM },
@@ -642,6 +640,14 @@ HRESULT DirectX::EncodeDDSHeader(
         case DXGI_FORMAT_B4G4R4A4_UNORM:        memcpy(&ddpf, &DDSPF_A4R4G4B4, sizeof(DDS_PIXELFORMAT)); break; // DXGI 1.2
         case DXGI_FORMAT_YUY2:                  memcpy(&ddpf, &DDSPF_YUY2, sizeof(DDS_PIXELFORMAT)); break; // DXGI 1.2
 
+        case DXGI_FORMAT_BC3_UNORM:
+            memcpy(&ddpf, metadata.IsPMAlpha() ? (&DDSPF_DXT4) : (&DDSPF_DXT5), sizeof(DDS_PIXELFORMAT));
+            if (flags & DDS_FLAGS_FORCE_DXT5_RXGB)
+            {
+                ddpf.fourCC = MAKEFOURCC('R', 'X', 'G', 'B');
+            }
+            break;
+
         // Legacy D3DX formats using D3DFMT enum value as FourCC
         case DXGI_FORMAT_R32G32B32A32_FLOAT:
             ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 116;  // D3DFMT_A32B32G32R32F
@@ -666,21 +672,6 @@ HRESULT DirectX::EncodeDDSHeader(
             break;
         case DXGI_FORMAT_R16_FLOAT:
             ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 111;  // D3DFMT_R16F
-            break;
-
-        case DXGI_FORMAT_BC3_UNORM:
-            if (flags & DDS_FLAGS_FORCE_DXT5_RXGB)
-            {
-                memcpy(&ddpf, &DDSPF_DXT5_RXGB, sizeof(DDS_PIXELFORMAT)); break;
-            }
-            else if (metadata.IsPMAlpha())
-            {
-                memcpy(&ddpf, &DDSPF_DXT4, sizeof(DDS_PIXELFORMAT)); break;
-            }
-            else
-            {
-                memcpy(&ddpf, &DDSPF_DXT5, sizeof(DDS_PIXELFORMAT)); break;
-            }
             break;
 
         // DX9 legacy pixel formats

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -66,6 +66,18 @@ namespace
         { DXGI_FORMAT_BC2_UNORM,          CONV_FLAGS_PMALPHA,     DDSPF_DXT2 }, // D3DFMT_DXT2
         { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_PMALPHA,     DDSPF_DXT4 }, // D3DFMT_DXT4
 
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', '2', 'D', '5'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'G', 'B', 'R'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'x', 'B', 'G'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'B', 'x', 'G'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'R', 'B', 'G'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'G', 'x', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'G', 'x', 'R'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G', 'X', 'R', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G', 'R', 'X', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'X', 'G', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'R', 'G', 'X'), 0, 0, 0, 0, 0 } },
+
         { DXGI_FORMAT_BC4_UNORM,          CONV_FLAGS_NONE,        DDSPF_BC4_UNORM },
         { DXGI_FORMAT_BC4_SNORM,          CONV_FLAGS_NONE,        DDSPF_BC4_SNORM },
         { DXGI_FORMAT_BC5_UNORM,          CONV_FLAGS_NONE,        DDSPF_BC5_UNORM },
@@ -73,6 +85,7 @@ namespace
 
         { DXGI_FORMAT_BC4_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', 'T', 'I', '1'), 0, 0, 0, 0, 0 } },
         { DXGI_FORMAT_BC5_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', 'T', 'I', '2'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC5_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', '2', 'X', 'Y'), 0, 0, 0, 0, 0 } },
 
         { DXGI_FORMAT_BC6H_UF16,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'C', '6', 'H'), 0, 0, 0, 0, 0 } },
         { DXGI_FORMAT_BC7_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'C', '7', 'L'), 0, 0, 0, 0, 0 } },

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -150,6 +150,7 @@ namespace
     enum
     {
         FORMAT_DXT5_NM = 1,
+        FORMAT_DXT5_RXGB,
     };
 
     static_assert(OPT_MAX <= 64, "dwOptions is a unsigned int bitfield");
@@ -347,6 +348,7 @@ namespace
     {
         { L"BC3n", FORMAT_DXT5_NM },
         { L"DXT5nm", FORMAT_DXT5_NM },
+        { L"RXGB", FORMAT_DXT5_RXGB },
 
         { nullptr, 0 }
     };
@@ -1443,6 +1445,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     float preserveAlphaCoverageRef = 0.0f;
     bool keepRecursiveDirs = false;
     bool dxt5nm = false;
+    bool dxt5rxgb = false;
     uint32_t swizzleElements[4] = { 0, 1, 2, 3 };
     uint32_t zeroElements[4] = {};
     uint32_t oneElements[4] = {};
@@ -1601,6 +1604,11 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                         case FORMAT_DXT5_NM:
                             format = DXGI_FORMAT_BC3_UNORM;
                             dxt5nm = true;
+                            break;
+
+                        case FORMAT_DXT5_RXGB:
+                            format = DXGI_FORMAT_BC3_UNORM;
+                            dxt5rxgb = true;
                             break;
 
                         default:
@@ -3478,81 +3486,12 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
         }
 
         // --- Compress ----------------------------------------------------------------
-        if (dxt5nm)
+        if (FileType == CODEC_DDS)
         {
-            // Prepare for DXT5nm
-            assert(tformat == DXGI_FORMAT_BC3_UNORM);
-
-            std::unique_ptr<ScratchImage> timage(new (std::nothrow) ScratchImage);
-            if (!timage)
+            if (dxt5nm || dxt5rxgb)
             {
-                wprintf(L"\nERROR: Memory allocation failed\n");
-                return 1;
-            }
-
-            hr = TransformImage(image->GetImages(), image->GetImageCount(), image->GetMetadata(),
-                [=](XMVECTOR* outPixels, const XMVECTOR* inPixels, size_t w, size_t y)
-                {
-                    UNREFERENCED_PARAMETER(y);
-
-                    for (size_t j = 0; j < w; ++j)
-                    {
-                        outPixels[j] = XMVectorPermute<4, 1, 5, 0>(inPixels[j], g_XMIdentityR0);
-                    }
-                }, *timage);
-            if (FAILED(hr))
-            {
-                wprintf(L" FAILED [DXT5nm] (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
-                return 1;
-            }
-
-        #ifndef NDEBUG
-            auto& tinfo = timage->GetMetadata();
-        #endif
-
-            assert(info.width == tinfo.width);
-            assert(info.height == tinfo.height);
-            assert(info.depth == tinfo.depth);
-            assert(info.arraySize == tinfo.arraySize);
-            assert(info.mipLevels == tinfo.mipLevels);
-            assert(info.miscFlags == tinfo.miscFlags);
-            assert(info.format == tinfo.format);
-            assert(info.dimension == tinfo.dimension);
-
-            image.swap(timage);
-            cimage.reset();
-        }
-
-        if (IsCompressed(tformat) && (FileType == CODEC_DDS))
-        {
-            if (cimage && (cimage->GetMetadata().format == tformat))
-            {
-                // We never changed the image and it was already compressed in our desired format, use original data
-                image.reset(cimage.release());
-
-                auto& tinfo = image->GetMetadata();
-
-                if ((tinfo.width % 4) != 0 || (tinfo.height % 4) != 0)
-                {
-                    non4bc = true;
-                }
-
-                info.format = tinfo.format;
-                assert(info.width == tinfo.width);
-                assert(info.height == tinfo.height);
-                assert(info.depth == tinfo.depth);
-                assert(info.arraySize == tinfo.arraySize);
-                assert(info.mipLevels == tinfo.mipLevels);
-                assert(info.miscFlags == tinfo.miscFlags);
-                assert(info.dimension == tinfo.dimension);
-            }
-            else
-            {
-                cimage.reset();
-
-                auto img = image->GetImage(0, 0, 0);
-                assert(img);
-                const size_t nimg = image->GetImageCount();
+                // Prepare for DXT5nm/RXGB
+                assert(tformat == DXGI_FORMAT_BC3_UNORM);
 
                 std::unique_ptr<ScratchImage> timage(new (std::nothrow) ScratchImage);
                 if (!timage)
@@ -3561,93 +3500,184 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     return 1;
                 }
 
-                bool bc6hbc7 = false;
-                switch (tformat)
+                if (dxt5nm)
                 {
-                case DXGI_FORMAT_BC6H_TYPELESS:
-                case DXGI_FORMAT_BC6H_UF16:
-                case DXGI_FORMAT_BC6H_SF16:
-                case DXGI_FORMAT_BC7_TYPELESS:
-                case DXGI_FORMAT_BC7_UNORM:
-                case DXGI_FORMAT_BC7_UNORM_SRGB:
-                    bc6hbc7 = true;
-
-                    {
-                        static bool s_tryonce = false;
-
-                        if (!s_tryonce)
+                    hr = TransformImage(image->GetImages(), image->GetImageCount(), image->GetMetadata(),
+                        [=](XMVECTOR* outPixels, const XMVECTOR* inPixels, size_t w, size_t y)
                         {
-                            s_tryonce = true;
+                            UNREFERENCED_PARAMETER(y);
 
-                            if (!(dwOptions & (uint64_t(1) << OPT_NOGPU)))
+                            for (size_t j = 0; j < w; ++j)
                             {
-                                if (!CreateDevice(adapter, pDevice.GetAddressOf()))
-                                    wprintf(L"\nWARNING: DirectCompute is not available, using BC6H / BC7 CPU codec\n");
+                                outPixels[j] = XMVectorPermute<4, 1, 5, 0>(inPixels[j], g_XMIdentityR0);
                             }
-                            else
-                            {
-                                wprintf(L"\nWARNING: using BC6H / BC7 CPU codec\n");
-                            }
-                        }
+                        }, *timage);
+                    if (FAILED(hr))
+                    {
+                        wprintf(L" FAILED [DXT5nm] (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
+                        return 1;
                     }
-                    break;
-
-                default:
-                    break;
-                }
-
-                TEX_COMPRESS_FLAGS cflags = dwCompress;
-            #ifdef _OPENMP
-                if (!(dwOptions & (uint64_t(1) << OPT_FORCE_SINGLEPROC)))
-                {
-                    cflags |= TEX_COMPRESS_PARALLEL;
-                }
-            #endif
-
-                if ((img->width % 4) != 0 || (img->height % 4) != 0)
-                {
-                    non4bc = true;
-                }
-
-                if (bc6hbc7 && pDevice)
-                {
-                    hr = Compress(pDevice.Get(), img, nimg, info, tformat, dwCompress | dwSRGB, alphaWeight, *timage);
                 }
                 else
                 {
-                    hr = Compress(img, nimg, info, tformat, cflags | dwSRGB, alphaThreshold, *timage);
-                }
-                if (FAILED(hr))
-                {
-                    wprintf(L" FAILED [compress] (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
-                    retVal = 1;
-                    continue;
+                    hr = TransformImage(image->GetImages(), image->GetImageCount(), image->GetMetadata(),
+                        [=](XMVECTOR* outPixels, const XMVECTOR* inPixels, size_t w, size_t y)
+                        {
+                            UNREFERENCED_PARAMETER(y);
+
+                            for (size_t j = 0; j < w; ++j)
+                            {
+                                outPixels[j] = XMVectorSwizzle<3, 1, 2, 0>(inPixels[j]);
+                            }
+                        }, *timage);
+                    if (FAILED(hr))
+                    {
+                        wprintf(L" FAILED [DXT5 RXGB] (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
+                        return 1;
+                    }
                 }
 
+            #ifndef NDEBUG
                 auto& tinfo = timage->GetMetadata();
+            #endif
 
-                info.format = tinfo.format;
                 assert(info.width == tinfo.width);
                 assert(info.height == tinfo.height);
                 assert(info.depth == tinfo.depth);
                 assert(info.arraySize == tinfo.arraySize);
                 assert(info.mipLevels == tinfo.mipLevels);
                 assert(info.miscFlags == tinfo.miscFlags);
+                assert(info.format == tinfo.format);
                 assert(info.dimension == tinfo.dimension);
 
                 image.swap(timage);
+                cimage.reset();
+            }
+
+            if (IsCompressed(tformat))
+            {
+                if (cimage && (cimage->GetMetadata().format == tformat))
+                {
+                    // We never changed the image and it was already compressed in our desired format, use original data
+                    image.reset(cimage.release());
+
+                    auto& tinfo = image->GetMetadata();
+
+                    if ((tinfo.width % 4) != 0 || (tinfo.height % 4) != 0)
+                    {
+                        non4bc = true;
+                    }
+
+                    info.format = tinfo.format;
+                    assert(info.width == tinfo.width);
+                    assert(info.height == tinfo.height);
+                    assert(info.depth == tinfo.depth);
+                    assert(info.arraySize == tinfo.arraySize);
+                    assert(info.mipLevels == tinfo.mipLevels);
+                    assert(info.miscFlags == tinfo.miscFlags);
+                    assert(info.dimension == tinfo.dimension);
+                }
+                else
+                {
+                    cimage.reset();
+
+                    auto img = image->GetImage(0, 0, 0);
+                    assert(img);
+                    const size_t nimg = image->GetImageCount();
+
+                    std::unique_ptr<ScratchImage> timage(new (std::nothrow) ScratchImage);
+                    if (!timage)
+                    {
+                        wprintf(L"\nERROR: Memory allocation failed\n");
+                        return 1;
+                    }
+
+                    bool bc6hbc7 = false;
+                    switch (tformat)
+                    {
+                    case DXGI_FORMAT_BC6H_TYPELESS:
+                    case DXGI_FORMAT_BC6H_UF16:
+                    case DXGI_FORMAT_BC6H_SF16:
+                    case DXGI_FORMAT_BC7_TYPELESS:
+                    case DXGI_FORMAT_BC7_UNORM:
+                    case DXGI_FORMAT_BC7_UNORM_SRGB:
+                        bc6hbc7 = true;
+
+                        {
+                            static bool s_tryonce = false;
+
+                            if (!s_tryonce)
+                            {
+                                s_tryonce = true;
+
+                                if (!(dwOptions & (uint64_t(1) << OPT_NOGPU)))
+                                {
+                                    if (!CreateDevice(adapter, pDevice.GetAddressOf()))
+                                        wprintf(L"\nWARNING: DirectCompute is not available, using BC6H / BC7 CPU codec\n");
+                                }
+                                else
+                                {
+                                    wprintf(L"\nWARNING: using BC6H / BC7 CPU codec\n");
+                                }
+                            }
+                        }
+                        break;
+
+                    default:
+                        break;
+                    }
+
+                    TEX_COMPRESS_FLAGS cflags = dwCompress;
+                #ifdef _OPENMP
+                    if (!(dwOptions & (uint64_t(1) << OPT_FORCE_SINGLEPROC)))
+                    {
+                        cflags |= TEX_COMPRESS_PARALLEL;
+                    }
+                #endif
+
+                    if ((img->width % 4) != 0 || (img->height % 4) != 0)
+                    {
+                        non4bc = true;
+                    }
+
+                    if (bc6hbc7 && pDevice)
+                    {
+                        hr = Compress(pDevice.Get(), img, nimg, info, tformat, dwCompress | dwSRGB, alphaWeight, *timage);
+                    }
+                    else
+                    {
+                        hr = Compress(img, nimg, info, tformat, cflags | dwSRGB, alphaThreshold, *timage);
+                    }
+                    if (FAILED(hr))
+                    {
+                        wprintf(L" FAILED [compress] (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
+                        retVal = 1;
+                        continue;
+                    }
+
+                    auto& tinfo = timage->GetMetadata();
+
+                    info.format = tinfo.format;
+                    assert(info.width == tinfo.width);
+                    assert(info.height == tinfo.height);
+                    assert(info.depth == tinfo.depth);
+                    assert(info.arraySize == tinfo.arraySize);
+                    assert(info.mipLevels == tinfo.mipLevels);
+                    assert(info.miscFlags == tinfo.miscFlags);
+                    assert(info.dimension == tinfo.dimension);
+
+                    image.swap(timage);
+                }
             }
         }
-        else
-        {
-            cimage.reset();
-        }
+
+        cimage.reset();
 
         // --- Set alpha mode ----------------------------------------------------------
         if (HasAlpha(info.format)
             && info.format != DXGI_FORMAT_A8_UNORM)
         {
-            if (dxt5nm)
+            if (dxt5nm || dxt5rxgb)
             {
                 info.SetAlphaMode(TEX_ALPHA_MODE_CUSTOM);
             }
@@ -3766,6 +3796,11 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     }
                     else if (dwOptions & (uint64_t(1) << OPT_USE_DX9))
                     {
+                        if (dxt5rxgb)
+                        {
+                            ddsFlags |= DDS_FLAGS_FORCE_DXT5_RXGB;
+                        }
+
                         ddsFlags |= DDS_FLAGS_FORCE_DX9_LEGACY;
                     }
 


### PR DESCRIPTION
The "DXT5nm" format is a "swizzled" DXT5/BC3 variant supported by a number of tools. It's intended to encode normal maps using BC3 which is supported on all Direct3D Hardware Feature levels rather than BC4/BC5 which originally was an ATI only extension and then part of Direct3D Hardware Feature Level 10.0. It encodes the 'x' as the alpha channel, 'y' as the green channel, sets the red channel to 1.0, and the blue channel to 0 to get good quality compression of both components.

The "RXGA" format is a "swizzled" DXT5/BC3 variant supported by a number of tools and popularized by Doom 3. It swaps the 'r' and 'a' channels, leaving 'g' and 'b' in place. This is normally written as "DXT5", but if ``-f RXGB -dx9`` is used, then it will write using the FourCC "RXGB" instead.

The PR also adds support to the DirectXTex DDS codec for reading the numerous legacy FourCC's that are just 'swizzled' versions of BC3 or BC5. These are returned 'as is' so there's no logic to 'deswizzle' built-in. This should be handled by the client of the code, potentially using the ``-swizzle`` texconv switch.
