### PR TITLE
PPM TGA HDR bounds updates on readers

### DIFF
--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -247,6 +247,11 @@ namespace
             return E_FAIL;
         }
 
+        if (height > UINT16_MAX)
+        {
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
         const char* ptr = orientation + 2;
         while (*ptr != 0 && *ptr != '-' && *ptr != '+')
             ++ptr;
@@ -279,12 +284,23 @@ namespace
             return E_FAIL;
         }
 
+        if (width > UINT16_MAX)
+        {
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
         info += len + 1;
         size -= len + 1;
 
         if (!width || !height)
         {
             return HRESULT_E_INVALID_DATA;
+        }
+
+        uint64_t sizeBytes = uint64_t(width) * uint64_t(height) * sizeof(float) * 4;
+        if (sizeBytes > UINT32_MAX)
+        {
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
         }
 
         if (size == 0)

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -133,6 +133,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cstdlib>
 #include <ctime>
 #include <cstring>

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -280,6 +280,12 @@ namespace
             return HRESULT_E_INVALID_DATA;
         }
 
+        uint64_t sizeBytes = uint64_t(pHeader->wWidth) * uint64_t(pHeader->wHeight) * uint64_t(pHeader->bBitsPerPixel) / 8;
+        if (sizeBytes > UINT32_MAX)
+        {
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
+        }
+
         metadata.width = pHeader->wWidth;
         metadata.height = pHeader->wHeight;
         metadata.depth = metadata.arraySize = metadata.mipLevels = 1;

--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -280,7 +280,7 @@ HRESULT __cdecl LoadFromPortablePixMap(
                         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
                     }
 
