### PR TITLE
Add NO_WCHAR_T build option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
 
 option(USE_PREBUILT_SHADERS "Use externally built HLSL shaders" OFF)
 
+option(NO_WCHAR_T "Use legacy wide-character as unsigned short" OFF)
+
 # Includes the functions for loading/saving OpenEXR files at runtime
 option(ENABLE_OPENEXR_SUPPORT "Build with OpenEXR support" OFF)
 
@@ -397,6 +399,13 @@ if(MSVC)
       foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
         target_compile_options(${t} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
         target_link_options(${t} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
+      endforeach()
+    endif()
+
+    if(NO_WCHAR_T)
+      message(STATUS "Using non-native wchar_t as unsigned short")
+      foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+        target_compile_options(${t} PRIVATE "/Zc:wchar_t-")
       endforeach()
     endif()
 else()

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -350,13 +350,13 @@ namespace DirectX
         _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
         _In_ WIC_FLAGS flags,
         _Out_ TexMetadata& metadata,
-        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
 
     HRESULT __cdecl GetMetadataFromWICFile(
         _In_z_ const wchar_t* szFile,
         _In_ WIC_FLAGS flags,
         _Out_ TexMetadata& metadata,
-        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
 #endif
 
     // Compatability helpers
@@ -534,31 +534,31 @@ namespace DirectX
         _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
         _In_ WIC_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image,
-        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
     HRESULT __cdecl LoadFromWICFile(
         _In_z_ const wchar_t* szFile, _In_ WIC_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image,
-        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
 
     HRESULT __cdecl SaveToWICMemory(
         _In_ const Image& image, _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _Out_ Blob& blob, _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
     HRESULT __cdecl SaveToWICMemory(
         _In_count_(nimages) const Image* images, _In_ size_t nimages,
         _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _Out_ Blob& blob, _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
 
     HRESULT __cdecl SaveToWICFile(
         _In_ const Image& image, _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* szFile, _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
     HRESULT __cdecl SaveToWICFile(
         _In_count_(nimages) const Image* images, _In_ size_t nimages,
         _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* szFile, _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
 #endif // WIN32
 
     // Compatability helpers
@@ -679,11 +679,12 @@ namespace DirectX
 
     HRESULT __cdecl ConvertEx(
         _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ const ConvertOptions& options,
-        _Out_ ScratchImage& image, _In_opt_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        _Out_ ScratchImage& image,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
     HRESULT __cdecl ConvertEx(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
         _In_ DXGI_FORMAT format, _In_ const ConvertOptions& options, _Out_ ScratchImage& result,
-        _In_opt_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
         // Convert the image to a new format
 
     HRESULT __cdecl ConvertToSinglePlane(_In_ const Image& srcImage, _Out_ ScratchImage& image) noexcept;
@@ -790,11 +791,12 @@ namespace DirectX
 
     HRESULT __cdecl CompressEx(
         _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ const CompressOptions& options,
-        _Out_ ScratchImage& cImage, _In_opt_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        _Out_ ScratchImage& cImage,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
     HRESULT __cdecl CompressEx(
         _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
         _In_ DXGI_FORMAT format, _In_ const CompressOptions& options, _Out_ ScratchImage& cImages,
-        _In_opt_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
 
 #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
     HRESULT __cdecl Compress(
@@ -807,11 +809,12 @@ namespace DirectX
 
     HRESULT __cdecl CompressEx(
         _In_ ID3D11Device* pDevice, _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ const CompressOptions& options,
-        _Out_ ScratchImage& image, _In_opt_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        _Out_ ScratchImage& image,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
     HRESULT __cdecl CompressEx(
         _In_ ID3D11Device* pDevice, _In_ const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
         _In_ DXGI_FORMAT format, _In_ const CompressOptions& options, _Out_ ScratchImage& cImages,
-        _In_opt_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
 #endif
 
     HRESULT __cdecl Decompress(_In_ const Image& cImage, _In_ DXGI_FORMAT format, _Out_ ScratchImage& image) noexcept;

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -2574,3 +2574,68 @@ HRESULT DirectX::SaveToDDSFile(
 
     return S_OK;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl GetMetadataFromDDSFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept
+    {
+        return GetMetadataFromDDSFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata);
+    }
+
+    HRESULT __cdecl GetMetadataFromDDSFileEx(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat) noexcept
+    {
+        return GetMetadataFromDDSFileEx(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, ddPixelFormat);
+    }
+
+    HRESULT __cdecl LoadFromDDSFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_ ScratchImage& image) noexcept
+    {
+        return LoadFromDDSFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, image);
+    }
+
+    HRESULT __cdecl LoadFromDDSFileEx(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat,
+        _Out_ ScratchImage& image) noexcept
+    {
+        return LoadFromDDSFileEx(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, ddPixelFormat, image);
+    }
+
+    HRESULT __cdecl SaveToDDSFile(
+        _In_ const Image& image,
+        _In_ DDS_FLAGS flags,
+        _In_z_ const __wchar_t* szFile) noexcept
+    {
+        return SaveToDDSFile(image, flags, reinterpret_cast<const unsigned short*>(szFile));
+    }
+
+    HRESULT __cdecl SaveToDDSFile(
+        _In_reads_(nimages) const Image* images,
+        _In_ size_t nimages,
+        _In_ const TexMetadata& metadata,
+        _In_ DDS_FLAGS flags,
+        _In_z_ const __wchar_t* szFile) noexcept
+    {
+        return SaveToDDSFile(images, nimages, metadata, flags, reinterpret_cast<const unsigned short*>(szFile));
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -1298,3 +1298,36 @@ HRESULT DirectX::SaveToHDRFile(const Image& image, const wchar_t* szFile) noexce
 
     return S_OK;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl GetMetadataFromHDRFile(
+        _In_z_ const __wchar_t* szFile,
+        _Out_ TexMetadata& metadata) noexcept
+    {
+        return GetMetadataFromHDRFile(reinterpret_cast<const unsigned short*>(szFile), metadata);
+    }
+
+    HRESULT __cdecl LoadFromHDRFile(
+        _In_z_ const __wchar_t* szFile,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_ ScratchImage& image) noexcept
+    {
+        return LoadFromHDRFile(reinterpret_cast<const unsigned short*>(szFile), metadata, image);
+    }
+
+    HRESULT __cdecl SaveToHDRFile(
+        _In_ const Image& image,
+        _In_z_ const __wchar_t* szFile) noexcept
+    {
+        return SaveToHDRFile(image, reinterpret_cast<const unsigned short*>(szFile));
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -2522,3 +2522,39 @@ HRESULT DirectX::SaveToTGAFile(
 
     return S_OK;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl GetMetadataFromTGAFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ TGA_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept
+    {
+        return GetMetadataFromTGAFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata);
+    }
+
+    HRESULT __cdecl LoadFromTGAFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ TGA_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_ ScratchImage& image) noexcept
+    {
+        return LoadFromTGAFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, image);
+    }
+
+    HRESULT __cdecl SaveToTGAFile(_In_ const Image& image,
+        _In_ TGA_FLAGS flags,
+        _In_z_ const __wchar_t* szFile,
+        _In_opt_ const TexMetadata* metadata) noexcept
+    {
+        return SaveToTGAFile(image, flags, reinterpret_cast<const unsigned short*>(szFile), metadata);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -1617,3 +1617,56 @@ HRESULT DirectX::SaveToWICFile(
 
     return S_OK;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl GetMetadataFromWICFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ WIC_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR)
+    {
+        return GetMetadataFromWICFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, getMQR);
+    }
+
+    HRESULT __cdecl LoadFromWICFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ WIC_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_ ScratchImage& image,
+        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR)
+    {
+        return LoadFromWICFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, image, getMQR);
+    }
+
+    HRESULT __cdecl SaveToWICFile(
+        _In_ const Image& image,
+        _In_ WIC_FLAGS flags,
+        _In_ REFGUID guidContainerFormat,
+        _In_z_ const __wchar_t* szFile,
+        _In_opt_ const GUID* targetFormat,
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps)
+    {
+        return SaveToWICFile(image, flags, guidContainerFormat, reinterpret_cast<const unsigned short*>(szFile), targetFormat, setCustomProps);
+    }
+
+    HRESULT __cdecl SaveToWICFile(
+        _In_count_(nimages) const Image* images,
+        _In_ size_t nimages,
+        _In_ WIC_FLAGS flags,
+        _In_ REFGUID guidContainerFormat,
+        _In_z_ const __wchar_t* szFile,
+        _In_opt_ const GUID* targetFormat,
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps)
+    {
+        return SaveToWICFile(images, nimages, flags, guidContainerFormat, reinterpret_cast<const unsigned short*>(szFile), targetFormat, setCustomProps);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -525,7 +525,7 @@ namespace
         _In_ IWICBitmapFrameDecode *frame,
         _Out_ TexMetadata& metadata,
         _Out_opt_ WICPixelFormatGUID* pConvert,
-        _In_opt_ std::function<void(IWICMetadataQueryReader*)> getMQR)
+        _In_ std::function<void(IWICMetadataQueryReader*)> getMQR)
     {
         if (!decoder || !frame)
             return E_POINTER;
@@ -1079,7 +1079,7 @@ namespace
         _In_ REFGUID containerFormat,
         _Inout_ IStream* stream,
         _In_opt_ const GUID* targetFormat,
-        _In_opt_ std::function<void(IPropertyBag2*)> setCustomProps)
+        _In_ std::function<void(IPropertyBag2*)> setCustomProps)
     {
         if (!stream)
             return E_INVALIDARG;
@@ -1144,7 +1144,7 @@ namespace
         _In_ REFGUID containerFormat,
         _Inout_ IStream* stream,
         _In_opt_ const GUID* targetFormat,
-        _In_opt_ std::function<void(IPropertyBag2*)> setCustomProps)
+        _In_ std::function<void(IPropertyBag2*)> setCustomProps)
     {
         if (!stream || nimages < 2)
             return E_INVALIDARG;
@@ -1630,7 +1630,7 @@ namespace DirectX
         _In_z_ const __wchar_t* szFile,
         _In_ WIC_FLAGS flags,
         _Out_ TexMetadata& metadata,
-        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR)
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR)
     {
         return GetMetadataFromWICFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, getMQR);
     }
@@ -1640,7 +1640,7 @@ namespace DirectX
         _In_ WIC_FLAGS flags,
         _Out_opt_ TexMetadata* metadata,
         _Out_ ScratchImage& image,
-        _In_opt_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR)
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR)
     {
         return LoadFromWICFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, image, getMQR);
     }
@@ -1651,7 +1651,7 @@ namespace DirectX
         _In_ REFGUID guidContainerFormat,
         _In_z_ const __wchar_t* szFile,
         _In_opt_ const GUID* targetFormat,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps)
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps)
     {
         return SaveToWICFile(image, flags, guidContainerFormat, reinterpret_cast<const unsigned short*>(szFile), targetFormat, setCustomProps);
     }
@@ -1663,7 +1663,7 @@ namespace DirectX
         _In_ REFGUID guidContainerFormat,
         _In_z_ const __wchar_t* szFile,
         _In_opt_ const GUID* targetFormat,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps)
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps)
     {
         return SaveToWICFile(images, nimages, flags, guidContainerFormat, reinterpret_cast<const unsigned short*>(szFile), targetFormat, setCustomProps);
     }

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -178,3 +178,13 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out11 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Config'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -NO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Build'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out12 -v --config Debug

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -182,7 +182,7 @@ jobs:
     displayName: 'CMake (NO_WCHAR_T): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -NO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Build'
     inputs:

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -194,7 +194,7 @@ jobs:
     displayName: 'CMake (NO_WCHAR_T): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -NO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Build'
     inputs:

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -190,3 +190,13 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out11 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Config'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -NO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Build'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out12 -v --config Debug


### PR DESCRIPTION
Some usage scenarios build the library with ``/Zc:wchar_t-`` but mix both ``unsigned short*`` and ``wchar_t*`` client usage. For this *opt-in* build scenario, the library will link with both the non-native and native ``wchar_t``.

> Also fixes some Code Analysis warnings as you can't use ``_In_opt_`` with ``std::function<>``.