### PR TITLE
Remove overvalidation bug for BC7 GPU compressor with -srgb

### DIFF
--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -380,7 +380,6 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
         || srcImage.height != destImage.height
         || srcImage.width != m_width
         || srcImage.height != m_height
-        || srcImage.format != m_srcformat
         || destImage.format != m_bcformat)
     {
         return E_UNEXPECTED;


### PR DESCRIPTION
Fixed a small bug that was missed in #326 where the code was over-validating the format information internally for BC7 compression scenarios using ``SRGB`` override flags.