### PR TITLE
Add ComputeTileShape utility

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -514,6 +514,53 @@ namespace DirectX
     };
 
     //---------------------------------------------------------------------------------
+    // Tiling utilities
+
+    struct DIRECTX_TEX_API TileShape
+    {
+        size_t width;
+        size_t height;
+        size_t depth;
+
+        TileShape() = default;
+
+    #if defined(__d3d11_2_h__) || defined(__d3d11_x_h__)
+        TileShape(const D3D11_TILE_SHAPE& tile) :
+            width(tile.WidthInTexels),
+            height(tile.HeightInTexels),
+            depth(tile.DepthInTexels)
+        {
+        }
+
+        void GetTileShape11(D3D11_TILE_SHAPE& tile) const
+        {
+            tile.WidthInTexels = static_cast<UINT>(width);
+            tile.HeightInTexels = static_cast<UINT>(height);
+            tile.DepthInTexels = static_cast<UINT>(depth);
+        }
+    #endif
+
+    #if defined(__d3d12_h__) || defined(__d3d12_x_h__) || defined(__XBOX_D3D12_X__)
+        TileShape(const D3D12_TILE_SHAPE& tile) :
+            width(tile.WidthInTexels),
+            height(tile.HeightInTexels),
+            depth(tile.DepthInTexels)
+        {
+        }
+
+        void GetTileShape12(D3D12_TILE_SHAPE& tile) const
+        {
+            tile.WidthInTexels = static_cast<UINT>(width);
+            tile.HeightInTexels = static_cast<UINT>(height);
+            tile.DepthInTexels = static_cast<UINT>(depth);
+        }
+    #endif
+    };
+
+    DIRECTX_TEX_API HRESULT __cdecl ComputeTileShape(_In_ DXGI_FORMAT fmt, _In_ TEX_DIMENSION dimension,
+        _Out_ TileShape& tiling) noexcept;
+
+    //---------------------------------------------------------------------------------
     // Image I/O
 
     // DDS operations

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -132,7 +132,7 @@
 #endif
 #include <d3d11_4.h>
 #else
-#include <d3d11_1.h>
+#include <d3d11_2.h>
 #endif
 #else // !WIN32
 #include <wsl/winadapter.h>

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -1247,6 +1247,158 @@ size_t DirectX::ComputeScanlines(DXGI_FORMAT fmt, size_t height) noexcept
 
 
 //-------------------------------------------------------------------------------------
