### PR TITLE
VS 2019 Win32 on ARM64 is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ For a full change history, see [CHANGELOG.md](https://github.com/microsoft/Direc
 
 * The UWP projects and the Win10 classic desktop project include configurations for the ARM64 platform. Building these requires installing the ARM64 toolset.
 
-* When using clang/LLVM for the ARM64 platform, the Windows 11 SDK ([22000](https://walbourn.github.io/windows-sdk-for-windows-11/)) or later is required.
+* For ARM64/AArch64 development, the VS 2022 compiler is strongly recommended over the VS 2019 toolset. The Windows SDK (26100 or later) is not compatible with VS 2019 for Win32 on ARM64 development. *Note that the ARM32/AArch32 platform is [deprecated](https://learn.microsoft.com/windows/arm/arm32-to-arm64)*.
+
+* When using clang/LLVM for the ARM64/AArch64 platform, the Windows 11 SDK ([22000](https://walbourn.github.io/windows-sdk-for-windows-11/)) or later is required.
 
 * The ``CompileShaders.cmd`` script must have Windows-style (CRLF) line-endings. If it is changed to Linux-style (LF) line-endings, it can fail to build all the required shaders.
 

--- a/build/DirectXTex-GitHub-SDK-prerelease.yml
+++ b/build/DirectXTex-GitHub-SDK-prerelease.yml
@@ -147,17 +147,18 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
+  # VS 2019 for Win32 on ARM64 is out of support.
   - task: VSBuild@1
-    displayName: Build solution DirectXTex_Desktop_2019_Win10.sln arm64dbg
+    displayName: Build solution DirectXTex_Desktop_2022_Win10.sln arm64dbg
     inputs:
-      solution: DirectXTex_Desktop_2019_Win10.sln
+      solution: DirectXTex_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
       configuration: Debug
   - task: VSBuild@1
-    displayName: Build solution DirectXTex_Desktop_2019_Win10.sln arm64rel
+    displayName: Build solution DirectXTex_Desktop_2022_Win10.sln arm64rel
     inputs:
-      solution: DirectXTex_Desktop_2019_Win10.sln
+      solution: DirectXTex_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
       configuration: Release

--- a/build/DirectXTex-GitHub-SDK-release.yml
+++ b/build/DirectXTex-GitHub-SDK-release.yml
@@ -147,17 +147,18 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
+  # VS 2019 for Win32 on ARM64 is out of support.
   - task: VSBuild@1
-    displayName: Build solution DirectXTex_Desktop_2019_Win10.sln arm64dbg
+    displayName: Build solution DirectXTex_Desktop_2022_Win10.sln arm64dbg
     inputs:
-      solution: DirectXTex_Desktop_2019_Win10.sln
+      solution: DirectXTex_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
       configuration: Debug
   - task: VSBuild@1
-    displayName: Build solution DirectXTex_Desktop_2019_Win10.sln arm64rel
+    displayName: Build solution DirectXTex_Desktop_2022_Win10.sln arm64rel
     inputs:
-      solution: DirectXTex_Desktop_2019_Win10.sln
+      solution: DirectXTex_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: ARM64
       configuration: Release


### PR DESCRIPTION
As of Windows SDK version 10.0.26100.1834, ARM64 for Win32 "classic" Desktop no longer builds with the VS 2019 toolset. VS 2022 is required.