### PR TITLE
texconv: Portable Half Map uses .phm extension

### DIFF
--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -449,9 +449,9 @@ HRESULT __cdecl SaveToPortablePixMap(
 
 
 //============================================================================
-// PFM (Portable Float Map)
+// PFM (Portable Float Map) / PHM (Portable Half Map)
 // http://paulbourke.net/dataformats/pbmhdr/
-// https://oyranos.org/2015/03/portable-float-map-with-16-bit-half/index.html
+// https://github.com/syoyo/libphm
 //============================================================================
 
 HRESULT __cdecl LoadFromPortablePixMapHDR(

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -2121,7 +2121,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 continue;
             }
         }
-        else if (_wcsicmp(ext.c_str(), L".pfm") == 0)
+        else if (_wcsicmp(ext.c_str(), L".pfm") == 0 || _wcsicmp(ext.c_str(), L".phm") == 0)
         {
             hr = LoadFromPortablePixMapHDR(curpath.c_str(), &info, *image);
             if (FAILED(hr))

--- a/build/DirectXTex-OneFuzz.yml
+++ b/build/DirectXTex-OneFuzz.yml
@@ -104,7 +104,10 @@ jobs:
             "UBW8.TGA",
             "ucm8.tga",
             "testimg.ppm",
-            "grad4d.pfm";
+            "grad4d.pfm",
+            "grad4d.phm",
+            "grad4d_mono.pfm",
+            "grad4d_mono.phm";
 
         New-Item -ItemType Directory -Force -Path .drop\seeds\
 


### PR DESCRIPTION
I added support for the 'float16' variant of PFM some time back. ImageMagick uses a `.phm` extension for these files instead of `.pfm`.

> My PFM codec only supports reading "PHM" files, and not writing them so there's no need to add another 'CODEC'
