### PR TITLE
Code review for const auto vs auto const

### DIFF
--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -374,7 +374,7 @@ HRESULT DirectX::LoadFromEXRFile(const wchar_t* szFile, TexMetadata* metadata, S
         Imf::RgbaInputFile file(fileName.c_str());
 #endif
 
-        auto const dw = file.dataWindow();
+        const auto dw = file.dataWindow();
 
         const int width = dw.max.x - dw.min.x + 1;
         int height = dw.max.y - dw.min.y + 1;

--- a/Auxiliary/DirectXTexXboxDDS.cpp
+++ b/Auxiliary/DirectXTexXboxDDS.cpp
@@ -64,7 +64,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(pSource);
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(pSource);
         if (dwMagicNumber != DDS_MAGIC)
         {
             return E_FAIL;

--- a/DDSTextureLoader/DDSTextureLoader11.cpp
+++ b/DDSTextureLoader/DDSTextureLoader11.cpp
@@ -183,7 +183,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
         if (dwMagicNumber != DDS_MAGIC)
         {
             return E_FAIL;
@@ -294,7 +294,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
         if (dwMagicNumber != DDS_MAGIC)
         {
             ddsData.reset();
@@ -1751,7 +1751,7 @@ namespace
             if (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC)
             {
                 auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const uint8_t*>(header) + sizeof(DDS_HEADER));
-                auto const mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
+                const auto mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
                 switch (mode)
                 {
                 case DDS_ALPHA_MODE_STRAIGHT:

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -229,7 +229,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
         if (dwMagicNumber != DDS_MAGIC)
         {
             return E_FAIL;
@@ -380,7 +380,7 @@ namespace
     #endif
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
         if (dwMagicNumber != DDS_MAGIC)
         {
             ddsData.reset();
@@ -1623,7 +1623,7 @@ namespace
             if (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC)
             {
                 auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const uint8_t*>(header) + sizeof(DDS_HEADER));
-                auto const mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
+                const auto mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
                 switch (mode)
                 {
                 case DDS_ALPHA_MODE_STRAIGHT:

--- a/DDSTextureLoader/DDSTextureLoader9.cpp
+++ b/DDSTextureLoader/DDSTextureLoader9.cpp
@@ -156,7 +156,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
         if (dwMagicNumber != DDS_MAGIC)
         {
             return E_FAIL;
@@ -259,7 +259,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
+        const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
         if (dwMagicNumber != DDS_MAGIC)
         {
             ddsData.reset();

--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -203,7 +203,7 @@ namespace
         }
 
         // Use Newton's Method to find local minima of sum-of-squares error.
-        auto const fSteps = static_cast<float>(cSteps - 1);
+        const auto fSteps = static_cast<float>(cSteps - 1);
 
         for (size_t iIteration = 0; iIteration < 8; iIteration++)
         {
@@ -1032,8 +1032,8 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags
     float fAlphaA, fAlphaB;
     OptimizeAlpha<false>(&fAlphaA, &fAlphaB, fAlpha, uSteps);
 
-    auto const bAlphaA = static_cast<uint8_t>(static_cast<int32_t>(fAlphaA * 255.0f + 0.5f));
-    auto const bAlphaB = static_cast<uint8_t>(static_cast<int32_t>(fAlphaB * 255.0f + 0.5f));
+    const auto bAlphaA = static_cast<uint8_t>(static_cast<int32_t>(fAlphaA * 255.0f + 0.5f));
+    const auto bAlphaB = static_cast<uint8_t>(static_cast<int32_t>(fAlphaB * 255.0f + 0.5f));
 
     fAlphaA = static_cast<float>(bAlphaA) * (1.0f / 255.0f);
     fAlphaB = static_cast<float>(bAlphaB) * (1.0f / 255.0f);
@@ -1084,7 +1084,7 @@ void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags
     }
 
     // Encode alpha bitmap
-    auto const fSteps = static_cast<float>(uSteps - 1);
+    const auto fSteps = static_cast<float>(uSteps - 1);
     const float fScale = (fStep[0] != fStep[1]) ? (fSteps / (fStep[1] - fStep[0])) : 0.0f;
 
     if (flags & BC_FLAGS_DITHER_A)

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -230,7 +230,7 @@ namespace DirectX
         }
 
         // Use Newton's Method to find local minima of sum-of-squares error.
-        auto const fSteps = static_cast<float>(cSteps - 1);
+        const auto fSteps = static_cast<float>(cSteps - 1);
 
         for (size_t iIteration = 0; iIteration < 8; iIteration++)
         {

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -593,7 +593,7 @@ namespace
             assert(uStartBit < 128);
             _Analysis_assume_(uStartBit < 128);
             const size_t uIndex = uStartBit >> 3;
-            auto const ret = static_cast<uint8_t>((m_uBits[uIndex] >> (uStartBit - (uIndex << 3))) & 0x01);
+            const auto ret = static_cast<uint8_t>((m_uBits[uIndex] >> (uStartBit - (uIndex << 3))) & 0x01);
             uStartBit++;
             return ret;
         }
@@ -1290,7 +1290,7 @@ namespace
         }
 
         // Use Newton's Method to find local minima of sum-of-squares error.
-        auto const fSteps = static_cast<float>(cSteps - 1);
+        const auto fSteps = static_cast<float>(cSteps - 1);
 
         for (size_t iIteration = 0; iIteration < 8; iIteration++)
         {
@@ -2048,7 +2048,7 @@ float D3DX_BC6H::MapColorsQuantized(const EncodeParams* pEP, const INTColor aCol
     _Analysis_assume_(pEP->uMode < c_NumModes);
 
     const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
-    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    const auto uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
     INTColor aPalette[BC6H_MAX_INDICES];
     GeneratePaletteQuantized(pEP, endPts, aPalette);
 
@@ -2264,7 +2264,7 @@ void D3DX_BC6H::AssignIndices(const EncodeParams* pEP, const INTEndPntPair aEndP
     _Analysis_assume_(pEP->uMode < c_NumModes);
 
     const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
-    auto const uNumIndices = static_cast<const uint8_t>(1u << ms_aInfo[pEP->uMode].uIndexPrec);
+    const auto uNumIndices = static_cast<const uint8_t>(1u << ms_aInfo[pEP->uMode].uIndexPrec);
 
     assert(uPartitions < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
     _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
@@ -2437,7 +2437,7 @@ void D3DX_BC6H::GeneratePaletteUnquantized(const EncodeParams* pEP, size_t uRegi
 
     const INTEndPntPair& endPts = pEP->aUnqEndPts[pEP->uShape][uRegion];
     const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
-    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    const auto uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
     assert(uNumIndices > 0);
     _Analysis_assume_(uNumIndices > 0);
 
@@ -2473,7 +2473,7 @@ float D3DX_BC6H::MapColors(const EncodeParams* pEP, size_t uRegion, size_t np, c
     _Analysis_assume_(pEP->uMode < c_NumModes);
 
     const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
-    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    const auto uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
     INTColor aPalette[BC6H_MAX_INDICES];
     GeneratePaletteUnquantized(pEP, uRegion, aPalette);
 
@@ -2577,7 +2577,7 @@ void D3DX_BC7::Decode(HDRColorA* pOut) const noexcept
         assert(uPartitions < BC7_MAX_REGIONS);
         _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
 
-        auto const uNumEndPts = static_cast<const uint8_t>((unsigned(uPartitions) + 1u) << 1);
+        const auto uNumEndPts = static_cast<const uint8_t>((unsigned(uPartitions) + 1u) << 1);
         const uint8_t uIndexPrec = ms_aInfo[uMode].uIndexPrec;
         const uint8_t uIndexPrec2 = ms_aInfo[uMode].uIndexPrec2;
         size_t i;
@@ -3151,8 +3151,8 @@ void D3DX_BC7::AssignIndices(const EncodeParams* pEP, size_t uShape, size_t uInd
 
     const uint8_t uIndexPrec = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec2 : ms_aInfo[pEP->uMode].uIndexPrec;
     const uint8_t uIndexPrec2 = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec : ms_aInfo[pEP->uMode].uIndexPrec2;
-    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
-    auto const uNumIndices2 = static_cast<const uint8_t>(1u << uIndexPrec2);
+    const auto uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    const auto uNumIndices2 = static_cast<const uint8_t>(1u << uIndexPrec2);
 
     assert((uNumIndices <= BC7_MAX_INDICES) && (uNumIndices2 <= BC7_MAX_INDICES));
     _Analysis_assume_((uNumIndices <= BC7_MAX_INDICES) && (uNumIndices2 <= BC7_MAX_INDICES));
@@ -3505,8 +3505,8 @@ float D3DX_BC7::RoughMSE(EncodeParams* pEP, size_t uShape, size_t uIndexMode) no
 
     const uint8_t uIndexPrec = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec2 : ms_aInfo[pEP->uMode].uIndexPrec;
     const uint8_t uIndexPrec2 = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec : ms_aInfo[pEP->uMode].uIndexPrec2;
-    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
-    auto const uNumIndices2 = static_cast<const uint8_t>(1u << uIndexPrec2);
+    const auto uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    const auto uNumIndices2 = static_cast<const uint8_t>(1u << uIndexPrec2);
     size_t auPixIdx[NUM_PIXELS_PER_BLOCK];
     LDRColorA aPalette[BC7_MAX_REGIONS][BC7_MAX_INDICES];
 

--- a/DirectXTex/BCDirectCompute.cpp
+++ b/DirectXTex/BCDirectCompute.cpp
@@ -264,7 +264,7 @@ HRESULT GPUCompressBC::Prepare(size_t width, size_t height, uint32_t flags, DXGI
     if (sizeInBytes >= UINT32_MAX)
         return HRESULT_E_ARITHMETIC_OVERFLOW;
 
-    auto const bufferSize = static_cast<size_t>(sizeInBytes);
+    const auto bufferSize = static_cast<size_t>(sizeInBytes);
 
     {
         D3D11_BUFFER_DESC desc = {};
@@ -459,7 +459,7 @@ HRESULT GPUCompressBC::Compress(const Image& srcImage, const Image& destImage)
     const size_t xblocks = std::max<size_t>(1, (m_width + 3) >> 2);
     const size_t yblocks = std::max<size_t>(1, (m_height + 3) >> 2);
 
-    auto const num_total_blocks = static_cast<UINT>(xblocks * yblocks);
+    const auto num_total_blocks = static_cast<UINT>(xblocks * yblocks);
     UINT num_blocks = num_total_blocks;
     UINT start_block_id = 0;
     while (num_blocks > 0)

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -172,7 +172,7 @@ namespace
             ScratchImage image;
             HRESULT hr = E_UNEXPECTED;
 
-            auto const srgb = GetSRGBFlags(compress);
+            const auto srgb = GetSRGBFlags(compress);
 
             switch (tformat)
             {

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -983,8 +983,8 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
             auto sPtr = static_cast<const uint32_t*>(pSource);
             for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
             {
-                auto const d = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
-                auto const s = static_cast<float>((*sPtr & 0xFF000000) >> 24);
+                const auto d = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
+                const auto s = static_cast<float>((*sPtr & 0xFF000000) >> 24);
                 ++sPtr;
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(d, s, 0.f, 1.f);
@@ -999,7 +999,7 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
             auto sPtr = static_cast<const uint32_t*>(pSource);
             for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
             {
-                auto const r = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
+                const auto r = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
                 ++sPtr;
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(r, 0.f /* typeless component assumed zero */, 0.f, 1.f);
@@ -1014,7 +1014,7 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
             auto sPtr = static_cast<const uint32_t*>(pSource);
             for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
             {
-                auto const g = static_cast<float>((*sPtr & 0xFF000000) >> 24);
+                const auto g = static_cast<float>((*sPtr & 0xFF000000) >> 24);
                 ++sPtr;
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(0.f /* typeless component assumed zero */, g, 0.f, 1.f);
@@ -1344,9 +1344,9 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
                 // G = 1.1678Y' - 0.3929Cb' - 0.8152Cr'
                 // B = 1.1678Y' + 2.0232Cb'
 
-                auto const r = static_cast<int>((76533 * y + 104905 * v + 32768) >> 16);
-                auto const g = static_cast<int>((76533 * y - 25747 * u - 53425 * v + 32768) >> 16);
-                auto const b = static_cast<int>((76533 * y + 132590 * u + 32768) >> 16);
+                const auto r = static_cast<int>((76533 * y + 104905 * v + 32768) >> 16);
+                const auto g = static_cast<int>((76533 * y - 25747 * u - 53425 * v + 32768) >> 16);
+                const auto b = static_cast<int>((76533 * y + 132590 * u + 32768) >> 16);
 
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 1023)) / 1023.f,
@@ -1367,7 +1367,7 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
                 const int64_t u = int64_t(sPtr->x) - 32768;
                 const int64_t y = int64_t(sPtr->y) - 4096;
                 const int64_t v = int64_t(sPtr->z) - 32768;
-                auto const a = static_cast<int>(sPtr->w);
+                const auto a = static_cast<int>(sPtr->w);
                 ++sPtr;
 
                 // http://msdn.microsoft.com/en-us/library/windows/desktop/bb970578.aspx
@@ -1380,9 +1380,9 @@ _Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
                 // G = 1.1689Y' - 0.3933Cb' - 0.8160Cr'
                 // B = 1.1689Y'+ 2.0251Cb'
 
-                auto const r = static_cast<int>((76607 * y + 105006 * v + 32768) >> 16);
-                auto const g = static_cast<int>((76607 * y - 25772 * u - 53477 * v + 32768) >> 16);
-                auto const b = static_cast<int>((76607 * y + 132718 * u + 32768) >> 16);
+                const auto r = static_cast<int>((76607 * y + 105006 * v + 32768) >> 16);
+                const auto g = static_cast<int>((76607 * y - 25772 * u - 53477 * v + 32768) >> 16);
+                const auto b = static_cast<int>((76607 * y + 132718 * u + 32768) >> 16);
 
                 if (dPtr >= ePtr) break;
                 *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 65535)) / 65535.f,
@@ -4716,7 +4716,7 @@ namespace
             filter &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
         }
 
-        auto const wicsrgb = CheckWICColorSpace(pfGUID, targetGUID);
+        const auto wicsrgb = CheckWICColorSpace(pfGUID, targetGUID);
 
         if (wicsrgb != (filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)))
         {
@@ -4943,7 +4943,7 @@ namespace
         {\
             const size_t rowPitch = srcImage.rowPitch;\
             \
-            auto const sourceE = reinterpret_cast<const srcType*>(pSrc + srcImage.slicePitch);\
+            const auto sourceE = reinterpret_cast<const srcType*>(pSrc + srcImage.slicePitch);\
             auto pSrcUV = pSrc + (srcImage.height * rowPitch);\
             \
             for(size_t y = 0; y < srcImage.height; y+= 2)\

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -738,10 +738,10 @@ HRESULT DirectX::CaptureTexture(
     pCommandQueue->GetDevice(IID_GRAPHICS_PPV_ARGS(device.GetAddressOf()));
 
 #if defined(_MSC_VER) || !defined(_WIN32)
-    auto const desc = pSource->GetDesc();
+    const auto desc = pSource->GetDesc();
 #else
     D3D12_RESOURCE_DESC tmpDesc;
-    auto const& desc = *pSource->GetDesc(&tmpDesc);
+    const auto& desc = *pSource->GetDesc(&tmpDesc);
 #endif
 
     ComPtr<ID3D12Resource> pStaging;

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -341,7 +341,7 @@ namespace
         }
 
         // DDS files always start with the same magic number ("DDS ")
-        auto const dwMagicNumber = *static_cast<const uint32_t*>(pSource);
+        const auto dwMagicNumber = *static_cast<const uint32_t*>(pSource);
         if (dwMagicNumber != DDS_MAGIC)
         {
             return E_FAIL;
@@ -1942,9 +1942,9 @@ HRESULT DirectX::GetMetadataFromDDSFileEx(
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    auto const headerLen = static_cast<size_t>(bytesRead);
+    const auto headerLen = static_cast<size_t>(bytesRead);
 #else
-    auto const headerLen = std::min<size_t>(len, DDS_DX10_HEADER_SIZE);
+    const auto headerLen = std::min<size_t>(len, DDS_DX10_HEADER_SIZE);
 
     inFile.read(reinterpret_cast<char*>(header), headerLen);
     if (!inFile)
@@ -2124,9 +2124,9 @@ HRESULT DirectX::LoadFromDDSFileEx(
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    auto const headerLen = static_cast<size_t>(bytesRead);
+    const auto headerLen = static_cast<size_t>(bytesRead);
 #else
-    auto const headerLen = std::min<size_t>(len, DDS_DX10_HEADER_SIZE);
+    const auto headerLen = std::min<size_t>(len, DDS_DX10_HEADER_SIZE);
 
     inFile.read(reinterpret_cast<char*>(header), headerLen);
     if (!inFile)
@@ -2263,7 +2263,7 @@ HRESULT DirectX::LoadFromDDSFileEx(
         }
 
     #ifdef _WIN32
-        auto const pixelBytes = static_cast<DWORD>(image.GetPixelsSize());
+        const auto pixelBytes = static_cast<DWORD>(image.GetPixelsSize());
         if (!ReadFile(hFile.get(), image.GetPixels(), pixelBytes, &bytesRead, nullptr))
         {
             image.Release();

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -675,9 +675,9 @@ HRESULT DirectX::GetMetadataFromHDRFile(const wchar_t* szFile, TexMetadata& meta
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    auto const headerLen = static_cast<size_t>(bytesRead);
+    const auto headerLen = static_cast<size_t>(bytesRead);
 #else
-    auto const headerLen = std::min<size_t>(sizeof(header), len);
+    const auto headerLen = std::min<size_t>(sizeof(header), len);
 
     inFile.read(reinterpret_cast<char*>(header), headerLen);
     if (!inFile)
@@ -890,7 +890,7 @@ HRESULT DirectX::LoadFromHDRMemory(const uint8_t* pSource, size_t size, TexMetad
 
         for (size_t j = 0; j < image.GetPixelsSize(); j += 16)
         {
-            auto const exponent = static_cast<int>(fdata[3]);
+            const auto exponent = static_cast<int>(fdata[3]);
             fdata[0] = 1.0f / exposure*ldexpf((fdata[0] + 0.5f), exponent - (128 + 8));
             fdata[1] = 1.0f / exposure*ldexpf((fdata[1] + 0.5f), exponent - (128 + 8));
             fdata[2] = 1.0f / exposure*ldexpf((fdata[2] + 0.5f), exponent - (128 + 8));
@@ -1174,7 +1174,7 @@ HRESULT DirectX::SaveToHDRFile(const Image& image, const wchar_t* szFile) noexce
 
         // Write blob
     #ifdef _WIN32
-        auto const bytesToWrite = static_cast<const DWORD>(blob.GetBufferSize());
+        const auto bytesToWrite = static_cast<const DWORD>(blob.GetBufferSize());
         DWORD bytesWritten;
         if (!WriteFile(hFile.get(), blob.GetConstBufferPointer(), bytesToWrite, &bytesWritten, nullptr))
         {
@@ -1207,7 +1207,7 @@ HRESULT DirectX::SaveToHDRFile(const Image& image, const wchar_t* szFile) noexce
         sprintf_s(header, g_Header, image.height, image.width);
 
     #ifdef _WIN32
-        auto const headerLen = static_cast<DWORD>(strlen(header));
+        const auto headerLen = static_cast<DWORD>(strlen(header));
 
         DWORD bytesWritten;
         if (!WriteFile(hFile.get(), header, headerLen, &bytesWritten, nullptr))

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -1146,7 +1146,7 @@ namespace
 
             for (size_t y = 0; y < nheight; ++y)
             {
-                auto const& toY = lfY[y];
+                const auto& toY = lfY[y];
 
                 if (toY.u0 != u0)
                 {
@@ -1176,7 +1176,7 @@ namespace
 
                 for (size_t x = 0; x < nwidth; ++x)
                 {
-                    auto const& toX = lfX[x];
+                    const auto& toX = lfX[x];
 
                     BILINEAR_INTERPOLATE(target[x], toX, toY, row0, row1)
                 }
@@ -1269,7 +1269,7 @@ namespace
 
             for (size_t y = 0; y < nheight; ++y)
             {
-                auto const& toY = cfY[y];
+                const auto& toY = cfY[y];
 
                 // Scanline 1
                 if (toY.u0 != u0)
@@ -1360,7 +1360,7 @@ namespace
 
                 for (size_t x = 0; x < nwidth; ++x)
                 {
-                    auto const& toX = cfX[x];
+                    const auto& toX = cfX[x];
 
                     XMVECTOR C0, C1, C2, C3;
 
@@ -2050,7 +2050,7 @@ namespace
 
                 for (size_t slice = 0; slice < ndepth; ++slice)
                 {
-                    auto const& toZ = lfZ[slice];
+                    const auto& toZ = lfZ[slice];
 
                     const Image* srca = mipChain.GetImage(level - 1, 0, toZ.u0);
                     const Image* srcb = mipChain.GetImage(level - 1, 0, toZ.u1);
@@ -2068,7 +2068,7 @@ namespace
 
                     for (size_t y = 0; y < nheight; ++y)
                     {
-                        auto const& toY = lfY[y];
+                        const auto& toY = lfY[y];
 
                         if (toY.u0 != u0)
                         {
@@ -2101,7 +2101,7 @@ namespace
 
                         for (size_t x = 0; x < nwidth; ++x)
                         {
-                            auto const& toX = lfX[x];
+                            const auto& toX = lfX[x];
 
                             TRILINEAR_INTERPOLATE(target[x], toX, toY, toZ, urow0, urow1, vrow0, vrow1)
                         }
@@ -2131,7 +2131,7 @@ namespace
 
                 for (size_t y = 0; y < nheight; ++y)
                 {
-                    auto const& toY = lfY[y];
+                    const auto& toY = lfY[y];
 
                     if (toY.u0 != u0)
                     {
@@ -2161,7 +2161,7 @@ namespace
 
                     for (size_t x = 0; x < nwidth; ++x)
                     {
-                        auto const& toX = lfX[x];
+                        const auto& toX = lfX[x];
 
                         BILINEAR_INTERPOLATE(target[x], toX, toY, urow0, urow1)
                     }
@@ -2260,7 +2260,7 @@ namespace
 
                 for (size_t slice = 0; slice < ndepth; ++slice)
                 {
-                    auto const& toZ = cfZ[slice];
+                    const auto& toZ = cfZ[slice];
 
                     const Image* srca = mipChain.GetImage(level - 1, 0, toZ.u0);
                     const Image* srcb = mipChain.GetImage(level - 1, 0, toZ.u1);
@@ -2282,7 +2282,7 @@ namespace
 
                     for (size_t y = 0; y < nheight; ++y)
                     {
-                        auto const& toY = cfY[y];
+                        const auto& toY = cfY[y];
 
                         // Scanline 1
                         if (toY.u0 != u0)
@@ -2403,7 +2403,7 @@ namespace
 
                         for (size_t x = 0; x < nwidth; ++x)
                         {
-                            auto const& toX = cfX[x];
+                            const auto& toX = cfX[x];
 
                             XMVECTOR D[4];
 
@@ -2448,7 +2448,7 @@ namespace
 
                 for (size_t y = 0; y < nheight; ++y)
                 {
-                    auto const& toY = cfY[y];
+                    const auto& toY = cfY[y];
 
                     // Scanline 1
                     if (toY.u0 != u0)
@@ -2539,7 +2539,7 @@ namespace
 
                     for (size_t x = 0; x < nwidth; ++x)
                     {
-                        auto const& toX = cfX[x];
+                        const auto& toX = cfX[x];
 
                         XMVECTOR C0, C1, C2, C3;
                         CUBIC_INTERPOLATE(C0, toX.x, urow[0][toX.u0], urow[0][toX.u1], urow[0][toX.u2], urow[0][toX.u3]);

--- a/DirectXTex/DirectXTexResize.cpp
+++ b/DirectXTex/DirectXTexResize.cpp
@@ -414,7 +414,7 @@ namespace
 
         for (size_t y = 0; y < destImage.height; ++y)
         {
-            auto const& toY = lfY[y];
+            const auto& toY = lfY[y];
 
             if (toY.u0 != u0)
             {
@@ -444,7 +444,7 @@ namespace
 
             for (size_t x = 0; x < destImage.width; ++x)
             {
-                auto const& toX = lfX[x];
+                const auto& toX = lfX[x];
 
                 BILINEAR_INTERPOLATE(target[x], toX, toY, row0, row1)
             }
@@ -511,7 +511,7 @@ namespace
 
         for (size_t y = 0; y < destImage.height; ++y)
         {
-            auto const& toY = cfY[y];
+            const auto& toY = cfY[y];
 
             // Scanline 1
             if (toY.u0 != u0)
@@ -602,7 +602,7 @@ namespace
 
             for (size_t x = 0; x < destImage.width; ++x)
             {
-                auto const& toX = cfX[x];
+                const auto& toX = cfX[x];
 
                 XMVECTOR C0, C1, C2, C3;
 

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -1413,7 +1413,7 @@ namespace
 
         if (ext && ext->wSize == sizeof(TGA_EXTENSION) && ext->wGammaDenominator != 0)
         {
-            auto const gamma = static_cast<float>(ext->wGammaNumerator) / static_cast<float>(ext->wGammaDenominator);
+            const auto gamma = static_cast<float>(ext->wGammaNumerator) / static_cast<float>(ext->wGammaDenominator);
             if (fabsf(gamma - 2.2f) < GAMMA_EPSILON || fabsf(gamma - 2.4f) < GAMMA_EPSILON)
             {
                 sRGB = true;
@@ -1550,7 +1550,7 @@ HRESULT DirectX::GetMetadataFromTGAFile(const wchar_t* szFile, TGA_FLAGS flags, 
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    auto const headerLen = static_cast<size_t>(bytesRead);
+    const auto headerLen = static_cast<size_t>(bytesRead);
 #else
     inFile.read(reinterpret_cast<char*>(header), TGA_HEADER_LEN);
     if (!inFile)
@@ -1814,7 +1814,7 @@ HRESULT DirectX::LoadFromTGAFile(
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    auto const headerLen = static_cast<size_t>(bytesRead);
+    const auto headerLen = static_cast<size_t>(bytesRead);
 #else
     inFile.read(reinterpret_cast<char*>(header), TGA_HEADER_LEN);
     if (!inFile)
@@ -1834,7 +1834,7 @@ HRESULT DirectX::LoadFromTGAFile(
         return HRESULT_E_INVALID_DATA;
 
     // Read the pixels
-    auto const remaining = len - offset;
+    const auto remaining = len - offset;
     if (remaining == 0)
         return E_FAIL;
 

--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -931,10 +931,10 @@ HRESULT DirectX::SaveDDSTextureToFile(
 
     // Get the size of the image
 #if defined(_MSC_VER) || !defined(_WIN32)
-    auto const desc = pSource->GetDesc();
+    const auto desc = pSource->GetDesc();
 #else
     D3D12_RESOURCE_DESC tmpDesc;
-    auto const& desc = *pSource->GetDesc(&tmpDesc);
+    const auto& desc = *pSource->GetDesc(&tmpDesc);
 #endif
 
     if (desc.Width > UINT32_MAX)
@@ -1161,10 +1161,10 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     // Get the size of the image
 #if defined(_MSC_VER) || !defined(_WIN32)
-    auto const desc = pSource->GetDesc();
+    const auto desc = pSource->GetDesc();
 #else
     D3D12_RESOURCE_DESC tmpDesc;
-    auto const& desc = *pSource->GetDesc(&tmpDesc);
+    const auto& desc = *pSource->GetDesc(&tmpDesc);
 #endif
 
     if (desc.Width > UINT32_MAX)

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -1258,7 +1258,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
         for (auto pConv = conversion.begin(); pConv != conversion.end(); ++pConv)
         {
             std::filesystem::path curpath(pConv->szSrc);
-            auto const ext = curpath.extension();
+            const auto ext = curpath.extension();
 
             // Load source image
             if (pConv != conversion.begin())

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -2010,7 +2010,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
         }
 
         std::filesystem::path curpath(pConv->szSrc);
-        auto const ext = curpath.extension();
+        const auto ext = curpath.extension();
 
     #ifndef USE_XBOX_EXTS
         constexpr
@@ -3693,7 +3693,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     continue;
                 }
 
-                auto const err = static_cast<DWORD>(SHCreateDirectoryExW(nullptr, apath.c_str(), nullptr));
+                const auto err = static_cast<DWORD>(SHCreateDirectoryExW(nullptr, apath.c_str(), nullptr));
                 if (err != ERROR_SUCCESS && err != ERROR_ALREADY_EXISTS)
                 {
                     wprintf(L" directory creation FAILED (%08X%ls)\n",

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -529,7 +529,7 @@ namespace
             return E_OUTOFMEMORY;
 
         std::filesystem::path fname(fileName);
-        auto const ext = fname.extension();
+        const auto ext = fname.extension();
 
         if (_wcsicmp(ext.c_str(), L".dds") == 0)
         {
@@ -1392,9 +1392,9 @@ namespace
 
     void Print565(uint16_t rgb)
     {
-        auto const r = float(((rgb >> 11) & 31) * (1.0f / 31.0f));
-        auto const g = float(((rgb >> 5) & 63) * (1.0f / 63.0f));
-        auto const b = float(((rgb >> 0) & 31) * (1.0f / 31.0f));
+        const auto r = float(((rgb >> 11) & 31) * (1.0f / 31.0f));
+        const auto g = float(((rgb >> 5) & 63) * (1.0f / 63.0f));
+        const auto b = float(((rgb >> 0) & 31) * (1.0f / 31.0f));
 
         wprintf(L"(R: %.3f, G: %.3f, B: %.3f)", r, g, b);
     }
@@ -3434,7 +3434,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 if (outputFile.empty())
                 {
                     std::filesystem::path curpath(pImage1->szSrc);
-                    auto const ext = curpath.extension();
+                    const auto ext = curpath.extension();
 
                     if (_wcsicmp(ext.c_str(), L".bmp") == 0)
                     {
@@ -3717,7 +3717,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 
                 wprintf(L"\n       images = %zu\n", image->GetImageCount());
 
-                auto const sizeInKb = static_cast<uint32_t>(image->GetPixelsSize() / 1024);
+                const auto sizeInKb = static_cast<uint32_t>(image->GetPixelsSize() / 1024);
 
                 wprintf(L"   pixel size = %u (KB)\n\n", sizeInKb);
             }
@@ -3730,7 +3730,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                     return 1;
                 }
 
-                auto const ext = LookupByValue(fileType, g_pDumpFileTypes);
+                const auto ext = LookupByValue(fileType, g_pDumpFileTypes);
 
                 std::filesystem::path basePath(outputFile);
 

--- a/WICTextureLoader/WICTextureLoader11.cpp
+++ b/WICTextureLoader/WICTextureLoader11.cpp
@@ -584,8 +584,8 @@ namespace
         if (rowBytes > UINT32_MAX || numBytes > UINT32_MAX)
             return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
 
-        auto const rowPitch = static_cast<size_t>(rowBytes);
-        auto const imageSize = static_cast<size_t>(numBytes);
+        const auto rowPitch = static_cast<size_t>(rowBytes);
+        const auto imageSize = static_cast<size_t>(numBytes);
 
         std::unique_ptr<uint8_t[]> temp(new (std::nothrow) uint8_t[imageSize]);
         if (!temp)

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -506,8 +506,8 @@ namespace
         if (rowBytes > UINT32_MAX || numBytes > UINT32_MAX)
             return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
 
-        auto const rowPitch = static_cast<size_t>(rowBytes);
-        auto const imageSize = static_cast<size_t>(numBytes);
+        const auto rowPitch = static_cast<size_t>(rowBytes);
+        const auto imageSize = static_cast<size_t>(numBytes);
 
         decodedData.reset(new (std::nothrow) uint8_t[imageSize]);
         if (!decodedData)


### PR DESCRIPTION
Both ``const auto`` and ``auto const`` are equivalent in terms of the C++ compiler parser, but general coding guidelines suggest using ``const auto``. The primary reason for this PR is to be consistent since the codebase was using both.