### PR TITLE
Update ADO pipeline exclusion paths

### DIFF
--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -50,6 +50,8 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
+  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
+  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
@@ -204,3 +206,83 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out12 -v --config Debug
+
+- job: CMAKE_BUILD_VCPKG
+  displayName: CMake using VCPKG
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+  - task: CmdLine@2
+    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
+    displayName: Fetch VCPKG
+    inputs:
+      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: VCPKG Bootstrap
+    inputs:
+      script: call bootstrap-vcpkg.bat
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+  - task: CmdLine@2
+    displayName: VCPKG install headers
+    inputs:
+      script: |
+        call vcpkg install directxmath
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install directx-headers
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install openexr
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libpng
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libjpeg-turbo
+        @if ERRORLEVEL 1 goto error
+        :finish
+        @echo --- VCPKG COMPLETE ---
+        exit /b 0
+        :error
+        @echo --- ERROR: VCPKG FAILED ---
+        exit /b 1
+
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64 w/ OpenEXR'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug w/ OpenEXR'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v --config Debug
+   - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug w/ libjpeg'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v --config Debug
+     displayName: 'CMake (MSVC): Config x64 w/ libpng'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug w/ libpng'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v --config Debug

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -267,7 +267,7 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v --config Debug
-   - task: CMake@1
+  - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
@@ -277,7 +277,8 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out3 -v --config Debug
-     displayName: 'CMake (MSVC): Config x64 w/ libpng'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64 w/ libpng'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -17,20 +17,28 @@ trigger:
     include:
     - main
   paths:
-    include:
-    - CMakeLists.txt
-    - build/CompilerAndLinker.cmake
-    - build/JoinPaths.cmake
+    exclude:
+    - '*.md'
+    - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
 
 pr:
   branches:
     include:
     - main
   paths:
-    include:
-    - CMakeLists.txt
-    - build/CompilerAndLinker.cmake
-    - build/JoinPaths.cmake
+    exclude:
+    - '*.md'
+    - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-CMake-Xbox.yml
+++ b/build/DirectXTex-GitHub-CMake-Xbox.yml
@@ -17,15 +17,28 @@ trigger:
     include:
     - main
   paths:
-    include:
-    - CMakeLists.txt
+    exclude:
+    - '*.md'
+    - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+
 pr:
   branches:
     include:
     - main
   paths:
-    include:
-    - CMakeLists.txt
+    exclude:
+    - '*.md'
+    - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -267,7 +267,7 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v --config Debug
-   - task: CMake@1
+  - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
@@ -277,7 +277,8 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out3 -v --config Debug
-     displayName: 'CMake (MSVC): Config x64 w/ libpng'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64 w/ libpng'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -50,6 +50,8 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
+  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
+  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   VS_GENERATOR: 'Visual Studio 16 2019'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
@@ -204,3 +206,83 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out12 -v --config Debug
+
+- job: CMAKE_BUILD_VCPKG
+  displayName: CMake using VCPKG
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+  - task: CmdLine@2
+    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
+    displayName: Fetch VCPKG
+    inputs:
+      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: VCPKG Bootstrap
+    inputs:
+      script: call bootstrap-vcpkg.bat
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+  - task: CmdLine@2
+    displayName: VCPKG install headers
+    inputs:
+      script: |
+        call vcpkg install directxmath
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install directx-headers
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install openexr
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libpng
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libjpeg-turbo
+        @if ERRORLEVEL 1 goto error
+        :finish
+        @echo --- VCPKG COMPLETE ---
+        exit /b 0
+        :error
+        @echo --- ERROR: VCPKG FAILED ---
+        exit /b 1
+
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64 w/ OpenEXR'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug w/ OpenEXR'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v --config Debug
+   - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug w/ libjpeg'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v --config Debug
+     displayName: 'CMake (MSVC): Config x64 w/ libpng'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug w/ libpng'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v --config Debug

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -17,20 +17,28 @@ trigger:
     include:
     - main
   paths:
-    include:
-    - CMakeLists.txt
-    - build/CompilerAndLinker.cmake
-    - build/JoinPaths.cmake
+    exclude:
+    - '*.md'
+    - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
 
 pr:
   branches:
     include:
     - main
   paths:
