### PR TITLE
IsPlanar option for D3D12 vs D3D11 depth

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -406,6 +406,15 @@
     { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
     { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
 
+    { "name": "x64-Debug-VCPKG"      , "configurePreset": "x64-Debug-VCPKG" },
+    { "name": "x64-Release-VCPKG"    , "configurePreset": "x64-Release-VCPKG" },
+    { "name": "x86-Debug-VCPKG"      , "configurePreset": "x86-Debug-VCPKG" },
+    { "name": "x86-Release-VCPKG"    , "configurePreset": "x86-Release-VCPKG" },
+    { "name": "arm64-Debug-VCPKG"    , "configurePreset": "arm64-Debug-VCPKG" },
+    { "name": "arm64-Release-VCPKG"  , "configurePreset": "arm64-Release-VCPKG" },
+    { "name": "arm64ec-Debug-VCPKG"  , "configurePreset": "arm64ec-Debug-VCPKG" },
+    { "name": "arm64ec-Release-VCPKG", "configurePreset": "arm64ec-Release-VCPKG" },
+
     { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
     { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
     { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -66,7 +66,7 @@ namespace DirectX
     DIRECTX_TEX_API bool __cdecl IsCompressed(_In_ DXGI_FORMAT fmt) noexcept;
     DIRECTX_TEX_API bool __cdecl IsPacked(_In_ DXGI_FORMAT fmt) noexcept;
     DIRECTX_TEX_API bool __cdecl IsVideo(_In_ DXGI_FORMAT fmt) noexcept;
-    DIRECTX_TEX_API bool __cdecl IsPlanar(_In_ DXGI_FORMAT fmt) noexcept;
+    DIRECTX_TEX_API bool __cdecl IsPlanar(_In_ DXGI_FORMAT fmt, _In_ bool isd3d12 = false) noexcept;
     DIRECTX_TEX_API bool __cdecl IsPalettized(_In_ DXGI_FORMAT fmt) noexcept;
     DIRECTX_TEX_API bool __cdecl IsDepthStencil(_In_ DXGI_FORMAT fmt) noexcept;
     DIRECTX_TEX_API bool __cdecl IsSRGB(_In_ DXGI_FORMAT fmt) noexcept;

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -392,10 +392,20 @@ bool DirectX::IsVideo(DXGI_FORMAT fmt) noexcept
 
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_
-bool DirectX::IsPlanar(DXGI_FORMAT fmt) noexcept
+bool DirectX::IsPlanar(DXGI_FORMAT fmt, bool isd3d12) noexcept
 {
     switch (static_cast<int>(fmt))
     {
+    case DXGI_FORMAT_R32G8X24_TYPELESS:
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+    case DXGI_FORMAT_R24G8_TYPELESS:
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+        return isd3d12; // Direct3D 12 considers these planar, Direct3D 11 does not.
+
     case DXGI_FORMAT_NV12:      // 4:2:0 8-bit
     case DXGI_FORMAT_P010:      // 4:2:0 10-bit
     case DXGI_FORMAT_P016:      // 4:2:0 16-bit


### PR DESCRIPTION
Depth/Stencil formats are explicitly considered "planar" by Direct3D 12, but were not in Direct3D 11. This PR updates **IsPlanar** with a defaulted optional parameter to handle these two choices, defaulting to Direct3D 11 as before.