### PR TITLE
Code review to silence some portability warnings

### DIFF
--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -61,6 +61,12 @@ namespace DirectX
         HDRColorA() = default;
         HDRColorA(float _r, float _g, float _b, float _a) noexcept : r(_r), g(_g), b(_b), a(_a) {}
 
+        HDRColorA(HDRColorA const&) = default;
+        HDRColorA& operator= (const HDRColorA&) = default;
+
+        HDRColorA(HDRColorA&&) = default;
+        HDRColorA& operator= (HDRColorA&&) = default;
+
         // binary operators
         HDRColorA operator + (const HDRColorA& c) const noexcept
         {

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -339,6 +339,12 @@ namespace DirectX
         LDRColorA() = default;
         LDRColorA(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) noexcept : r(_r), g(_g), b(_b), a(_a) {}
 
+        LDRColorA(LDRColorA const&) = default;
+        LDRColorA& operator= (const LDRColorA&) = default;
+
+        LDRColorA(LDRColorA&&) = default;
+        LDRColorA& operator= (LDRColorA&&) = default;
+
         const uint8_t& operator [] (_In_range_(0, 3) size_t uElement) const noexcept
         {
             switch (uElement)
@@ -449,9 +455,14 @@ namespace
         int r, g, b;
         int pad;
 
-    public:
         INTColor() = default;
         INTColor(int nr, int ng, int nb) noexcept : r(nr), g(ng), b(nb), pad(0) {}
+
+        INTColor(INTColor const&) = default;
+        INTColor& operator= (const INTColor&) = default;
+
+        INTColor(INTColor&&) = default;
+        INTColor& operator= (INTColor&&) = default;
 
         INTColor& operator += (_In_ const INTColor& c) noexcept
         {

--- a/DirectXTex/BCDirectCompute.h
+++ b/DirectXTex/BCDirectCompute.h
@@ -17,6 +17,12 @@ namespace DirectX
     public:
         GPUCompressBC() noexcept;
 
+        GPUCompressBC(GPUCompressBC&&) = default;
+        GPUCompressBC& operator= (GPUCompressBC&&) = default;
+
+        GPUCompressBC(GPUCompressBC const&) = delete;
+        GPUCompressBC& operator= (GPUCompressBC const&) = delete;
+
         HRESULT Initialize(_In_ ID3D11Device* pDevice);
 
         HRESULT Prepare(size_t width, size_t height, uint32_t flags, DXGI_FORMAT format, float alphaWeight);


### PR DESCRIPTION
warning C5267 definition of implicit assignment operator for '{class}' is deprecated because it has a user-provided copy constructor 