### PR TITLE
Add GitHub Action for BVTs with subset of tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 name: 'CTest (BVTs)'
 

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -1,0 +1,106 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248926
+
+name: 'CTest (BVTs)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+env:
+  DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release]
+        arch: [amd64]
+
+    steps:
+    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+    - name: Clone test repository
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        repository: walbourn/directxtextest
+        path: Tests
+        ref: main
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Set triplet'
+      shell: pwsh
+      run: |
+        if ("${{ matrix.arch }}" -eq "amd64")
+        {
+            echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> $env:GITHUB_ENV
+        }
+        elseif ("${{ matrix.arch }}" -eq "amd64_x86")
+        {
+            echo "VCPKG_DEFAULT_TRIPLET=x86-windows" >> $env:GITHUB_ENV
+        }
+        elseif ("${{ matrix.arch }}" -eq "amd64_arm64")
+        {
+            if ("${{ matrix.build_type }}" -match "^arm64ec")
+            {
+                echo "VCPKG_DEFAULT_TRIPLET=arm64ec-windows" >> $env:GITHUB_ENV
+            }
+            else
+            {
+                echo "VCPKG_DEFAULT_TRIPLET=arm64-windows" >> $env:GITHUB_ENV
+            }
+        }
+        else
+        {
+            echo "::error Unknown architecture/build-type triplet mapping"
+        }
+
+    - uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7 # v11
+      with:
+        runVcpkgInstall: true
+        vcpkgJsonGlob: '**/build/vcpkg.json'
+        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+
+    - name: 'Configure CMake'
+      working-directory: ${{ github.workspace }}
+      run: >
+        cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON -DBUILD_TOOLS=OFF -DBUILD_SAMPLE=OFF -DBUILD_BVT=ON
+        -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_MANIFEST_DIR="${{ github.workspace }}/build"
+        -DVCPKG_TARGET_TRIPLET="${env:VCPKG_DEFAULT_TRIPLET}"
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - name: 'Run BVTs'
+      working-directory: ${{ github.workspace }}
+      run: ctest --preset=${{ matrix.build_type }} --output-on-failure

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -85,7 +85,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -21,9 +21,6 @@ on:
       - build/*.targets
       - build/*.yml
 
-env:
-  DIRECTXTEX_MEDIA_PATH: ${{ github.workspace }}/Media
-
 permissions:
   contents: read
 

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -85,7 +85,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -37,7 +37,7 @@ jobs:
 
       matrix:
         os: [windows-2019, windows-2022]
-        build_type: [x64-Debug, x64-Release]
+        build_type: [x64-Release]
         arch: [amd64]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 name: 'CTest (Windows)'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 name: 'CMake (Windows using VCPKG)'
 

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 name: 'CMake (WSL)'
 

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,13 +605,16 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       target_compile_options(${t} PRIVATE ${WarningsEXE})
     endforeach()
 
-    if(BUILD_FUZZING
-       AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
-       AND (NOT WINDOWS_STORE))
-          foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-            target_compile_options(${t} PRIVATE ${ASAN_SWITCHES})
-            target_link_libraries(${t} PRIVATE ${ASAN_LIBS})
-          endforeach()
+    if(BUILD_FUZZING AND (NOT WINDOWS_STORE))
+      string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+      string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
+        foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+          target_compile_options(${t} PRIVATE ${ASAN_SWITCHES})
+          target_link_libraries(${t} PRIVATE ${ASAN_LIBS})
+        endforeach()
+      endif()
     endif()
 endif()
 

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -50,13 +50,17 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: Microsoft/vcpkg
+    name: vcpkg
+    type: github
+    ref: refs/tags/$(VCPKG_TAG)
+    path: $(Build.SourcesDirectory)/vcpkg
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
   Codeql.Enabled: false
   VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
@@ -218,16 +222,16 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+  - checkout: vcpkg
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
       script: call bootstrap-vcpkg.bat
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      workingDirectory: $(Build.SourcesDirectory)/vcpkg
   - task: CmdLine@2
     displayName: VCPKG install headers
     inputs:
@@ -249,7 +253,7 @@ jobs:
         @echo --- ERROR: VCPKG FAILED ---
         exit /b 1
 
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      workingDirectory: $(Build.SourcesDirectory)/vcpkg
 
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -62,7 +62,7 @@ variables:
   Codeql.Enabled: false
   VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
   VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
-  VCPKG_MANIFEST_DIR: '$(Build.SourcesDirectory)/build
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -219,10 +219,9 @@ jobs:
     clean: true
     fetchTags: false
   - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
     displayName: Fetch VCPKG
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: VCPKG Bootstrap

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -23,7 +23,7 @@ trigger:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -39,7 +39,7 @@ pr:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -80,142 +80,142 @@ jobs:
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x86'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A Win32 -B out2 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A Win32 -B out2 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x86 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x86 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC): Config ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC): Build ARM64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Build ARM64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (UWP): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0
   - task: CMake@1
     displayName: 'CMake (UWP): Build x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4 -v
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out6 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out6 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out7 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (Win10): Config'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out8 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out8 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON
   - task: CMake@1
     displayName: 'CMake (Win10): Build'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out8 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out9 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out9 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out10 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A ARM64 -B out10 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build ARM64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out10 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build ARM64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out10 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (Win10 Spectre): Config'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out11 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out11 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON
   - task: CMake@1
     displayName: 'CMake (Win10 Spectre): Build'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out11 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Config'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Build'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out12 -v --config Debug
 
 - job: CMAKE_BUILD_VCPKG
@@ -240,53 +240,53 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
-      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR)
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
       workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ OpenEXR'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        '-G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
-        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)"
+        -G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ OpenEXR'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        '-G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+        -G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ libjpeg'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ libpng'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+        -G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ libpng'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4 -v --config Debug

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -50,12 +50,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
-  - repository: Microsoft/vcpkg
-    name: vcpkg
+  - repository: vcpkg
+    name: Microsoft/vcpkg
     type: github
     endpoint: microsoft
     ref: refs/tags/$(VCPKG_TAG)
-    path: $(Build.SourcesDirectory)/vcpkg
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -228,6 +227,7 @@ jobs:
     clean: true
     fetchTags: false
     fetchDepth: 1
+    path: $(Build.SourcesDirectory)/vcpkg
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -53,6 +53,7 @@ resources:
   - repository: Microsoft/vcpkg
     name: vcpkg
     type: github
+    endpoint: microsoft
     ref: refs/tags/$(VCPKG_TAG)
     path: $(Build.SourcesDirectory)/vcpkg
 

--- a/build/DirectXTex-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTex-GitHub-CMake-Dev17.yml
@@ -50,7 +50,7 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
-  - repository: vcpkg
+  - repository: vcpkgRepo
     name: Microsoft/vcpkg
     type: github
     endpoint: microsoft
@@ -60,7 +60,9 @@ name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: '$(Build.SourcesDirectory)/build
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
@@ -222,45 +224,31 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - checkout: vcpkg
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
     clean: true
     fetchTags: false
     fetchDepth: 1
-    path: $(Build.SourcesDirectory)/vcpkg
+    path: 's/vcpkg'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
       script: call bootstrap-vcpkg.bat
-      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+      workingDirectory: $(VCPKG_ROOT)
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install openexr
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install libpng
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install libjpeg-turbo
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)/vcpkg
-
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR)
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: >
+        '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug'
     inputs:
@@ -270,7 +258,9 @@ jobs:
     displayName: 'CMake (MSVC): Config x64 w/ OpenEXR'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: >
+        '-G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)"
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ OpenEXR'
     inputs:
@@ -280,7 +270,9 @@ jobs:
     displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: >
+        '-G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ libjpeg'
     inputs:
@@ -290,7 +282,9 @@ jobs:
     displayName: 'CMake (MSVC): Config x64 w/ libpng'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: >
+        '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ libpng'
     inputs:

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -219,10 +219,9 @@ jobs:
     clean: true
     fetchTags: false
   - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
     displayName: Fetch VCPKG
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: VCPKG Bootstrap

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -50,13 +50,19 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   VS_GENERATOR: 'Visual Studio 16 2019'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
@@ -74,142 +80,142 @@ jobs:
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x86'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A Win32 -B out2 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A Win32 -B out2 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x86 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x86 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC): Config ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC): Build ARM64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Build ARM64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (UWP): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0
   - task: CMake@1
     displayName: 'CMake (UWP): Build x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4 -v
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out6 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out6 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out7 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (Win10): Config'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out8 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out8 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON
   - task: CMake@1
     displayName: 'CMake (Win10): Build'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out8 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out9 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out9 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config ARM64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out10 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A ARM64 -B out10 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build ARM64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out10 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build ARM64 Release'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out10 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (Win10 Spectre): Config'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out11 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out11 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON
   - task: CMake@1
     displayName: 'CMake (Win10 Spectre): Build'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out11 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Config'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: -G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_DX12=ON
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Build'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out12 -v --config Debug
 
 - job: CMAKE_BUILD_VCPKG
@@ -218,76 +224,69 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
       script: call bootstrap-vcpkg.bat
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      workingDirectory: $(VCPKG_ROOT)
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install openexr
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install libpng
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install libjpeg-turbo
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
-
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ OpenEXR'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out2 -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ OpenEXR'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ libjpeg'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out3 -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ libjpeg'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64 w/ libpng'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out4 -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-windows
   - task: CMake@1
     displayName: 'CMake (MSVC): Build x64 Debug w/ libpng'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4 -v --config Debug

--- a/build/DirectXTex-GitHub-CMake.yml
+++ b/build/DirectXTex-GitHub-CMake.yml
@@ -23,7 +23,7 @@ trigger:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -39,7 +39,7 @@ pr:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -134,6 +134,10 @@ jobs:
         }
 
       workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: GCC version
+    inputs:
+      script: g++ --version
   - task: BatchScript@1
     displayName: CompileShaders
     inputs:
@@ -144,10 +148,6 @@ jobs:
     inputs:
       filename: DDSView/hlsl.cmd
       workingFolder: $(Build.SourcesDirectory)\DDSView
-  - task: CmdLine@2
-    displayName: GCC version
-    inputs:
-      script: g++ --version
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
@@ -160,7 +160,7 @@ jobs:
       cmakeArgs: >
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build
@@ -174,7 +174,7 @@ jobs:
       cmakeArgs: >
         -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build  w/ OpenEXR
@@ -188,7 +188,7 @@ jobs:
       cmakeArgs: >
         -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build w/ libjpeg
@@ -202,7 +202,7 @@ jobs:
       cmakeArgs: >
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build w/ libpng
@@ -258,6 +258,10 @@ jobs:
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
         }
 
+  - task: CmdLine@2
+    displayName: GCC version
+    inputs:
+      script: g++ --version
   - task: BatchScript@1
     displayName: CompileShaders.cmd
     inputs:
@@ -268,10 +272,6 @@ jobs:
     inputs:
       filename: DDSView/hlsl.cmd
       workingFolder: $(Build.SourcesDirectory)\DDSView
-  - task: CmdLine@2
-    displayName: GCC version
-    inputs:
-      script: g++ --version
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
@@ -284,7 +284,7 @@ jobs:
       cmakeArgs: >
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
@@ -298,7 +298,7 @@ jobs:
       cmakeArgs: >
         -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build  w/ OpenEXR
@@ -312,7 +312,7 @@ jobs:
       cmakeArgs: >
         -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libjpeg
@@ -326,7 +326,7 @@ jobs:
       cmakeArgs: >
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libpng

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -50,6 +50,16 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
+  - repository: testRepo
+    name: walbourn/directxtextest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -58,8 +68,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   WIN11_SDK: '10.0.22000.0'
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
@@ -72,11 +83,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -131,83 +145,83 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call .\vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install openexr
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install libpng
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install libjpeg-turbo
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x86-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW32)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out
   - task: CMake@1
     displayName: CMake (MinGW32) w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build  w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2
   - task: CMake@1
     displayName: CMake (MinGW32) w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3
   - task: CMake@1
     displayName: CMake (MinGW32) w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4
 
 - job: MINGW64_BUILD
-  displayName: 'Minimalist GNU for Windows (MinGW-W64) BUILD_TESTING=ON'
+  displayName: 'Minimalist GNU for Windows (MinGW-W64)'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -249,64 +263,59 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call .\vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install openexr
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install libpng
-        @if ERRORLEVEL 1 goto error
-        call .\vcpkg install libjpeg-turbo
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW-W64)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"  -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out
   - task: CMake@1
     displayName: CMake (MinGW-W64) w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build  w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2
   - task: CMake@1
     displayName: CMake (MinGW-W64) w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3
   - task: CMake@1
     displayName: CMake (MinGW-W64) w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DBUILD_TESTING=OFF -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -73,10 +73,9 @@ jobs:
     clean: true
     fetchTags: false
   - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
     displayName: Fetch VCPKG
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
@@ -203,7 +202,7 @@ jobs:
   - task: CmdLine@2
     displayName: Fetch VCPKG
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
   - task: CmdLine@2
     displayName: Fetch Tests

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -285,7 +285,7 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
@@ -298,7 +298,7 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
@@ -311,7 +311,7 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -23,7 +23,7 @@ trigger:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -39,7 +39,7 @@ pr:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library and test suite using the MinGW compiler.
 
@@ -155,7 +155,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build
@@ -168,7 +169,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x86
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build  w/ OpenEXR
@@ -181,7 +183,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x86
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build w/ libjpeg
@@ -194,7 +197,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x86
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build w/ libpng
@@ -203,7 +207,7 @@ jobs:
       cmakeArgs: --build out4
 
 - job: MINGW64_BUILD
-  displayName: 'Minimalist GNU for Windows (MinGW-W64)'
+  displayName: 'Minimalist GNU for Windows (MinGW-W64) BUILD_TESTING=ON'
   steps:
   - checkout: self
     clean: true
@@ -273,7 +277,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
@@ -286,7 +291,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out2 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build  w/ OpenEXR
@@ -299,7 +305,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out3 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libjpeg
@@ -312,7 +319,8 @@ jobs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64 -DBUILD_TESTING=OFF
-        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.BinariesDirectory)\Shaders
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build w/ libpng

--- a/build/DirectXTex-GitHub-MinGW.yml
+++ b/build/DirectXTex-GitHub-MinGW.yml
@@ -121,9 +121,13 @@ jobs:
         Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
+        $wsdkbin = "{0}bin\" -f $sdkroot
+        $wsdkverbin = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
+        $wsdkarchbin = "{0}bin\$(WIN11_SDK)\x86" -f $sdkroot
+        if (Test-Path "$wsdkarchbin") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkBinPath;]$wsdkbin"
+            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
+            Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
         else {
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
@@ -242,11 +246,13 @@ jobs:
       script: |
         $ProgressPreference = 'SilentlyContinue'
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        $windows11x64sdk = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
-            Write-Host "##vso[task.prependpath]$windows11x64sdk"
+        $wsdkbin = "{0}bin\" -f $sdkroot
+        $wsdkverbin = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
+        $wsdkarchbin = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
+        if (Test-Path "$wsdkarchbin") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkBinPath;]$wsdkbin"
+            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
+            Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
         else {
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library and test suite.
 

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -28,6 +28,11 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: testRepo
+    name: walbourn/directxtextest
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -37,7 +42,6 @@ pool:
 variables:
   Codeql.Enabled: false
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -49,19 +53,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetCommand@2
@@ -170,19 +169,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -257,19 +251,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:

--- a/build/DirectXTex-GitHub-Test-Dev17.yml
+++ b/build/DirectXTex-GitHub-Test-Dev17.yml
@@ -32,7 +32,7 @@ resources:
     name: walbourn/directxtextest
     type: github
     endpoint: microsoft
-    ref: refs/tags/main
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library and test suite.
 

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -31,7 +31,7 @@ resources:
     name: walbourn/directxtextest
     type: github
     endpoint: microsoft
-    ref: refs/tags/main
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 

--- a/build/DirectXTex-GitHub-Test.yml
+++ b/build/DirectXTex-GitHub-Test.yml
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtextest
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -35,7 +40,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -47,19 +51,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetCommand@2

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -31,6 +31,21 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: dxHeadersRepo
+    name: Microsoft/DirectX-Headers
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/main
+  - repository: dxMathRepo
+    name: Microsoft/DirectXMath
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -39,8 +54,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
@@ -52,10 +68,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: dxHeadersRepo
+    displayName: Fetch DirectX-Headers
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directx-headers'
+  - checkout: dxMathRepo
+    displayName: Fetch DirectX-Math
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directxmath'
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
@@ -71,10 +97,6 @@ jobs:
     inputs:
       cwd: directx-headers
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch directxmath
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMath.git directxmath
   - task: CMake@1
     displayName: CMake DirectXMath
     inputs:
@@ -107,22 +129,22 @@ jobs:
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
 
 - job: BUILD_WSL_VCPKG
@@ -133,11 +155,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: Bash@3
     displayName: VCPKG Bootstrap
     inputs:
@@ -152,57 +177,67 @@ jobs:
         cmake --version
 
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo
-      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE=Debug -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE=Release -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENEXR_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBJPEG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out4 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4 -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out5 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBPNG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out5 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out5 -v

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -35,12 +35,12 @@ resources:
     name: Microsoft/DirectX-Headers
     type: github
     endpoint: microsoft
-    ref: refs/tags/main
+    ref: refs/heads/main
   - repository: dxMathRepo
     name: Microsoft/DirectXMath
     type: github
     endpoint: microsoft
-    ref: refs/tags/main
+    ref: refs/heads/main
   - repository: vcpkgRepo
     name: Microsoft/vcpkg
     type: github

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -179,7 +179,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
-      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-linux
       workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -179,7 +179,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
-      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
       workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library for Windows Subsystem for Linux (WSL)
 

--- a/build/DirectXTex-GitHub-WSL-11.yml
+++ b/build/DirectXTex-GitHub-WSL-11.yml
@@ -136,7 +136,7 @@ jobs:
   - task: CmdLine@2
     displayName: Fetch VCPKG
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
   - task: Bash@3
     displayName: VCPKG Bootstrap

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -50,7 +50,6 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
-    trigger: none
   - repository: dxHeadersRepo
     name: Microsoft/DirectX-Headers
     type: github

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -199,7 +199,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
-      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-linux
       workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -50,6 +50,22 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+    trigger: none
+  - repository: dxHeadersRepo
+    name: Microsoft/DirectX-Headers
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/main
+  - repository: dxMathRepo
+    name: Microsoft/DirectXMath
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -58,8 +74,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
@@ -71,10 +88,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: dxHeadersRepo
+    displayName: Fetch DirectX-Headers
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directx-headers'
+  - checkout: dxMathRepo
+    displayName: Fetch DirectX-Math
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directxmath'
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
@@ -90,10 +117,6 @@ jobs:
     inputs:
       cwd: directx-headers
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch directxmath
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMath.git directxmath
   - task: CMake@1
     displayName: CMake DirectXMath
     inputs:
@@ -126,22 +149,22 @@ jobs:
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(LOCAL_PKG_DIR)/share;$(LOCAL_PKG_DIR)/cmake
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
 
 - job: BUILD_WSL_VCPKG
@@ -152,11 +175,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: Bash@3
     displayName: VCPKG Bootstrap
     inputs:
@@ -171,57 +197,67 @@ jobs:
         cmake --version
 
   - task: CmdLine@2
-    displayName: VCPKG install headers
+    displayName: VCPKG install packages
     inputs:
-      script: $(Build.SourcesDirectory)/vcpkg/vcpkg install directxmath directx-headers openexr libpng zlib libjpeg-turbo
-      workingDirectory: $(Build.SourcesDirectory)/vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE=Debug -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) dbg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE=Release -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) rel
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out2 -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENEXR_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENEXR_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) w/ OpenEXR
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out3 -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out4 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBJPEG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out4 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBJPEG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) w/ libjpeg
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out4 -v
   - task: CMake@1
     displayName: CMake DirectXTex (Config) w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out5 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBPNG_SUPPORT=ON -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)"
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out5 -DCMAKE_BUILD_TYPE=Debug -DENABLE_LIBPNG_SUPPORT=ON -DDIRECTX_ARCH=x64
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-linux
   - task: CMake@1
     displayName: CMake DirectXTex (Build) w/ libpng
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out5 -v

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -55,12 +55,12 @@ resources:
     name: Microsoft/DirectX-Headers
     type: github
     endpoint: microsoft
-    ref: refs/tags/main
+    ref: refs/heads/main
   - repository: dxMathRepo
     name: Microsoft/DirectXMath
     type: github
     endpoint: microsoft
-    ref: refs/tags/main
+    ref: refs/heads/main
   - repository: vcpkgRepo
     name: Microsoft/vcpkg
     type: github

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -23,7 +23,7 @@ trigger:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -39,7 +39,7 @@ pr:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -155,7 +155,7 @@ jobs:
   - task: CmdLine@2
     displayName: Fetch VCPKG
     inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
+      script: git clone --quiet --no-tags --depth=1 --branch $(VCPKG_TAG) https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
   - task: Bash@3
     displayName: VCPKG Bootstrap

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library for Windows Subsystem for Linux (WSL)
 

--- a/build/DirectXTex-GitHub-WSL.yml
+++ b/build/DirectXTex-GitHub-WSL.yml
@@ -199,7 +199,7 @@ jobs:
   - task: CmdLine@2
     displayName: VCPKG install packages
     inputs:
-      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
+      script: vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-windows
       workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake DirectXTex (Config) dbg

--- a/build/DirectXTex-OneFuzz-Coverage.yml
+++ b/build/DirectXTex-OneFuzz-Coverage.yml
@@ -64,12 +64,12 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: 's'
-  - checkout: vcpkgRepo
-    displayName: Fetch VCPKG
+  - checkout: testRepo
+    displayName: Fetch Tests
     clean: true
     fetchTags: false
     fetchDepth: 1
-    path: 's/vcpkg'
+    path: 's/Tests'
   - powershell: |
       Write-Host "Job ID: $(job-ID), Build Date: $(build-date), Branch: $(branch)"
       $SASUrl = [System.Uri]::new("$(sas-url)")

--- a/build/DirectXTex-OneFuzz-Coverage.yml
+++ b/build/DirectXTex-OneFuzz-Coverage.yml
@@ -8,6 +8,17 @@
 pr: none
 trigger: none
 
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtextest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+
 pool:
   vmImage: windows-latest
 
@@ -48,17 +59,17 @@ jobs:
   workspace:
     clean: all
   steps:
-  - task: CmdLine@2
-    displayName: 'Fetch source'
-    inputs:
-      script: |
-        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/microsoft/DirectXTex.git
-        cd DirectXTex
-        git checkout $(commit-ID)
-        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/walbourn/directxtextest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
-
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
+    displayName: Fetch VCPKG
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - powershell: |
       Write-Host "Job ID: $(job-ID), Build Date: $(build-date), Branch: $(branch)"
       $SASUrl = [System.Uri]::new("$(sas-url)")

--- a/build/DirectXTex-OneFuzz-Coverage.yml
+++ b/build/DirectXTex-OneFuzz-Coverage.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # OneFuzz code coverage pipeline
 

--- a/build/DirectXTex-OneFuzz.yml
+++ b/build/DirectXTex-OneFuzz.yml
@@ -21,6 +21,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtextest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -28,7 +33,6 @@ variables:
   Codeql.Enabled: false
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN11_SDK: '10.0.22000.0'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 pool:
   vmImage: windows-2022
@@ -40,19 +44,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtextest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: 'CMake (MSVC): Config with ASan'
     inputs:

--- a/build/DirectXTex-OneFuzz.yml
+++ b/build/DirectXTex-OneFuzz.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248926
+# https://go.microsoft.com/fwlink/?LinkId=248926
 
 # Builds the library using CMake and submit for file fuzzing
 

--- a/build/DirectXTex-SDL.yml
+++ b/build/DirectXTex-SDL.yml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - main
+  always: true    
 
 # GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none


### PR DESCRIPTION
This builds the test suite such that it only needs a few test data files which are included directly in the test repo. This avoids LFS bandwidth traffic for the full set of test data and provides an automated BVT.

This PR makes sure ``assert`` macros in the library built for fuzz-testing remain in place even in release builds.

> Includes ADO YAML code review to clean up use of PATs, and to convert all use of vcpkg in the pipelines to 'manifest mode'.

> Also sets the dependabot to not spam quite so often for GHA.