### PR TITLE
October 2023 release [Xbox variant]

### DIFF
--- a/.nuget/directxtex_desktop_2019.nuspec
+++ b/.nuget/directxtex_desktop_2019.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 and supports Windows 7 / DirectX 11.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the September 1, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the October 28, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxtex_desktop_win10.nuspec
+++ b/.nuget/directxtex_desktop_win10.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 and supports Windows 10 / Windows 11 including both DirectX 11 and DirectX 12.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the September 1, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the October 28, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxtex_uwp.nuspec
+++ b/.nuget/directxtex_uwp.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Universal Windows Platform apps on Windows 10 / Windows 11 using Visual Studio 2019 (16.11) or Visual Studio 2022.
 
 DirectXTex, a shared source library for reading and writing .DDS files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes simple .TGA and .HDR readers and writers since these image file format are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.</description>
-        <releaseNotes>Matches the September 1, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the October 28, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248926</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTex.git" />
         <icon>images\icon.jpg</icon>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@
 
 cmake_minimum_required (VERSION 3.20)
 
-set(DIRECTXTEX_VERSION 2.0.0)
+set(DIRECTXTEX_VERSION 2.0.1)
 
-if(DEFINED XBOX_CONSOLE_TARGET)
+if(WINDOWS_STORE OR (DEFINED XBOX_CONSOLE_TARGET))
   set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 endif()
 
@@ -482,6 +482,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
             list(APPEND WarningsLib "-Wno-reserved-identifier")
         endif()
     endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)
+        list(APPEND WarningsLib "-Wno-unsafe-buffer-usage")
+    endif()
+    target_compile_options(${PROJECT_NAME} PRIVATE ${WarningsLib})
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)
         list(APPEND WarningsLib "-Wno-unsafe-buffer-usage")

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -47,7 +47,7 @@ struct IWICImagingFactory;
 struct IWICMetadataQueryReader;
 #endif
 
-#define DIRECTX_TEX_VERSION 200
+#define DIRECTX_TEX_VERSION 201
 
 
 namespace DirectX
@@ -225,6 +225,9 @@ namespace DirectX
 
         DDS_FLAGS_BAD_DXTN_TAILS = 0x40,
         // Some older DXTn DDS files incorrectly handle mipchain tails for blocks smaller than 4x4
+
+        DDS_FLAGS_PERMISSIVE = 0x80,
+        // Allow some file variants due to common bugs in the header written by various leagcy DDS writers
 
         DDS_FLAGS_FORCE_DX10_EXT = 0x10000,
         // Always use the 'DX10' header extension for DDS writer (i.e. don't try to write DX9 compatible DDS files)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,15 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXT
 
 ## Release History
 
+### October 28, 2023
+* New ``DDS_PERMISSIVE_FLAG`` to allow reading of various DDS DX9 file variants
+  * *breaking change* required to accept reading *Unreal Tournament 2004* DDS files
+  * Allows cases where DDS_HEADER size is incorrectly set to 24
+  * Allows cases where DDPIXELFORMAT size is incorrectly set to 24
+  * Allows cases where DDS_HEADER.MipMapCount is set to the wrong value
+* texassemble/texconv/texdiag: -flist option updated to support filenames with spaces
+* texconv: -permissive switch added to opt-in use of new flag when reading DDS files
+
 ### September 1, 2023
 * ``CompressEx`` and ``ConvertEx`` functions added with status callback and options structs
 * Added optional ``DDSMetaData`` return for Ex versions of DDS loader functions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkId=248926
 
 Copyright (c) Microsoft Corporation.
 
-**September 1, 2023**
+**October 28, 2023**
 
 This package contains DirectXTex, a shared source library for reading and writing ``.DDS`` files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes ``.TGA`` and ``.HDR`` readers and writers since these image file formats are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.
 

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -491,10 +491,10 @@ namespace
         std::list<SConversion> flist;
         std::set<std::wstring> excludes;
 
-        auto fname = std::make_unique<wchar_t[]>(32768);
         for (;;)
         {
-            inFile >> fname.get();
+            std::wstring fname;
+            std::getline(inFile, fname);
             if (!inFile)
                 break;
 
@@ -506,13 +506,13 @@ namespace
             {
                 if (flist.empty())
                 {
-                    wprintf(L"WARNING: Ignoring the line '%ls' in -flist\n", fname.get());
+                    wprintf(L"WARNING: Ignoring the line '%ls' in -flist\n", fname.c_str());
                 }
                 else
                 {
-                    std::filesystem::path path(fname.get() + 1);
+                    std::filesystem::path path(fname.c_str() + 1);
                     auto& npath = path.make_preferred();
-                    if (wcspbrk(fname.get(), L"?*") != nullptr)
+                    if (wcspbrk(fname.c_str(), L"?*") != nullptr)
                     {
                         std::list<SConversion> removeFiles;
                         SearchForFiles(npath, removeFiles, false);
@@ -532,20 +532,18 @@ namespace
                     }
                 }
             }
-            else if (wcspbrk(fname.get(), L"?*") != nullptr)
+            else if (wcspbrk(fname.c_str(), L"?*") != nullptr)
             {
-                std::filesystem::path path(fname.get());
+                std::filesystem::path path(fname.c_str());
                 SearchForFiles(path.make_preferred(), flist, false);
             }
             else
             {
                 SConversion conv = {};
-                std::filesystem::path path(fname.get());
+                std::filesystem::path path(fname.c_str());
                 conv.szSrc = path.make_preferred().native();
                 flist.push_back(conv);
             }
-
-            inFile.ignore(1000, '\n');
         }
 
         inFile.close();

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -481,10 +481,10 @@ namespace
         std::list<SConversion> flist;
         std::set<std::wstring> excludes;
 
