### PR TITLE
Some DDS DX10 writers set arraySize to 0 instead of 1

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -353,6 +353,8 @@
     { "name": "x86-Release"  , "configurePreset": "x86-Release" },
     { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
     { "name": "arm64-Release", "configurePreset": "arm64-Release" },
+    { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
+    { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
 
     { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
     { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -397,7 +397,7 @@ namespace
             metadata.arraySize = d3d10ext->arraySize;
             if (metadata.arraySize == 0)
             {
-                return HRESULT_E_INVALID_DATA;
+                metadata.arraySize = 1;
             }
 
             metadata.format = d3d10ext->dxgiFormat;


### PR DESCRIPTION
The vast majority of "DX10" extended header DDS files are written by D3DX10/D3DX11 or DirectXTex, and properly set the ``DDS_HEADER_DXT10.arraySize`` field to 1 or greater. Some 3rd party writer is setting it to '0' instead for '1' (thinking since it wasn't an array, it doesn't need a value here), which was a common pattern for mipLevels set to 0 for legacy DX9 format DDS files as well.