### PR TITLE
Added GitHub Actions for build and security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         build-mode: manual
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --preset=x64-Debug
 
     - name: 'Build'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --build out\build\x64-Debug
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '43 3 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze (C/C++)
+    runs-on: windows-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: c-cpp
+        build-mode: manual
+
+    - name: 'Configure CMake'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --preset=x64-Debug
+
+    - name: 'Build'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --build out\build\x64-Debug
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:c-cpp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,16 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
   schedule:
     - cron: '43 3 * * 3'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,9 +81,9 @@ jobs:
         arch: ${{ matrix.arch }}
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --preset=${{ matrix.build_type }}
 
     - name: 'Build'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,3 +87,13 @@ jobs:
     - name: 'Build'
       working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}
+
+    - if: matrix.arch != 'amd64_arm64'
+      name: 'Configure CMake (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DENABLE_SPECTRE_MITIGATION=ON
+
+    - if: matrix.arch != 'amd64_arm64'
+      name: 'Build (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248926
 
-name: 'CMake'
+name: 'CMake (Windows)'
 
 on:
   push:
@@ -69,12 +69,6 @@ jobs:
           - os: windows-2022
             build_type: arm64ec-Release
             arch: amd64_arm64
-          - os: ubuntu-latest
-            build_type: x64-Debug-Linux
-            arch: none
-          - os: ubuntu-latest
-            build_type: x64-Release-Linux
-            arch: none
 
     steps:
     - uses: actions/checkout@v4
@@ -82,8 +76,7 @@ jobs:
     - name: 'Install Ninja'
       run: choco install ninja
 
-    - if: matrix.arch != 'none'
-      uses: ilammy/msvc-dev-cmd@v1
+    - uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248926
 
-name: 'CMake (Windows)'
+name: 'CMake'
 
 on:
   push:
@@ -59,6 +59,12 @@ jobs:
           - os: windows-2022
             build_type: arm64ec-Release
             arch: amd64_arm64
+          - os: ubuntu-latest
+            build_type: x64-Debug-Linux
+            arch: none
+          - os: ubuntu-latest
+            build_type: x64-Release-Linux
+            arch: none
 
     steps:
     - uses: actions/checkout@v4
@@ -66,12 +72,13 @@ jobs:
     - name: 'Install Ninja'
       run: choco install ninja
 
-    - uses: ilammy/msvc-dev-cmd@v1
+    - if: matrix.arch != 'none'
+      uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}    
+      working-directory: ${{env.GITHUB_WORKSPACE}}
       run: cmake --preset=${{ matrix.build_type }}
 
     - name: 'Build'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+name: 'CMake (Windows)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - os: windows-2019
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: arm64-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake'
+      working-directory: ${{env.GITHUB_WORKSPACE}}    
+      run: cmake --preset=${{ matrix.build_type }}
+
+    - name: 'Build'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,16 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
 
 jobs:
   build:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+name: MSBuild
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-${{ matrix.vs }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        vs: [2019, 2022]
+        build_type: [Debug, Release]
+        platform: [x86, x64, ARM64]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - if: matrix.platform != 'ARM64'
+      name: Build
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTex_Desktop_${{ matrix.vs }}.sln
+
+    - name: 'Build (Windows 10)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTex_Desktop_${{ matrix.vs }}_Win10.sln
+
+    - if: matrix.vs == '2022'
+      name: 'Build (UWP)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTex_Windows10_2022.sln

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -50,3 +50,13 @@ jobs:
       name: 'Build (UWP)'
       working-directory: ${{ github.workspace }}
       run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTex_Windows10_2022.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Desktop_${{ matrix.vs }}.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Spectre Windows 10)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Desktop_${{ matrix.vs }}_Win10.sln

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -54,9 +54,9 @@ jobs:
     - if: matrix.platform != 'ARM64'
       name: 'Build (Spectre)'
       working-directory: ${{ github.workspace }}