-                    uint64_t sizeBytes = uint64_t(width) * uint64_t(u);
+                    uint64_t sizeBytes = uint64_t(width) * uint64_t(u) * 4;
                     if (sizeBytes > UINT32_MAX)
                     {
                         HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
@@ -460,12 +460,13 @@ HRESULT __cdecl LoadFromPortablePixMapHDR(
     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
     bool monochrome = false;
     bool half16 = false;
+    unsigned int bpp = 0;
     switch (pfmData[1])
     {
-    case 'f': format = DXGI_FORMAT_R32_FLOAT; monochrome = true; break;
-    case 'F': format = DXGI_FORMAT_R32G32B32A32_FLOAT; break;
-    case 'h': format = DXGI_FORMAT_R16_FLOAT; monochrome = true; half16 = true; break;
-    case 'H': format = DXGI_FORMAT_R16G16B16A16_FLOAT; half16 = true; break;
+    case 'f': format = DXGI_FORMAT_R32_FLOAT; monochrome = true; bpp = 4u; break;
+    case 'F': format = DXGI_FORMAT_R32G32B32A32_FLOAT; bpp = 16u; break;
+    case 'h': format = DXGI_FORMAT_R16_FLOAT; monochrome = true; half16 = true; bpp = 2u; break;
+    case 'H': format = DXGI_FORMAT_R16G16B16A16_FLOAT; half16 = true; bpp = 8u; break;
     default:
         return E_FAIL;
     }
@@ -509,7 +510,7 @@ HRESULT __cdecl LoadFromPortablePixMapHDR(
         return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    uint64_t sizeBytes = uint64_t(width) * uint64_t(height);
+    uint64_t sizeBytes = uint64_t(width) * uint64_t(height) * bpp;
     if (sizeBytes > UINT32_MAX)
     {
         HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);

--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -157,7 +157,7 @@ HRESULT __cdecl LoadFromPortablePixMap(
     if (ppmSize < 3)
         return E_FAIL;
 
-    if (ppmData[0] != 'P' || (ppmData[1] != '3' && ppmData[1] != '6'))
+    if (ppmData[0] != 'P' || (ppmData[1] != '3' && ppmData[1] != '6') || !isspace(ppmData[2]))
         return E_FAIL;
 
     const bool ascii = ppmData[1] == '3';
@@ -283,7 +283,7 @@ HRESULT __cdecl LoadFromPortablePixMap(
                     uint64_t sizeBytes = uint64_t(width) * uint64_t(u) * 4;
                     if (sizeBytes > UINT32_MAX)
                     {
-                        HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
+                        return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
                     }
 
                     if (metadata)
@@ -454,7 +454,7 @@ HRESULT __cdecl LoadFromPortablePixMapHDR(
     if (pfmSize < 3)
         return E_FAIL;
 
-    if (pfmData[0] != 'P' || pfmData[2] != '\n')
+    if (pfmData[0] != 'P' || !isspace(pfmData[2]))
         return E_FAIL;
 
     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
@@ -513,7 +513,7 @@ HRESULT __cdecl LoadFromPortablePixMapHDR(
     uint64_t sizeBytes = uint64_t(width) * uint64_t(height) * bpp;
     if (sizeBytes > UINT32_MAX)
     {
-        HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
+        return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
     }
 
     pData += len + 1;

--- a/build/OneFuzzConfig.json
+++ b/build/OneFuzzConfig.json
@@ -15,7 +15,10 @@
           "TargetName": "DirectXTex",
           "TargetOptions": [
              " -rss_limit_mb=4096"
-          ]
+          ],
+          "TargetEnv": {
+            "ASAN_OPTIONS": "allocator_may_return_null=1"
+          }
         }
       ],
       "JobDependencies": [

--- a/build/onefuzz-setup.ps1
+++ b/build/onefuzz-setup.ps1
@@ -7,23 +7,6 @@ function Execute-Setup {
     # Exclude any uploaded DLL from known DLLs
     gci -filter '*.dll' | Exclude-Library
 
-    # Update environment values for ASAN_OPTIONS.
-    # These environment variables affect how the ASan runtime operates. 
-    # Use the 'allocator_may_return_null=1' environment variable if you have compiled
-    # your fuzzer using clang with the ASan flags
-    #
-    # Use 'windows_hook_rtl_allocators=true:allocator_may_return_null=1' if your fuzzer has
-    # been compiled using MSVC with the ASan flags
-    # 
-    # $AsanOptions = 'windows_hook_rtl_allocators=true:allocator_may_return_null=1'
-    # $AsanOptions = 'allocator_may_return_null=1'
-
-    $AsanOptions = 'allocator_may_return_null=1'
-
-    # Use the 'machine' scope to make this permanent because the machine will reboot  
-    [Environment]::SetEnvironmentVariable('ASAN_OPTIONS', $AsanOptions, 'Machine')
-    Write-Log "Set ASAN_OPTIONS to $AsanOptions"
-
     # Done. Useful to know that the script did not prematurely error out
     Write-Log 'Setup script finished successfully'
 }

--- a/build/onefuzz-setup.ps1
+++ b/build/onefuzz-setup.ps1
@@ -18,7 +18,7 @@ function Execute-Setup {
     # $AsanOptions = 'windows_hook_rtl_allocators=true:allocator_may_return_null=1'
     # $AsanOptions = 'allocator_may_return_null=1'
 
-    $AsanOptions = 'windows_hook_rtl_allocators=true:allocator_may_return_null=1'
+    $AsanOptions = 'allocator_may_return_null=1'
 
     # Use the 'machine' scope to make this permanent because the machine will reboot  
     [Environment]::SetEnvironmentVariable('ASAN_OPTIONS', $AsanOptions, 'Machine')


### PR DESCRIPTION
In #413 I missed the bytes-per-pixel value in checking for 32-bit overflow for PPM image memory. I also had a typo so it was failing to actually return in this case too.

Also added explicit bounds checks for TGA and HDR readers. DDS reader already has bounds in place based on hardware limitations unless `DDS_FLAGS_ALLOW_LARGE_FILES` is used.

> Also fixed ASAN_OPTIONS problem.
