### PR TITLE
Fix warnings in tools for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,15 +371,8 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DirectXTex.pc"
 
 #--- Command-line tools
 set(TOOL_EXES "")
-if(BUILD_TOOLS AND WIN32)
-  add_executable(texdiag
-    Texdiag/texdiag.cpp
-    Texdiag/texdiag.rc
-    Texdiag/settings.manifest)
-  target_link_libraries(texdiag PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
-  source_group(texdiag REGULAR_EXPRESSION Texdiag/*.*)
-  list(APPEND TOOL_EXES texdiag)
 
+if(BUILD_TOOLS AND WIN32)
   add_executable(texassemble
     Texassemble/texassemble.cpp
     Texassemble/texassemble.rc
@@ -404,7 +397,19 @@ if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
   if(BC_USE_OPENMP)
     target_link_libraries(texconv PRIVATE OpenMP::OpenMP_CXX)
   endif()
+endif()
 
+if(BUILD_TOOLS AND WIN32)
+  add_executable(texdiag
+    Texdiag/texdiag.cpp
+    Texdiag/texdiag.rc
+    Texdiag/settings.manifest)
+  target_link_libraries(texdiag PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
+  source_group(texdiag REGULAR_EXPRESSION Texdiag/*.*)
+  list(APPEND TOOL_EXES texdiag)
+endif()
+
+if(BUILD_TOOLS AND WIN32)
   if(ENABLE_OPENEXR_SUPPORT)
     foreach(t IN LISTS TOOL_EXES)
       target_include_directories(${t} PRIVATE Auxiliary)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,8 +370,15 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DirectXTex.pc"
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 #--- Command-line tools
-if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
-  set(TOOL_EXES texassemble texconv texdiag)
+set(TOOL_EXES "")
+if(BUILD_TOOLS AND WIN32)
+  add_executable(texdiag
+    Texdiag/texdiag.cpp
+    Texdiag/texdiag.rc
+    Texdiag/settings.manifest)
+  target_link_libraries(texdiag PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
+  source_group(texdiag REGULAR_EXPRESSION Texdiag/*.*)
+  list(APPEND TOOL_EXES texdiag)
 
   add_executable(texassemble
     Texassemble/texassemble.cpp
@@ -380,7 +387,10 @@ if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
     Texassemble/AnimatedGif.cpp)
   target_link_libraries(texassemble PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
   source_group(texassemble REGULAR_EXPRESSION Texassemble/*.*)
+  list(APPEND TOOL_EXES texassemble)
+endif()
 
+if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
   add_executable(texconv
     Texconv/texconv.cpp
     Texconv/texconv.rc
@@ -389,13 +399,7 @@ if(BUILD_TOOLS AND BUILD_DX11 AND WIN32)
     Texconv/PortablePixMap.cpp)
   target_link_libraries(texconv PRIVATE ${PROJECT_NAME} ole32.lib shell32.lib version.lib)
   source_group(texconv REGULAR_EXPRESSION Texconv/*.*)
-
-  add_executable(texdiag
-    Texdiag/texdiag.cpp
-    Texdiag/texdiag.rc
-    Texdiag/settings.manifest)
-  target_link_libraries(texdiag PRIVATE ${PROJECT_NAME} ole32.lib version.lib)
-  source_group(texdiag REGULAR_EXPRESSION Texdiag/*.*)
+  list(APPEND TOOL_EXES texconv)
 
   if(BC_USE_OPENMP)
     target_link_libraries(texconv PRIVATE OpenMP::OpenMP_CXX)

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -1011,12 +1011,16 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wswitch-enum"
 #endif
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4619 4616 4061)
+#endif
 
 #include "DirectXTex.inl"
 
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Texassemble/AnimatedGif.cpp
+++ b/Texassemble/AnimatedGif.cpp
@@ -13,8 +13,10 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -22,7 +24,9 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <cstddef>
 #include <iterator>
@@ -35,7 +39,9 @@
 
 #include <wincodec.h>
 
+#ifdef  _MSC_VER
 #pragma warning(disable : 4619 4616 26812)
+#endif
 
 #include "DirectXTex.h"
 

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -9,8 +9,10 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -18,7 +20,9 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #if __cplusplus < 201703L
 #error Requires C++17 (and /Zc:__cplusplus with MSVC)
@@ -52,7 +56,9 @@
 #include <DirectXPackedVector.h>
 #include <wincodec.h>
 
+#ifdef  _MSC_VER
 #pragma warning(disable : 4619 4616 26812)
+#endif
 
 #include "DirectXTex.h"
 

--- a/Texconv/ExtendedBMP.cpp
+++ b/Texconv/ExtendedBMP.cpp
@@ -12,15 +12,19 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <Windows.h>
 

--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -9,15 +9,19 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <Windows.h>
 

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -9,15 +9,19 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <ShlObj.h>
 
@@ -52,7 +56,9 @@
 
 #include <wincodec.h>
 
+#ifdef  _MSC_VER
 #pragma warning(disable : 4619 4616 26812)
+#endif
 
 #include "DirectXTex.h"
 
@@ -525,7 +531,9 @@ HRESULT __cdecl SaveToPortablePixMapHDR(
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+#ifdef  _MSC_VER
 #pragma warning( disable : 4616 6211 )
+#endif
 
 namespace
 {

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -9,8 +9,10 @@
 // http://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
+#ifdef  _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -18,7 +20,9 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef  _MSC_VER
 #pragma warning(pop)
+#endif
 
 #if __cplusplus < 201703L
 #error Requires C++17 (and /Zc:__cplusplus with MSVC)
@@ -46,7 +50,9 @@
 
 #include <dxgiformat.h>
 
+#ifdef  _MSC_VER
 #pragma warning(disable : 4619 4616 26812)
+#endif
 
 #include "DirectXTex.h"
 


### PR DESCRIPTION
Also allows texassemble and texdiag to be built without requiring DX11 support.