-      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Desktop_${{ matrix.vs }}.sln
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTex_Desktop_${{ matrix.vs }}.sln
 
     - if: matrix.platform != 'ARM64'
       name: 'Build (Spectre Windows 10)'
       working-directory: ${{ github.workspace }}
-      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXMesh_Desktop_${{ matrix.vs }}_Win10.sln
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTex_Desktop_${{ matrix.vs }}_Win10.sln

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -44,7 +44,7 @@ jobs:
           arch: amd64
 
       - name: Configure CMake
-        working-directory: ${{ env.GITHUB_WORKSPACE }}
+        working-directory: ${{ github.workspace }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
       - name: Build Shaders
@@ -52,7 +52,7 @@ jobs:
         working-directory: ./DirectXTex/Shaders
         run: CompileShaders.cmd
         env:
-          CompileShadersOutput: ${{ env.GITHUB_WORKSPACE }}/out/Shaders/Compiled
+          CompileShadersOutput: ${{ github.workspace }}/out/Shaders/Compiled
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -39,9 +39,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
       - name: Configure CMake
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+
+      - name: Build Shaders
+        working-directory: ./DirectXTex/Shaders
+        run: CompileShaders.cmd
+        env:
+          CompileShadersOutput: ./out/Shaders/Compiled
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -44,7 +44,7 @@ jobs:
           arch: amd64
 
       - name: Configure CMake
-        working-directory: ${{env.GITHUB_WORKSPACE}}
+        working-directory: ${{ env.GITHUB_WORKSPACE }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
       - name: Build Shaders
@@ -52,7 +52,7 @@ jobs:
         working-directory: ./DirectXTex/Shaders
         run: CompileShaders.cmd
         env:
-          CompileShadersOutput: ./out/Shaders/Compiled
+          CompileShadersOutput: '${{ env.GITHUB_WORKSPACE }}/out/Shaders/Compiled'
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: ./DirectXTex/Shaders
         run: CompileShaders.cmd
         env:
-          CompileShadersOutput: '$GITHUB_WORKSPACE/out/Shaders/Compiled'
+          CompileShadersOutput: ${{ env.GITHUB_WORKSPACE }}/out/Shaders/Compiled
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -48,8 +48,9 @@ jobs:
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
       - name: Build Shaders
+        shell: pwsh
         working-directory: ./DirectXTex/Shaders
-        run: CompileShaders.cmd
+        run: ./CompileShaders.cmd
         env:
           CompileShadersOutput: ./out/Shaders/Compiled
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -47,10 +47,17 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
-      - name: Build Shaders
+      - name: 'Build Shaders (BC)'
         shell: cmd
         working-directory: ./DirectXTex/Shaders
         run: CompileShaders.cmd
+        env:
+          CompileShadersOutput: ${{ github.workspace }}/out/Shaders/Compiled
+
+      - name: 'Build Shaders (DDSVIEW)'
+        shell: cmd
+        working-directory: ./DDSView
+        run: hlsl.cmd
         env:
           CompileShadersOutput: ${{ github.workspace }}/out/Shaders/Compiled
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -48,9 +48,9 @@ jobs:
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
       - name: Build Shaders
-        shell: pwsh
+        shell: cmd
         working-directory: ./DirectXTex/Shaders
-        run: ./CompileShaders.cmd
+        run: CompileShaders.cmd
         env:
           CompileShadersOutput: ./out/Shaders/Compiled
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+name: Microsoft C++ Code Analysis
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+  schedule:
+    - cron: '41 16 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Analyze
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+
+      - name: Initialize MSVC Code Analysis
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
+        id: run-analysis
+        with:
+          cmakeBuildDirectory: ./out
+          buildConfiguration: Debug
+          ruleset: NativeRecommendedRules.ruleset
+
+      # Upload SARIF file to GitHub Code Scanning Alerts
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: ./DirectXTex/Shaders
         run: CompileShaders.cmd
         env:
-          CompileShadersOutput: '${{ env.GITHUB_WORKSPACE }}/out/Shaders/Compiled'
+          CompileShadersOutput: '$GITHUB_WORKSPACE/out/Shaders/Compiled'
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ on:
 
 env:
   DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
+  CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
 
 jobs:
   build:
@@ -112,10 +113,10 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library --output-on-failure
+      run: ctest --preset=${{ matrix.build_type }} -L Library ${{ env.CTEST_EXTRA_OPTS }}
 
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats --output-on-failure
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${{ env.CTEST_EXTRA_OPTS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,15 +111,17 @@ jobs:
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (CPU only)'
+      shell: cmd
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library $env:CTEST_DEBUG_OPTS
+      run: ctest --preset=${{ matrix.build_type }} -L Library %CTEST_DEBUG_OPTS%
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
 
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
+      shell: cmd
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats $env:CTEST_DEBUG_OPTS
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats %CTEST_DEBUG_OPTS%
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library $env:CTEST_DEBUG_OPTS
+      run: ctest --preset=${{ matrix.build_type }} -L Library ${env:CTEST_DEBUG_OPTS}
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
   
@@ -120,6 +120,6 @@ jobs:
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats $env:CTEST_DEBUG_OPTS
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${env:CTEST_DEBUG_OPTS}
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library ${{ env.CTEST_DEBUG_OPTS }}
+      run: ctest --preset=${{ matrix.build_type }} -L Library $env:CTEST_DEBUG_OPTS
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
   
@@ -120,6 +120,6 @@ jobs:
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${{ env.CTEST_DEBUG_OPTS }}
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats $env:CTEST_DEBUG_OPTS
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,115 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+name: 'CTest (Windows)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+env:
+  DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - os: windows-2019
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: arm64-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Clone test repository
+      uses: actions/checkout@v4
+      with:
+        repository: walbourn/directxtextest
+        path: Tests
+        ref: main
+
+    - if: matrix.build_type == 'x64-Release'
+      name: Clone media repository
+      uses: actions/checkout@v4
+      with:
+        repository: walbourn/directxtexmedia
+        path: Media
+        ref: main
+        lfs: true
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
+      timeout-minutes: 30
+      name: 'Test (CPU only)'
+      working-directory: ${{ github.workspace }}
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats,Library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,14 +112,14 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library ${{ env.CTEST_EXTRA_OPTS }}
+      run: ctest --preset=${{ matrix.build_type }} -L Library ${{ env.CTEST_DEBUG_OPTS }}
       env:
-        CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
+        CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
   
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${{ env.CTEST_EXTRA_OPTS }}
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${{ env.CTEST_DEBUG_OPTS }}
       env:
-        CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
+        CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -112,4 +112,10 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats,Library
+      run: ctest --preset=${{ matrix.build_type }} -L Library
+
+    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
+      timeout-minutes: 30
+      name: 'Test (ImageFormats)'
+      working-directory: ${{ github.workspace }}
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,15 +84,6 @@ jobs:
         path: Tests
         ref: main
 
-    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
-      name: Clone media repository
-      uses: actions/checkout@v4
-      with:
-        repository: walbourn/directxtexmedia
-        path: Media
-        ref: main
-        lfs: true
-
     - name: 'Install Ninja'
       run: choco install ninja
 
@@ -107,16 +98,3 @@ jobs:
     - name: 'Build'
       working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}
-
-    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
-      timeout-minutes: 30
-      name: 'Test (CPU only)'
-      shell: cmd
-      working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library
-
-    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
-      timeout-minutes: 30
-      name: 'Test (ImageFormats)'
-      working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}
-      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON -DBUILD_TOOLS=OFF -DBUILD_SAMPLE=OFF
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}
@@ -112,14 +112,14 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library ${env:CTEST_DEBUG_OPTS}
+      run: ctest --preset=${{ matrix.build_type }} -L Library $env:CTEST_DEBUG_OPTS
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
-  
+
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${env:CTEST_DEBUG_OPTS}
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats $env:CTEST_DEBUG_OPTS
       env:
         CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         path: Tests
         ref: main
 
-    - if: matrix.build_type == 'x64-Release'
+    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       name: Clone media repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,15 +113,10 @@ jobs:
       name: 'Test (CPU only)'
       shell: cmd
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library %CTEST_DEBUG_OPTS%
-      env:
-        CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
+      run: ctest --preset=${{ matrix.build_type }} -L Library
 
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
-      shell: cmd
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats %CTEST_DEBUG_OPTS%
-      env:
-        CTEST_DEBUG_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '' }}
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,14 @@ on:
 
 env:
   DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