+// Compute standard tile shape for 64KB tiles
+//-------------------------------------------------------------------------------------
+namespace
+{
+    constexpr size_t TILED_RESOURCE_TILE_SIZE_IN_BYTES = 65536;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::ComputeTileShape(
+    DXGI_FORMAT fmt,
+    TEX_DIMENSION dimension,
+    TileShape& tiling) noexcept
+{
+    tiling = {};
+
+    if (IsVideo(fmt) || IsPacked(fmt))
+        return E_INVALIDARG;
+
+    size_t bpp = BitsPerPixel(fmt);
+    if (bpp == 1 || bpp == 96)
+        return E_INVALIDARG;
+
+    switch(dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+        tiling.width = (bpp) ? ((TILED_RESOURCE_TILE_SIZE_IN_BYTES * 8) / bpp) : TILED_RESOURCE_TILE_SIZE_IN_BYTES;
+        tiling.height = tiling.depth = 1;
+        break;
+
+    case TEX_DIMENSION_TEXTURE2D:
+        tiling.depth = 1;
+        if(IsCompressed(fmt))
+        {
+            size_t bpb = BytesPerBlock(fmt);
+            switch(bpb)
+            {
+            case 8:
+                tiling.width = 128 * 4;
+                tiling.height = 64 * 4;
+                break;
+
+            case 16:
+                tiling.width = tiling.height = 64 * 4;
+                break;
+
+            default:
+                return E_INVALIDARG;
+            }
+
+            assert(((tiling.width / 4) * (tiling.height / 4) * bpb) == TILED_RESOURCE_TILE_SIZE_IN_BYTES);
+        }
+        else
+        {
+            if (bpp <= 8)
+            {
+                tiling.width = tiling.height = 256;
+            }
+            else if (bpp <= 16)
+            {
+                tiling.width = 256;
+                tiling.height = 128;
+            }
+            else if (bpp <= 32)
+            {
+                tiling.width = tiling.height = 128;
+            }
+            else if (bpp <= 64)
+            {
+                tiling.width = 128;
+                tiling.height = 64;
+            }
+            else if (bpp <= 128)
+            {
+                tiling.width = tiling.height = 64;
+            }
+            else
+            {
+                tiling = {};
+                return E_INVALIDARG;
+            }
+
+            assert(((tiling.width * tiling.height * bpp) / 8) == TILED_RESOURCE_TILE_SIZE_IN_BYTES);
+        }
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        if(IsCompressed(fmt))
+        {
+            size_t bpb = BytesPerBlock(fmt);
+            switch(bpb)
+            {
+            case 8:
+                tiling.width = 32 * 4;
+                tiling.height = 16 * 4;
+                tiling.depth = 16;
+                break;
+
+            case 16:
+                tiling.width = tiling.height = 16 * 4;
+                tiling.depth = 16;
+                break;
+
+            default:
+                return E_INVALIDARG;
+            }
+
+            assert(((tiling.width / 4) * (tiling.height / 4) * tiling.depth * bpb) == TILED_RESOURCE_TILE_SIZE_IN_BYTES);
+        }
+        else
+        {
+            if (bpp <= 8)
+            {
+                tiling.width = 64;
+                tiling.height = tiling.depth = 32;
+            }
+            else if (bpp <= 16)
+            {
+                tiling.width = tiling.height = tiling.depth = 32;
+            }
+            else if (bpp <= 32)
+            {
+                tiling.width = tiling.height = 32;
+                tiling.depth = 16;
+            }
+            else if (bpp <= 64)
+            {
+                tiling.width = 32;
+                tiling.height = tiling.depth = 16;
+            }
+            else if (bpp <= 128)
+            {
+                tiling.width = tiling.height = tiling.depth = 16;
+            }
+            else
+            {
+                tiling = {};
+                return E_INVALIDARG;
+            }
+
+            assert(((tiling.width * tiling.height * tiling.depth * bpp) / 8) == TILED_RESOURCE_TILE_SIZE_IN_BYTES);
+        }
+        break;
+
+    default:
+        return E_INVALIDARG;
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
 // Converts to an SRGB equivalent type if available
 //-------------------------------------------------------------------------------------
 _Use_decl_annotations_

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -1266,7 +1266,7 @@ HRESULT DirectX::ComputeTileShape(
         return E_INVALIDARG;
 
     size_t bpp = BitsPerPixel(fmt);
-    if (bpp == 1 || bpp == 96)
+    if (!bpp || bpp == 1 || bpp == 96)
         return E_INVALIDARG;
 
     switch(dimension)

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -1265,20 +1265,25 @@ HRESULT DirectX::ComputeTileShape(
     if (IsVideo(fmt) || IsPacked(fmt))
         return E_INVALIDARG;
 
-    size_t bpp = BitsPerPixel(fmt);
-    if (!bpp || bpp == 1 || bpp == 96)
+    const size_t bpp = BitsPerPixel(fmt);
+    if (!bpp || bpp == 1 || bpp == 24 || bpp == 96)
         return E_INVALIDARG;
+
+    const bool iscompressed = IsCompressed(fmt);
 
     switch(dimension)
     {
     case TEX_DIMENSION_TEXTURE1D:
+        if (iscompressed)
+            return E_INVALIDARG;
+
         tiling.width = (bpp) ? ((TILED_RESOURCE_TILE_SIZE_IN_BYTES * 8) / bpp) : TILED_RESOURCE_TILE_SIZE_IN_BYTES;
         tiling.height = tiling.depth = 1;
         break;
 
     case TEX_DIMENSION_TEXTURE2D:
         tiling.depth = 1;
-        if(IsCompressed(fmt))
+        if(iscompressed)
         {
             size_t bpb = BytesPerBlock(fmt);
             switch(bpb)
@@ -1333,7 +1338,7 @@ HRESULT DirectX::ComputeTileShape(
         break;
 
     case TEX_DIMENSION_TEXTURE3D:
-        if(IsCompressed(fmt))
+        if(iscompressed)
         {
             size_t bpb = BytesPerBlock(fmt);
             switch(bpb)


### PR DESCRIPTION
Adds helper to compute the 'shape' of 1D, 2D, and 3D tiles based on the format to get 64KiB sized texture tiles. This uses the 'standard' tiles as defined for Direct3D 11.2 and Direct3D 12, but does not support any Xbox-specific or IHV-specific tiling features.

