### PR TITLE
Suppress some additional clang v16 warnings when upgrading to clangcl

### DIFF
--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -71,6 +71,8 @@
 #pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
The CMake scenario already disables the new clang v16 warning, but if you upgrade the VCXPROJ project to clangcl, it reappears.