### PR TITLE
CMake fix for legacy Durango

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required (VERSION 3.20)
 
 set(DIRECTXTEX_VERSION 2.0.6)
 
+if(XBOX_CONSOLE_TARGET STREQUAL "durango")
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+endif()
+
 project (DirectXTex
   VERSION ${DIRECTXTEX_VERSION}
   DESCRIPTION "DirectX Texture Library"


### PR DESCRIPTION
In #593 I did a cleanup for CMake which was correct for most scenarios. It turns out that legacy Durango (i.e. Xbox One XDK circa 2015 - 2018) which I still support for some projects still needs that behavior to successfully build.

