### PR TITLE
Add cubemap support for OpenEXR

### DIFF
--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -373,7 +373,7 @@ HRESULT DirectX::LoadFromEXRFile(const wchar_t* szFile, TexMetadata* metadata, S
 
         int width = dw.max.x - dw.min.x + 1;
         int height = dw.max.y - dw.min.y + 1;
-        bool isEnvmap = false;
+        size_t arraySize = 1;
 
         if (width < 1 || height < 1)
             return E_FAIL;
@@ -384,28 +384,21 @@ HRESULT DirectX::LoadFromEXRFile(const wchar_t* szFile, TexMetadata* metadata, S
             {
                 height = width;
             }
-            isEnvmap = true;
+            arraySize = 6;
         }
 
         if (metadata)
         {
             metadata->width = static_cast<size_t>(width);
             metadata->height = static_cast<size_t>(height);
-            metadata->depth = metadata->arraySize = metadata->mipLevels = 1;
+            metadata->depth = metadata->mipLevels = 1;
+            metadata->arraySize = arraySize;
             metadata->format = DXGI_FORMAT_R16G16B16A16_FLOAT;
             metadata->dimension = TEX_DIMENSION_TEXTURE2D;
         }
 
-        if (!isEnvmap)
-        {
-            hr = image.Initialize2D(DXGI_FORMAT_R16G16B16A16_FLOAT,
-                static_cast<size_t>(width), static_cast<size_t>(height), 1u, 1u);
-        }
-        else
-        {
-            hr = image.InitializeCube(DXGI_FORMAT_R16G16B16A16_FLOAT,
-                static_cast<size_t>(width), static_cast<size_t>(height), 1u, 1u);
-        }
+        hr = image.Initialize2D(DXGI_FORMAT_R16G16B16A16_FLOAT,
+                static_cast<size_t>(width), static_cast<size_t>(height), arraySize, 1u);
         
         if (FAILED(hr))
             return hr;


### PR DESCRIPTION
OpenEXR format can includes metadata indicating the image is cubemap which is six images in a single file.