### PR TITLE
Minor code review change for PPM/PFM code

### DIFF
--- a/DDSTextureLoader/DDSTextureLoader11.cpp
+++ b/DDSTextureLoader/DDSTextureLoader11.cpp
@@ -502,7 +502,7 @@ namespace
         _In_ size_t width,
         _In_ size_t height,
         _In_ DXGI_FORMAT fmt,
-        size_t* outNumBytes,
+        _Out_opt_ size_t* outNumBytes,
         _Out_opt_ size_t* outRowBytes,
         _Out_opt_ size_t* outNumRows) noexcept
     {
@@ -516,6 +516,9 @@ namespace
         size_t bpe = 0;
         switch (fmt)
         {
+        case DXGI_FORMAT_UNKNOWN:
+            return E_INVALIDARG;
+
         case DXGI_FORMAT_BC1_TYPELESS:
         case DXGI_FORMAT_BC1_UNORM:
         case DXGI_FORMAT_BC1_UNORM_SRGB:
@@ -568,6 +571,15 @@ namespace
             planar = true;
             bpe = 2;
             break;
+
+        #if (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
+
+        case DXGI_FORMAT_P208:
+            planar = true;
+            bpe = 2;
+            break;
+
+        #endif
 
         case DXGI_FORMAT_P010:
         case DXGI_FORMAT_P016:

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -581,7 +581,7 @@ namespace
         _In_ size_t width,
         _In_ size_t height,
         _In_ DXGI_FORMAT fmt,
-        size_t* outNumBytes,
+        _Out_opt_ size_t* outNumBytes,
         _Out_opt_ size_t* outRowBytes,
         _Out_opt_ size_t* outNumRows) noexcept
     {
@@ -595,6 +595,9 @@ namespace
         size_t bpe = 0;
         switch (fmt)
         {
+        case DXGI_FORMAT_UNKNOWN:
+            return E_INVALIDARG;
+
         case DXGI_FORMAT_BC1_TYPELESS:
         case DXGI_FORMAT_BC1_UNORM:
         case DXGI_FORMAT_BC1_UNORM_SRGB:

--- a/DDSTextureLoader/DDSTextureLoader9.cpp
+++ b/DDSTextureLoader/DDSTextureLoader9.cpp
@@ -416,7 +416,7 @@ namespace
         _In_ size_t width,
         _In_ size_t height,
         _In_ D3DFORMAT fmt,
-        size_t* outNumBytes,
+        _Out_opt_ size_t* outNumBytes,
         _Out_opt_ size_t* outRowBytes,
         _Out_opt_ size_t* outNumRows) noexcept
     {
@@ -429,6 +429,9 @@ namespace
         size_t bpe = 0;
         switch (static_cast<int>(fmt))
         {
+        case D3DFMT_UNKNOWN:
+            return E_INVALIDARG;
+
         case D3DFMT_DXT1:
             bc = true;
             bpe = 8;

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -261,6 +261,9 @@ HRESULT DirectX::CompressEx(
         || IsTypeless(srcImage.format) || IsPlanar(srcImage.format) || IsPalettized(srcImage.format))
         return HRESULT_E_NOT_SUPPORTED;
 
+    if (!srcImage.pixels)
+        return E_POINTER;
+
     // Setup GPU compressor
     std::unique_ptr<GPUCompressBC> gpubc(new (std::nothrow) GPUCompressBC);
     if (!gpubc)

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -972,6 +972,9 @@ HRESULT DirectX::ComputePitch(DXGI_FORMAT fmt, size_t width, size_t height,
 
     switch (static_cast<int>(fmt))
     {
+    case DXGI_FORMAT_UNKNOWN:
+        return E_INVALIDARG;
+
     case DXGI_FORMAT_BC1_TYPELESS:
     case DXGI_FORMAT_BC1_UNORM:
     case DXGI_FORMAT_BC1_UNORM_SRGB:
@@ -1192,6 +1195,9 @@ size_t DirectX::ComputeScanlines(DXGI_FORMAT fmt, size_t height) noexcept
 {
     switch (static_cast<int>(fmt))
     {
+    case DXGI_FORMAT_UNKNOWN:
+        return 0;
+
     case DXGI_FORMAT_BC1_TYPELESS:
     case DXGI_FORMAT_BC1_UNORM:
     case DXGI_FORMAT_BC1_UNORM_SRGB:

--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -86,6 +86,9 @@ namespace
 
     HRESULT ReadData(_In_z_ const wchar_t* szFile, std::unique_ptr<uint8_t[]>& blob, size_t& blobSize)
     {
+        if (!szFile)
+            return E_INVALIDARG;
+
         blob.reset();
 
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
@@ -361,6 +364,9 @@ HRESULT __cdecl SaveToPortablePixMap(
     _In_ const Image& image,
     _In_z_ const wchar_t* szFile) noexcept
 {
+    if (!szFile)
+        return E_INVALIDARG;
+
     switch (image.format)
     {
     case DXGI_FORMAT_R8G8B8A8_UNORM:
@@ -688,6 +694,9 @@ HRESULT __cdecl SaveToPortablePixMapHDR(
     _In_ const Image& image,
     _In_z_ const wchar_t* szFile) noexcept
 {
+    if (!szFile)
+        return E_INVALIDARG;
+
     switch (image.format)
     {
     case DXGI_FORMAT_R32G32B32A32_FLOAT:


### PR DESCRIPTION
If you gave it a ``nullptr`` for the filename, it would return a Win32 result of "ERROR_PATH_NOT_FOUND". Makes more sense to early-out as an ``E_INVALIDARG``.

> Includes a few more minor tweaks for where invalid args should be returned.