-        auto fname = std::make_unique<wchar_t[]>(32768);
         for (;;)
         {
-            inFile >> fname.get();
+            std::wstring fname;
+            std::getline(inFile, fname);
             if (!inFile)
                 break;
 
@@ -496,13 +496,13 @@ namespace
             {
                 if (flist.empty())
                 {
-                    wprintf(L"WARNING: Ignoring the line '%ls' in -flist\n", fname.get());
+                    wprintf(L"WARNING: Ignoring the line '%ls' in -flist\n", fname.c_str());
                 }
                 else
                 {
-                    std::filesystem::path path(fname.get() + 1);
+                    std::filesystem::path path(fname.c_str() + 1);
                     auto& npath = path.make_preferred();
-                    if (wcspbrk(fname.get(), L"?*") != nullptr)
+                    if (wcspbrk(fname.c_str(), L"?*") != nullptr)
                     {
                         std::list<SConversion> removeFiles;
                         SearchForFiles(npath, removeFiles, false);
@@ -522,20 +522,18 @@ namespace
                     }
                 }
             }
-            else if (wcspbrk(fname.get(), L"?*") != nullptr)
+            else if (wcspbrk(fname.c_str(), L"?*") != nullptr)
             {
-                std::filesystem::path path(fname.get());
+                std::filesystem::path path(fname.c_str());
                 SearchForFiles(path.make_preferred(), flist, false);
             }
             else
             {
                 SConversion conv = {};
-                std::filesystem::path path(fname.get());
+                std::filesystem::path path(fname.c_str());
                 conv.szSrc = path.make_preferred().native();
                 flist.push_back(conv);
             }
-
-            inFile.ignore(1000, '\n');
         }
 
         inFile.close();

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -51,8 +51,6 @@ variables:
   WIN11_SDK: '10.0.22000.0'
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
-  URL_MINGW64: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
-  HASH_MINGW64: '6694e552d73195b57f283645ab78cb0180f4d957b5501a83e6b4f2679dfad13a8e85e1df6f7b061ea4431fbd2bb0c8f2ac3a1dd810489c1a8d1665b226df8092'
 
 jobs:
 - job: MINGW32_BUILD
@@ -77,8 +75,7 @@ jobs:
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: PowerShell@2
-    # We install GCC 12.2 as the MS Hosted only offers 11.2
-    displayName: Install MinGW32
+    displayName: Install MinGW32 and setup for Windows 11 SDK
     inputs:
       targetType: inline
       script: |
@@ -173,25 +170,11 @@ jobs:
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: PowerShell@2
-    displayName: Install MinGW-W64
+    displayName: Setup for Shader Compilation
     inputs:
       targetType: inline
       script: |
         $ProgressPreference = 'SilentlyContinue'
-        Write-Host "Downloading winlibs..."
-        Invoke-WebRequest -Uri "$(URL_MINGW64)" -OutFile "gw64.zip"
-        Write-Host "Downloaded."
-        $fileHash = Get-FileHash -Algorithm SHA512 gw64.zip | ForEach { $_.Hash} | Out-String
-        $filehash = $fileHash.Trim()
-        Write-Host "##[debug]SHA512: " $fileHash
-        if ($fileHash -ne '$(HASH_MINGW64)') {
-            Write-Error -Message "##[error]Computed hash does not match!" -ErrorAction Stop
-        }
-        Write-Host "Extracting winlibs..."
-        Expand-Archive -LiteralPath 'gw64.zip'
-        Write-Host "Extracted."
-        Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw64\mingw64\bin"
-        Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw64\mingw64\bin"
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
         $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
         $windows11x64sdk = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
@@ -203,7 +186,6 @@ jobs:
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
         }
 
-      workingDirectory: $(Build.SourcesDirectory)
   - task: BatchScript@1
     displayName: CompileShaders.cmd
     inputs:

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -162,6 +162,11 @@ jobs:
       script: git clone --quiet https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
+  - task: ChocolateyCommand@0
+    displayName: Install Ninja
+    inputs:
+      command: 'install'
+      installPackageId: 'ninja'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:


### PR DESCRIPTION
* New ``DDS_PERMISSIVE_FLAG`` to allow reading of various DDS DX9 file variants
  * *breaking change* required to accept reading *Unreal Tournament 2004* DDS files
  * Allows cases where DDS_HEADER size is incorrectly set to 24
  * Allows cases where DDPIXELFORMAT size is incorrectly set to 24
  * Allows cases where DDS_HEADER.MipMapCount is set to the wrong value
* texassemble/texconv/texdiag: -flist option updated to support filenames with spaces
* texconv: -permissive switch added to opt-in use of new flag when reading DDS files