### PR TITLE
Code review feedback for DLL declimport/export

### DIFF
--- a/.azuredevops/policies/approvercountpolicy.yml
+++ b/.azuredevops/policies/approvercountpolicy.yml
@@ -1,0 +1,20 @@
+name: approver_count
+description: Approver count policy for mscodehub/DirectXTex/DirectXTex repository
+resource: repository
+where: 
+configuration:
+  approverCountPolicySettings:
+    isBlocking: true
+    requireMinimumApproverCount: 1
+    creatorVoteCounts: false
+    allowDownvotes: false
+    sourcePushOptions:
+      resetOnSourcePush: false
+      requireVoteOnLastIteration: true
+      requireVoteOnEachIteration: false
+      resetRejectionsOnSourcePush: false
+    blockLastPusherVote: true
+    branchNames:
+    - refs/heads/release
+    - refs/heads/main
+    displayName: mscodehub/DirectXTex/DirectXTex Approver Count Policy

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -49,10 +49,18 @@ struct IWICMetadataQueryReader;
 
 #define DIRECTX_TEX_VERSION 207
 
-#ifdef DIRECTX_TEX_EXPORT
+#if defined(_WIN32) && defined(DIRECTX_TEX_EXPORT)
+#ifdef __GNUC__
+#define DIRECTX_TEX_API __attribute__ ((dllexport))
+#else
 #define DIRECTX_TEX_API __declspec(dllexport)
-#elif defined(DIRECTX_TEX_IMPORT)
+#endif
+#elif defined(_WIN32) && defined(DIRECTX_TEX_IMPORT)
+#ifdef __GNUC__
+#define DIRECTX_TEX_API __attribute__ ((dllimport))
+#else
 #define DIRECTX_TEX_API __declspec(dllimport)
+#endif
 #else
 #define DIRECTX_TEX_API
 #endif


### PR DESCRIPTION
CoPilot suggested a change which I disagreed with, but when I researched it a bit I realized there was a different change that would be useful to prefer `__attribute__` to `__declspec` for GNUC.

> Also includes some AzureDev Ops polices from the production pipelines.