### PR TITLE
OneFuzz ADO pipeline adjustments

### DIFF
--- a/build/DirectXTex-OneFuzz.yml
+++ b/build/DirectXTex-OneFuzz.yml
@@ -6,8 +6,8 @@
 # Builds the library using CMake and submit for file fuzzing
 
 schedules:
-- cron: "0 12 * * 0"
-  displayName: 'Submit for File Fuzzing'
+- cron: "0 12 1 * *"
+  displayName: 'Submit for File Fuzzing (Monthly)'
   branches:
     include:
     - main
@@ -69,7 +69,7 @@ jobs:
     inputs:
       Contents: |
         build\OneFuzzConfig.json
-        out\bin\CMake\RelWithDebInfo\fuzzloaders.exe
+        out\bin\RelWithDebInfo\fuzzloaders.exe
       TargetFolder: .drop
       OverWrite: true
       flattenFolders: true
@@ -77,7 +77,7 @@ jobs:
     displayName: Copy symbols
     inputs:
       Contents: |
-        out\bin\CMake\RelWithDebInfo\fuzzloaders.pdb
+        out\bin\RelWithDebInfo\fuzzloaders.pdb
       TargetFolder: .drop\symbols
       OverWrite: true
       flattenFolders: true


### PR DESCRIPTION
In #438 the output directory of CMake was updated, so the OneFuzz pipeline need adjustment to match.