### PR TITLE
ADO test pipeline updates

### DIFF
--- a/Auxiliary/DirectXTexJPEG.cpp
+++ b/Auxiliary/DirectXTexJPEG.cpp
@@ -141,11 +141,15 @@ namespace
             metadata.arraySize = 1;
             metadata.mipLevels = 1;
             metadata.dimension = TEX_DIMENSION_TEXTURE2D;
-            metadata.miscFlags2 |= TEX_ALPHA_MODE_OPAQUE;
-
             metadata.format = TranslateColor(dec.out_color_space);
             if (metadata.format == DXGI_FORMAT_UNKNOWN)
+            {
                 throw std::runtime_error{ "unexpected out_color_space in jpeg_decompress_struct" };
+            }
+            if (metadata.format == DXGI_FORMAT_R8G8B8A8_UNORM)
+            {
+                metadata.miscFlags2 |= TEX_ALPHA_MODE_OPAQUE;
+            }
         }
 
         HRESULT GetHeader(TexMetadata& metadata) noexcept(false)

--- a/Auxiliary/DirectXTexJPEG.cpp
+++ b/Auxiliary/DirectXTexJPEG.cpp
@@ -297,7 +297,7 @@ namespace
             #endif
 
             default:
-                return E_INVALIDARG;
+                return HRESULT_E_NOT_SUPPORTED;
             }
             enc.image_width = static_cast<JDIMENSION>(image.width);
             enc.image_height = static_cast<JDIMENSION>(image.height);

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -381,6 +381,9 @@
     { "name": "x64-Release-ICC"  , "configurePreset": "x64-Release-ICC"},
 
     { "name": "x64-Debug-ICX"    , "configurePreset": "x64-Debug-ICX" },
-    { "name": "x64-Release-ICX"  , "configurePreset": "x64-Release-ICX"}
+    { "name": "x64-Release-ICX"  , "configurePreset": "x64-Release-ICX"},
+
+    { "name": "x64-Debug-JPEG-PNG"  , "configurePreset": "x64-Debug-JPEG-PNG" },
+    { "name": "x64-Release-JPEG-PNG", "configurePreset": "x64-Release-JPEG-PNG"}
   ]
 }

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -38,6 +38,7 @@ variables:
   Codeql.Enabled: false
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  GUID_FEED: $(ADOFeedGUID)
 
 jobs:
 - job: DESKTOP_BUILD
@@ -61,6 +62,14 @@ jobs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
+  - task: NuGetToolInstaller
+    displayName: 'Use NuGet'
+  - task: NuGetCommand@2
+    displayName: NuGet restore tests
+    inputs:
+      solution: Tests/DirectXTex_Tests_Desktop_2022.sln
+      feedRestore: $(GUID_FEED)
+      includeNuGetOrg: false
   - task: VSBuild@1
     displayName: Build solution DirectXTex_Tests_Desktop_2022.sln 32dbg
     inputs:

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -62,7 +62,7 @@ jobs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-  - task: NuGetToolInstaller
+  - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetCommand@2
     displayName: NuGet restore tests

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -60,7 +60,7 @@ jobs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
-  - task: NuGetToolInstaller
+  - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetCommand@2
     displayName: NuGet restore tests

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -36,6 +36,7 @@ pool:
 variables:
   Codeql.Enabled: false
   GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  GUID_FEED: $(ADOFeedGUID)
 
 jobs:
 - job: DESKTOP_BUILD
@@ -59,6 +60,14 @@ jobs:
       script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
       workingDirectory: $(Build.SourcesDirectory)
       failOnStderr: true
+  - task: NuGetToolInstaller
+    displayName: 'Use NuGet'
+  - task: NuGetCommand@2
+    displayName: NuGet restore tests
+    inputs:
+      solution: Tests/DirectXTex_Tests_Desktop_2019.sln
+      feedRestore: $(GUID_FEED)
+      includeNuGetOrg: false
   - task: VSBuild@1
     displayName: Build solution DirectXTex_Tests_Desktop_2019.sln 32dbg
     inputs:


### PR DESCRIPTION
Includes minor fix to JPEG module to not set ALPHA MODE for returned formats that lack alpha. This matches a fix made to the PNG module in #503 .