-    include:
-    - CMakeLists.txt
-    - build/CompilerAndLinker.cmake
-    - build/JoinPaths.cmake
+    exclude:
+    - '*.md'
+    - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-GDK.yml
+++ b/build/DirectXTex-GitHub-GDK.yml
@@ -20,20 +20,29 @@ trigger:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - CMake*
+    - '.nuget/*'
+    - build/*.cmake
+    - build/*.in
+    - build/*.json
+    - build/*.ps1
+
 pr:
   branches:
     include:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - CMake*
+    - '.nuget/*'
+    - build/*.cmake
+    - build/*.in
+    - build/*.json
+    - build/*.ps1
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -18,20 +18,27 @@ trigger:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+
 pr:
   branches:
     include:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -129,15 +129,15 @@ jobs:
     displayName: VCPKG install headers
     inputs:
       script: |
-        call vcpkg install directxmath
+        call .\vcpkg install directxmath
         @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
+        call .\vcpkg install directx-headers
         @if ERRORLEVEL 1 goto error
-        call vcpkg install openexr
+        call .\vcpkg install openexr
         @if ERRORLEVEL 1 goto error
-        call vcpkg install libpng
+        call .\vcpkg install libpng
         @if ERRORLEVEL 1 goto error
-        call vcpkg install libjpeg-turbo
+        call .\vcpkg install libjpeg-turbo
         @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
@@ -247,15 +247,15 @@ jobs:
     displayName: VCPKG install headers
     inputs:
       script: |
-        call vcpkg install directxmath
+        call .\vcpkg install directxmath
         @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
+        call .\vcpkg install directx-headers
         @if ERRORLEVEL 1 goto error
-        call vcpkg install openexr
+        call .\vcpkg install openexr
         @if ERRORLEVEL 1 goto error
-        call vcpkg install libpng
+        call .\vcpkg install libpng
         @if ERRORLEVEL 1 goto error
-        call vcpkg install libjpeg-turbo
+        call .\vcpkg install libjpeg-turbo
         @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
@@ -279,7 +279,7 @@ jobs:
     displayName: CMake (MinGW-W64) w/ OpenEXR
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build  w/ OpenEXR
     inputs:
@@ -289,7 +289,7 @@ jobs:
     displayName: CMake (MinGW-W64) w/ libjpeg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libjpeg
     inputs:
@@ -299,7 +299,7 @@ jobs:
     displayName: CMake (MinGW-W64) w/ libpng
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libpng
     inputs:

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -133,6 +133,12 @@ jobs:
         @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
         @if ERRORLEVEL 1 goto error
+        call vcpkg install openexr
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libpng
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libjpeg-turbo
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -151,6 +157,36 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out
+  - task: CMake@1
+    displayName: CMake (MinGW32) w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+  - task: CMake@1
+    displayName: CMake (MinGW32) Build  w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2
+  - task: CMake@1
+    displayName: CMake (MinGW32) w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+  - task: CMake@1
+    displayName: CMake (MinGW32) Build w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3
+  - task: CMake@1
+    displayName: CMake (MinGW32) w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+  - task: CMake@1
+    displayName: CMake (MinGW32) Build w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4
 
 - job: MINGW64_BUILD
   displayName: 'Minimalist GNU for Windows (MinGW-W64) BUILD_TESTING=ON'
@@ -215,6 +251,12 @@ jobs:
         @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
         @if ERRORLEVEL 1 goto error
+        call vcpkg install openexr
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libpng
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install libjpeg-turbo
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -233,3 +275,33 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) Build  w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) Build w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\DirectXTex\Shaders\Compiled -DCOMPILED_DDSVIEW_SHADERS=$(Build.SourcesDirectory)\DDSView\Shaders
+  - task: CMake@1
+    displayName: CMake (MinGW-W64) Build w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -18,20 +18,34 @@ trigger:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - CMake*
+    - '.nuget/*'
+    - build/*.cmake
+    - build/*.in
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+    - Auxiliary/*
 pr:
   branches:
     include:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - CMake*
+    - '.nuget/*'
+    - build/*.cmake
+    - build/*.in
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+    - Auxiliary/*
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -29,7 +29,6 @@ pool:
 variables:
   VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
-  DEST_DIR: $(DESTDIR)
 
 jobs:
 - job: BUILD_WSL
@@ -40,6 +39,10 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
+  - task: CmdLine@2
+    displayName: Fetch directx-headers
+    inputs:
+      script: export DESTDIR=$(Agent.BuildDirectory)/install/
   - task: CmdLine@2
     displayName: Fetch directx-headers
     inputs:
@@ -84,8 +87,8 @@ jobs:
       targetType: inline
       script: |
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(DEST_DIR)usr/local/include/sal.h
-        $fileHash = Get-FileHash -Algorithm SHA512 $(DEST_DIR)usr/local/include/sal.h | ForEach { $_.Hash} | Out-String
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(DESTDIR)usr/local/include/sal.h
+        $fileHash = Get-FileHash -Algorithm SHA512 $(DESTDIR)usr/local/include/sal.h | ForEach { $_.Hash} | Out-String
         $filehash = $fileHash.Trim()
         Write-Host "##[debug]SHA512: " $filehash
         if ($fileHash -ne "1643571673195d9eb892d2f2ac76eac7113ef7aa0ca116d79f3e4d3dc9df8a31600a9668b7e7678dfbe5a76906f9e0734ef8d6db0903ccc68fc742dd8238d8b0") {
@@ -96,7 +99,7 @@ jobs:
     displayName: CMake DirectXTex (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
@@ -106,7 +109,7 @@ jobs:
     displayName: CMake DirectXTex (Config) rel
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -139,12 +139,10 @@ jobs:
         g++ --version
         cmake --version
 
-  - task: Bash@3
+  - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
-      targetType: filePath
-      filePath: $(Build.SourcesDirectory)/vcpkg/vcpkg
-      arguments: install directxmath directx-headers openexr libpng zlib libjpeg-turbo
+      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -27,6 +27,7 @@ pool:
     vmImage: ubuntu-22.04
 
 variables:
+  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   DEST_DIR: $(DESTDIR)
 
@@ -111,3 +112,87 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v
+
+- job: BUILD_WSL_VCPKG
+  displayName: 'Windows Subsystem for Linux (WSL) using VCPKG'
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+  - task: CmdLine@2
+    displayName: Fetch VCPKG
+    inputs:
+      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      workingDirectory: $(Build.SourcesDirectory)
+  - task: Bash@3
+    displayName: VCPKG Bootstrap
+    inputs:
+      targetType: filePath
+      filePath: $(Build.SourcesDirectory)/vcpkg/bootstrap-vcpkg.sh
+      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+  - task: CmdLine@2
+    displayName: GCC and CMake version
+    inputs:
+      script: |
+        g++ --version
+        cmake --version
+
+  - task: Bash@3
+    displayName: VCPKG install headers
+    inputs:
+      targetType: filePath
+      filePath: $(Build.SourcesDirectory)/vcpkg/vcpkg
+      arguments: install directxmath directx-headers openexr libpng zlib libjpeg-turbo
+      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) dbg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) dbg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENEXR_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBJPEG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out5 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBPNG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out5 -v

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -29,6 +29,7 @@ pool:
 variables:
   VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
 - job: BUILD_WSL
@@ -42,16 +43,12 @@ jobs:
   - task: CmdLine@2
     displayName: Fetch directx-headers
     inputs:
-      script: export DESTDIR=$(Agent.BuildDirectory)/install/
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
       cwd: directx-headers
-      cmakeArgs: . -DDXHEADERS_BUILD_TEST=OFF -DDXHEADERS_BUILD_GOOGLE_TEST=OFF
+      cmakeArgs: . -DDXHEADERS_BUILD_TEST=OFF -DDXHEADERS_BUILD_GOOGLE_TEST=OFF -DCMAKE_INSTALL_PREFIX=$(LOCAL_PKG_DIR)
   - task: CMake@1
     displayName: CMake DirectX-Headers (Build)
     inputs:
@@ -70,7 +67,7 @@ jobs:
     displayName: CMake DirectXMath
     inputs:
       cwd: directxmath
-      cmakeArgs: .
+      cmakeArgs: . -DCMAKE_INSTALL_PREFIX=$(LOCAL_PKG_DIR)
   - task: CMake@1
     displayName: CMake DirectXMath (Build)
     inputs:
@@ -87,8 +84,8 @@ jobs:
       targetType: inline
       script: |
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(DESTDIR)usr/local/include/sal.h
-        $fileHash = Get-FileHash -Algorithm SHA512 $(DESTDIR)usr/local/include/sal.h | ForEach { $_.Hash} | Out-String
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(LOCAL_PKG_DIR)/include/sal.h
+        $fileHash = Get-FileHash -Algorithm SHA512 $(LOCAL_PKG_DIR)/include/sal.h | ForEach { $_.Hash} | Out-String
         $filehash = $fileHash.Trim()
         Write-Host "##[debug]SHA512: " $filehash
         if ($fileHash -ne "1643571673195d9eb892d2f2ac76eac7113ef7aa0ca116d79f3e4d3dc9df8a31600a9668b7e7678dfbe5a76906f9e0734ef8d6db0903ccc68fc742dd8238d8b0") {
@@ -99,7 +96,7 @@ jobs:
     displayName: CMake DirectXTex (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
@@ -109,7 +106,7 @@ jobs:
     displayName: CMake DirectXTex (Config) rel
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -18,20 +18,27 @@ trigger:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
-pr:
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+
+  pr:
   branches:
     include:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - '.nuget/*'
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
   drafts: false
 
 resources:

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -53,6 +53,7 @@ pool:
     vmImage: ubuntu-20.04
 
 variables:
+  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   DEST_DIR: $(DESTDIR)
 
@@ -137,3 +138,84 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v
+
+- job: BUILD_WSL_VCPKG
+  displayName: 'Windows Subsystem for Linux (WSL) using VCPKG'
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+  - task: CmdLine@2
+    displayName: Fetch VCPKG
+    inputs:
+      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      workingDirectory: $(Build.SourcesDirectory)
+  - task: Bash@3
+    displayName: VCPKG Bootstrap
+    inputs:
+      targetType: filePath
+      filePath: ./bootstrap-vcpkg.sh
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+  - task: CmdLine@2
+    displayName: VCPKG install headers
+    inputs:
+      script: |
+        .\vcpkg install directxmath
+        .\vcpkg install directx-headers
+        .\vcpkg install openexr
+        .\vcpkg install libpng
+        .\vcpkg install libjpeg-turbo
+
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) dbg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) dbg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENEXR_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) w/ OpenEXR
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBJPEG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) w/ libjpeg
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v
+  - task: CMake@1
+    displayName: CMake DirectXTex (Config) w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out5 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBPNG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+  - task: CMake@1
+    displayName: CMake DirectXTex (Build) w/ libpng
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out5 -v

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -168,7 +168,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo
+      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo --debug
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -55,7 +55,6 @@ pool:
 variables:
   VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
-  DEST_DIR: $(DESTDIR)
 
 jobs:
 - job: BUILD_WSL
@@ -66,6 +65,10 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
+  - task: CmdLine@2
+    displayName: Fetch directx-headers
+    inputs:
+      script: export DESTDIR=$(Agent.BuildDirectory)/install/
   - task: CmdLine@2
     displayName: Fetch directx-headers
     inputs:
@@ -110,8 +113,8 @@ jobs:
       targetType: inline
       script: |
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(DEST_DIR)usr/local/include/sal.h
-        $fileHash = Get-FileHash -Algorithm SHA512 $(DEST_DIR)usr/local/include/sal.h | ForEach { $_.Hash} | Out-String
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(DESTDIR)usr/local/include/sal.h
+        $fileHash = Get-FileHash -Algorithm SHA512 $(DESTDIR)usr/local/include/sal.h | ForEach { $_.Hash} | Out-String
         $filehash = $fileHash.Trim()
         Write-Host "##[debug]SHA512: " $filehash
         if ($fileHash -ne "1643571673195d9eb892d2f2ac76eac7113ef7aa0ca116d79f3e4d3dc9df8a31600a9668b7e7678dfbe5a76906f9e0734ef8d6db0903ccc68fc742dd8238d8b0") {
@@ -122,7 +125,7 @@ jobs:
     displayName: CMake DirectXTex (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
@@ -132,7 +135,7 @@ jobs:
     displayName: CMake DirectXTex (Config) rel
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:
@@ -168,7 +171,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg --debug --debug-env install directxmath directx-headers openexr libpng zlib libjpeg-turbo
+      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -159,15 +159,18 @@ jobs:
       filePath: $(Build.SourcesDirectory)/vcpkg/bootstrap-vcpkg.sh
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: GCC and CMake version
     inputs:
       script: |
-        ./vcpkg install directxmath
-        ./vcpkg install directx-headers
-        ./vcpkg install openexr
-        ./vcpkg install libpng
-        ./vcpkg install libjpeg-turbo
+        g++ --version
+        cmake --version
 
+  - task: Bash@3
+    displayName: VCPKG install headers
+    inputs:
+      targetType: filePath
+      filePath: $(Build.SourcesDirectory)/vcpkg/vcpkg
+      arguments: install directxmath directx-headers openexr libpng zlib libjpeg-turbo
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -157,18 +157,18 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./bootstrap-vcpkg.sh
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
       script: |
-        .\vcpkg install directxmath
-        .\vcpkg install directx-headers
-        .\vcpkg install openexr
-        .\vcpkg install libpng
-        .\vcpkg install libjpeg-turbo
+        ./vcpkg install directxmath
+        ./vcpkg install directx-headers
+        ./vcpkg install openexr
+        ./vcpkg install libpng
+        ./vcpkg install libjpeg-turbo
 
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg
     inputs:

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -55,6 +55,7 @@ pool:
 variables:
   VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
 - job: BUILD_WSL
@@ -68,16 +69,12 @@ jobs:
   - task: CmdLine@2
     displayName: Fetch directx-headers
     inputs:
-      script: export DESTDIR=$(Agent.BuildDirectory)/install/
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
       cwd: directx-headers
-      cmakeArgs: . -DDXHEADERS_BUILD_TEST=OFF -DDXHEADERS_BUILD_GOOGLE_TEST=OFF
+      cmakeArgs: . -DDXHEADERS_BUILD_TEST=OFF -DDXHEADERS_BUILD_GOOGLE_TEST=OFF -DCMAKE_INSTALL_PREFIX=$(LOCAL_PKG_DIR)
   - task: CMake@1
     displayName: CMake DirectX-Headers (Build)
     inputs:
@@ -96,7 +93,7 @@ jobs:
     displayName: CMake DirectXMath
     inputs:
       cwd: directxmath
-      cmakeArgs: .
+      cmakeArgs: . -DCMAKE_INSTALL_PREFIX=$(LOCAL_PKG_DIR)
   - task: CMake@1
     displayName: CMake DirectXMath (Build)
     inputs:
@@ -113,8 +110,8 @@ jobs:
       targetType: inline
       script: |
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(DESTDIR)usr/local/include/sal.h
-        $fileHash = Get-FileHash -Algorithm SHA512 $(DESTDIR)usr/local/include/sal.h | ForEach { $_.Hash} | Out-String
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h -OutFile $(LOCAL_PKG_DIR)/include/sal.h
+        $fileHash = Get-FileHash -Algorithm SHA512 $(LOCAL_PKG_DIR)/include/sal.h | ForEach { $_.Hash} | Out-String
         $filehash = $fileHash.Trim()
         Write-Host "##[debug]SHA512: " $filehash
         if ($fileHash -ne "1643571673195d9eb892d2f2ac76eac7113ef7aa0ca116d79f3e4d3dc9df8a31600a9668b7e7678dfbe5a76906f9e0734ef8d6db0903ccc68fc742dd8238d8b0") {
@@ -125,7 +122,7 @@ jobs:
     displayName: CMake DirectXTex (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
@@ -135,7 +132,7 @@ jobs:
     displayName: CMake DirectXTex (Config) rel
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DESTDIR)usr/local/share;$(DESTDIR)usr/local/cmake
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -156,7 +156,7 @@ jobs:
     displayName: VCPKG Bootstrap
     inputs:
       targetType: filePath
-      filePath: ./bootstrap-vcpkg.sh
+      filePath: $(Build.SourcesDirectory)/vcpkg/bootstrap-vcpkg.sh
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CmdLine@2
     displayName: VCPKG install headers

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -168,7 +168,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg --debug install directxmath directx-headers openexr libpng zlib libjpeg-turbo
+      script: $(Build.SourcesDirectory)/vcpkg/vcpkg --debug --debug-env install directxmath directx-headers openexr libpng zlib libjpeg-turbo
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -165,12 +165,10 @@ jobs:
         g++ --version
         cmake --version
 
-  - task: Bash@3
+  - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
-      targetType: filePath
-      filePath: $(Build.SourcesDirectory)/vcpkg/vcpkg
-      arguments: install directxmath directx-headers openexr libpng zlib libjpeg-turbo
+      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -168,7 +168,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo --debug
+      script: $(Build.SourcesDirectory)/vcpkg/vcpkg --debug install directxmath directx-headers openexr libpng zlib libjpeg-turbo
       workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -26,7 +26,7 @@ trigger:
     - build/*.ps1
     - build/*.targets
 
-  pr:
+pr:
   branches:
     include:
     - main

--- a/build/DirectXTex-GitHub.yml
+++ b/build/DirectXTex-GitHub.yml
@@ -18,20 +18,35 @@ trigger:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - CMake*
+    - '.nuget/*'
+    - build/*.cmake
+    - build/*.in
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+    - Auxiliary/*
+
 pr:
   branches:
     include:
     - main
   paths:
     exclude:
-    - README.md
-    - HISTORY.md
-    - SECURITY.md
+    - '*.md'
     - LICENSE
+    - CMake*
+    - '.nuget/*'
+    - build/*.cmake
+    - build/*.in
+    - build/*.json
+    - build/*.props
+    - build/*.ps1
+    - build/*.targets
+    - Auxiliary/*
   drafts: false
 
 resources:

--- a/build/DirectXTex-OneFuzz-Coverage.yml
+++ b/build/DirectXTex-OneFuzz-Coverage.yml
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+# OneFuzz code coverage pipeline
+
+pr: none
+trigger: none
+
+pool:
+  vmImage: windows-latest
+
+parameters:
+  - name: sasUrl
+    type: string
+    displayName: SAS URL
+  - name: branch
+    type: string
+    displayName: Branch
+  - name: jobID
+    type: string
+    displayName: OneFuzz Job ID
+  - name: buildDate
+    type: string
+    displayName: Build Date
+  - name: commitID
+    type: string
+    displayName: Commit ID
+
+variables:
+  - name: coverage-file
+    value: cobertura-coverage.xml
+  - name: job-ID
+    value: ${{ parameters.jobID }}
+  - name: build-date
+    value: ${{ parameters.buildDate }}
+  - name: branch
+    value: ${{ parameters.branch }}
+  - name: sas-url
+    value: ${{ parameters.sasUrl }}
+  - name: commit-ID
+    value: ${{ parameters.commitID }}
+
+jobs:
+- job: prod
+  displayName: Prod Task
+  workspace:
+    clean: all
+  steps:
+  - task: CmdLine@2
+    displayName: 'Fetch source'
+    inputs:
+      script: |
+        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/microsoft/DirectXTex.git
+        cd DirectXTex
+        git checkout $(commit-ID)
+        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/walbourn/directxtextest.git Tests
+      workingDirectory: $(Build.SourcesDirectory)
+      failOnStderr: true
+
+  - powershell: |
+      Write-Host "Job ID: $(job-ID), Build Date: $(build-date), Branch: $(branch)"
+      $SASUrl = [System.Uri]::new("$(sas-url)")
+      azcopy cp $SASUrl.AbsoluteUri ./ --recursive
+      $ContainerName = $SASURL.LocalPath.Split("/")[1]
+      Write-Host "##vso[task.setvariable variable=container-name;]$ContainerName"
+      cd $ContainerName
+      $size = ((Get-Item .\$(coverage-file)).length)
+      if ($size -eq 0) {
+        Write-Host "Cobertura coverage XML is empty."
+        exit 1
+      }
+    displayName: 'Get code coverage from OneFuzz'
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: ./$(container-name)\$(coverage-file)
+      pathToSources: $(Build.SourcesDirectory)
+    displayName: 'Generate coverage report'


### PR DESCRIPTION
Also adds coverage of `Auxiliary` code to CMake-based pipelines for EXR, JPEG, and PNG extensions.