### PR TITLE
CMake targets fixes for optional vs. required packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
     Texassemble/texassemble.rc
     Texassemble/settings.manifest
     Texassemble/AnimatedGif.cpp)
-  target_link_libraries(texassemble ${PROJECT_NAME} ole32.lib version.lib)
+  target_link_libraries(texassemble PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
   source_group(texassemble REGULAR_EXPRESSION Texassemble/*.*)
 
   add_executable(texconv
@@ -296,24 +296,24 @@ if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
     Texconv/settings.manifest
     Texconv/ExtendedBMP.cpp
     Texconv/PortablePixMap.cpp)
-  target_link_libraries(texconv ${PROJECT_NAME} ole32.lib shell32.lib version.lib)
+  target_link_libraries(texconv PRIVATE ${PROJECT_NAME} ole32.lib shell32.lib version.lib)
   source_group(texconv REGULAR_EXPRESSION Texconv/*.*)
 
   add_executable(texdiag
     Texdiag/texdiag.cpp
     Texdiag/texdiag.rc
     Texdiag/settings.manifest)
-  target_link_libraries(texdiag ${PROJECT_NAME} ole32.lib version.lib)
+  target_link_libraries(texdiag PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
   source_group(texdiag REGULAR_EXPRESSION Texdiag/*.*)
 
   if(BC_USE_OPENMP)
-    target_link_libraries(texconv OpenMP::OpenMP_CXX)
+    target_link_libraries(texconv PRIVATE OpenMP::OpenMP_CXX)
   endif()
 
   if(ENABLE_OPENEXR_SUPPORT)
     foreach(t IN LISTS TOOL_EXES)
       target_include_directories(${t} PRIVATE Auxiliary)
-      target_link_libraries(${t} ${OPENEXR_ILMIMF_LIBRARY})
+      target_link_libraries(${t} PRIVATE ${OPENEXR_ILMIMF_LIBRARY})
       target_compile_options(${t} PRIVATE -DUSE_OPENEXR)
     endforeach()
   endif()
@@ -337,7 +337,7 @@ if(BUILD_SAMPLE AND BUILD_DX11 AND WIN32)
     DDSView/ddsview.cpp
     DDSView/ddsview.rc
     ${COMPILED_DDSVIEW_SHADERS}/ddsview_ps1D.inc)
-  target_link_libraries(ddsview ${PROJECT_NAME} d3d11.lib ole32.lib)
+  target_link_libraries(ddsview PRIVATE ${PROJECT_NAME} d3d11.lib ole32.lib)
   source_group(ddsview REGULAR_EXPRESSION DDSView/*.*)
 
   target_include_directories(ddsview PRIVATE ${COMPILED_DDSVIEW_SHADERS})
@@ -356,7 +356,7 @@ endif()
 
 if(directxmath_FOUND)
   foreach(t IN LISTS TOOL_EXES)
-    target_link_libraries(${t} Microsoft::DirectXMath)
+    target_link_libraries(${t} PRIVATE Microsoft::DirectXMath)
   endforeach()
 endif()
 

--- a/build/DirectXTex-config.cmake.in
+++ b/build/DirectXTex-config.cmake.in
@@ -14,8 +14,11 @@ if(ENABLE_OPENEXR_SUPPORT)
 endif()
 
 if(MINGW OR (NOT WIN32))
-    find_dependency(directx-headers CONFIG)
-    find_dependency(directxmath CONFIG)
+    find_dependency(directx-headers)
+    find_dependency(directxmath)
+else()
+    find_package(directx-headers CONFIG QUIET)
+    find_package(directxmath CONFIG QUIET)
 endif()
 
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
WIth the changes to make use of DirectXMath & DirectX-Headers 'optional' for VCPKG scenarios unless using MinGW -or- Linux, the generated targets file needed more robust handling of these targets.

Also made sure that explicit 'scope' is used consistently with all CMake ``target_`` commands.

> This was noticed when building ``rsm-bsa`` with VCPKG as this uses DirectXTex, but not DirectXMath.