### PR TITLE
Fix build break when building for Xbox using latest Windows SDK

### DIFF
--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -27,7 +27,7 @@ static_assert(WIN10_DXGI_FORMAT_V208 == DXGI_FORMAT_V208, "Windows SDK mismatch 
 static_assert(WIN10_DXGI_FORMAT_V408 == DXGI_FORMAT_V408, "Windows SDK mismatch detected");
 #endif
 
-#if defined(NTDDI_WIN11_GE)
+#if defined(NTDDI_WIN11_GE) && !defined(_GAMING_XBOX)
 static_assert(WIN11_DXGI_FORMAT_A4B4G4R4_UNORM == DXGI_FORMAT_A4B4G4R4_UNORM, "Windows SDK mismatch detected");
 #endif
 


### PR DESCRIPTION
When building for Scarlett or Xbox One, the symbol ``DXGI_FORMAT_A4B4G4R4_UNORM`` is not defined even when using Windows SDK (26100).