-  CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
+    env:
+      CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
-    env:
-      CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
-
     strategy:
       fail-fast: false
 
@@ -116,9 +113,13 @@ jobs:
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
       run: ctest --preset=${{ matrix.build_type }} -L Library ${{ env.CTEST_EXTRA_OPTS }}
-
+      env:
+        CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}
+  
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
       run: ctest --preset=${{ matrix.build_type }} -L ImageFormats ${{ env.CTEST_EXTRA_OPTS }}
+      env:
+        CTEST_EXTRA_OPTS: ${{ runner.debug == '1' && '--output-on-failure' || '--stop-on-failure' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,10 +112,10 @@ jobs:
       timeout-minutes: 30
       name: 'Test (CPU only)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L Library
+      run: ctest --preset=${{ matrix.build_type }} -L Library --output-on-failure
 
     - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
       timeout-minutes: 30
       name: 'Test (ImageFormats)'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats
+      run: ctest --preset=${{ matrix.build_type }} -L ImageFormats --output-on-failure

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -240,12 +240,12 @@
       "hidden": true
     },
 
-    { "name": "x64-Debug"    , "description": "MSVC for x64 (Debug) with DX12", "inherits": [ "base", "x64", "Debug", "MSVC" ] },
-    { "name": "x64-Release"  , "description": "MSVC for x64 (Release) with DX12", "inherits": [ "base", "x64", "Release", "MSVC" ] },
-    { "name": "x86-Debug"    , "description": "MSVC for x86 (Debug) with DX12", "inherits": [ "base", "x86", "Debug", "MSVC" ] },
-    { "name": "x86-Release"  , "description": "MSVC for x86 (Release) with DX12", "inherits": [ "base", "x86", "Release", "MSVC" ] },
-    { "name": "arm64-Debug"  , "description": "MSVC for ARM64 (Debug) with DX12", "inherits": [ "base", "ARM64", "Debug", "MSVC" ] },
-    { "name": "arm64-Release", "description": "MSVC for ARM64 (Release) with DX12", "inherits": [ "base", "ARM64", "Release", "MSVC" ] },
+    { "name": "x64-Debug"      , "description": "MSVC for x64 (Debug) with DX12", "inherits": [ "base", "x64", "Debug", "MSVC" ] },
+    { "name": "x64-Release"    , "description": "MSVC for x64 (Release) with DX12", "inherits": [ "base", "x64", "Release", "MSVC" ] },
+    { "name": "x86-Debug"      , "description": "MSVC for x86 (Debug) with DX12", "inherits": [ "base", "x86", "Debug", "MSVC" ] },
+    { "name": "x86-Release"    , "description": "MSVC for x86 (Release) with DX12", "inherits": [ "base", "x86", "Release", "MSVC" ] },
+    { "name": "arm64-Debug"    , "description": "MSVC for ARM64 (Debug) with DX12", "inherits": [ "base", "ARM64", "Debug", "MSVC" ] },
+    { "name": "arm64-Release"  , "description": "MSVC for ARM64 (Release) with DX12", "inherits": [ "base", "ARM64", "Release", "MSVC" ] },
     { "name": "arm64ec-Debug"  , "description": "MSVC for ARM64EC (Debug) with DX12", "inherits": [ "base", "ARM64EC", "Debug", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
     { "name": "arm64ec-Release", "description": "MSVC for ARM64EC (Release) with DX12", "inherits": [ "base", "ARM64EC", "Release", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" } },
 
@@ -347,12 +347,12 @@
     { "name": "x64-Fuzzing"      , "description": "MSVC for x64 (Release) with ASan", "inherits": [ "base", "x64", "Release", "MSVC", "Fuzzing" ] }
   ],
   "testPresets": [
-    { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },
-    { "name": "x64-Release"  , "configurePreset": "x64-Release" },
-    { "name": "x86-Debug"    , "configurePreset": "x86-Debug" },
-    { "name": "x86-Release"  , "configurePreset": "x86-Release" },
-    { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
-    { "name": "arm64-Release", "configurePreset": "arm64-Release" },
+    { "name": "x64-Debug"      , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"    , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"      , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"    , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug"    , "configurePreset": "arm64-Debug" },
+    { "name": "arm64-Release"  , "configurePreset": "arm64-Release" },
     { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
     { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
 

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248926
 
-# Builds the library using CMake.
+# Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 
 schedules:
 - cron: "0 5 * * *"

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTex-GitHub-CMake-Xbox.yml
+++ b/build/DirectXTex-GitHub-CMake-Xbox.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248926
 
-# Builds the library using CMake.
+# Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 
 schedules:
 - cron: "0 5 * * *"

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTex-GitHub-Dev17.yml
+++ b/build/DirectXTex-GitHub-Dev17.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -40,6 +41,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTex-GitHub-Dev17.yml
+++ b/build/DirectXTex-GitHub-Dev17.yml
@@ -12,46 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - Auxiliary/*
-
+# GitHub Actions handles MSBuild for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - Auxiliary/*
-  drafts: false
+    include:
+    - build/DirectXTex-GitHub-Dev17.yml
 
 resources:
   repositories:

--- a/build/DirectXTex-GitHub-GDK.yml
+++ b/build/DirectXTex-GitHub-GDK.yml
@@ -23,6 +23,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -39,6 +40,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -12,8 +12,8 @@ schedules:
     include:
     - main
 
+# GitHub Actions handles test suite for CI/PR
 trigger: none
-
 pr:
   branches:
     include:

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -12,46 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - Auxiliary/*
-
+# GitHub Actions handles test suite for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - Auxiliary/*
-  drafts: false
+    include:
+    - build/DirectXTex-GitHub-Test.yml
 
 resources:
   repositories:

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -30,6 +31,7 @@ trigger:
     - build/*.ps1
     - build/*.targets
     - Auxiliary/*
+
 pr:
   branches:
     include:
@@ -39,6 +41,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTex-GitHub.yml
+++ b/build/DirectXTex-GitHub.yml
@@ -6,52 +6,21 @@
 # Builds the library for Windows Desktop and UWP.
 
 schedules:
-- cron: "0 3 * * *"
+- cron: "5 3 * * *"
   displayName: 'Nightly build'
   branches:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - Auxiliary/*
-
+# GitHub Actions handles MSBuild for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-    - Auxiliary/*
-  drafts: false
+    include:
+    - build/DirectXTex-GitHub.yml
 
 resources:
   repositories:

--- a/build/DirectXTex-GitHub.yml
+++ b/build/DirectXTex-GitHub.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -40,6 +41,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTex-SDL.yml
+++ b/build/DirectXTex-SDL.yml
@@ -12,8 +12,8 @@ schedules:
     include:
     - main
 
+# GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none
-
 pr:
   branches:
     include:


### PR DESCRIPTION
While most pipelines are hosted on ADO, this adds GitHub build actions that are available to everyone who forks the repo. This also uses GitHub actions to validate PRs where possible rather than ADO for security reasons.

Also enables the GitHub Action based CodeQL and PREfast analysis.

Minor code review.