### PR TITLE
Update DirectXTexXboxDDS.cpp

### DIFF
--- a/Auxiliary/DirectXTexXboxDDS.cpp
+++ b/Auxiliary/DirectXTexXboxDDS.cpp
@@ -229,7 +229,7 @@ namespace
 _Use_decl_annotations_
 HRESULT Xbox::EncodeDDSHeader(
     const XboxImage& xbox,
-    void* pDestination,
+    uint8_t* pDestination,
     size_t maxsize) noexcept
 {
     if (!pDestination)


### PR DESCRIPTION
I changed *void to uint8_t* because it makes safer and improve readability. It helps to reduce mistakes.