### PR TITLE
--ignore-mips does not apply to array textures

### DIFF
--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -378,7 +378,7 @@ namespace
         }
 
         metadata.mipLevels = pHeader->mipMapCount;
-        if ((metadata.mipLevels == 0) || (flags & DDS_FLAGS_IGNORE_MIPS))
+        if (metadata.mipLevels == 0)
         {
             metadata.mipLevels = 1;
         }
@@ -648,6 +648,12 @@ namespace
             {
                 return HRESULT_E_NOT_SUPPORTED;
             }
+        }
+
+        // Special-handling flag for ignoring mipchains on simple DDS files
+        if ((flags & DDS_FLAGS_IGNORE_MIPS) && (metadata.arraySize == 1))
+        {
+            metadata.mipLevels = 1;
         }
 
         // Handle DDS-specific metadata


### PR DESCRIPTION
The ``--ignore-mips`` flag add in #484 is intended as a 'header hack' to treats the mipLevel as if it were 1 in DDS files. This is a workaround for some corrupt files. This doesn't work on cubemaps, arrays, or cubemap arrays because of how miplevels are laid out in those files.

This change just makes ``--ignore-mips`` only work on arraySize=1 textures since modifying the mipLevel count is not correct for array textures with mips. For array textures/cubemaps, the flag is ignored.

> You can remove mips in general by copying out the top-level mips to a new image. The `texconv` tool will do this with `-m 1`.