### PR TITLE
Improve error reporting for TGAs with invalid palettes

### DIFF
--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -30,7 +30,7 @@ jobs:
 
       matrix:
         build_type: [x64-Debug-Linux, x64-Release-Linux]
-        gcc: [10, 11, 12]
+        gcc: [12, 13, 14]
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -1679,7 +1679,7 @@ HRESULT DirectX::LoadFromTGAMemory(
 
     const size_t remaining = size - offset - paletteOffset;
     if (remaining == 0)
-        return E_FAIL;
+        return HRESULT_E_HANDLE_EOF;
 
     const void* pPixels = static_cast<const uint8_t*>(pSource) + offset + paletteOffset;
 
@@ -2126,6 +2126,12 @@ HRESULT DirectX::LoadFromTGAFile(
             {
                 image.Release();
                 return hr;
+            }
+
+            if ((remaining - paletteOffset) == 0)
+            {
+                image.Release();
+                return HRESULT_E_HANDLE_EOF;
             }
         }
 


### PR DESCRIPTION
> GNUC 10 and 11 not included in Linux runner image anymore. Now has GNUC 12, 13, and 14.