### PR TITLE
Update DDSTextureLoader12.cpp

### DIFF
--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -499,6 +499,7 @@ namespace
         case DXGI_FORMAT_AYUV:
         case DXGI_FORMAT_Y410:
         case DXGI_FORMAT_YUY2:
+        case D3DFMT_X8B8G8R8:
             return 32;
 
         case DXGI_FORMAT_P010:
@@ -768,7 +769,10 @@ namespace
                     return DXGI_FORMAT_B8G8R8X8_UNORM;
                 }
 
-                // No DXGI format maps to ISBITMASK(0x000000ff,0x0000ff00,0x00ff0000,0) aka D3DFMT_X8B8G8R8
+                if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0))
+                {
+                    return D3DFMT_X8B8G8R8;
+                }
 
                 // Note that many common DDS reader/writers (including D3DX) swap the
                 // the RED/BLUE masks for 10:10:10:2 formats. We assume

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -499,7 +499,7 @@ namespace
         case DXGI_FORMAT_AYUV:
         case DXGI_FORMAT_Y410:
         case DXGI_FORMAT_YUY2:
-        case D3DFMT_X8B8G8R8:
+        case D3DFMT_X8B8G8R8_UNORM:
             return 32;
 
         case DXGI_FORMAT_P010:
@@ -771,7 +771,7 @@ namespace
 
                 if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0))
                 {
-                    return D3DFMT_X8B8G8R8;
+                    return D3DFMT_X8B8G8R8_UNORM;
                 }
 
                 // Note that many common DDS reader/writers (including D3DX) swap the


### PR DESCRIPTION
It looks like the original code had a comment saying there wasn't an existing DXGI format for `D3DFMT_X8B8G8R8`, which is 32-bit format. To fix this, I added for `D3DFMT_X8B8G8R8` by using `ISBITMASK(0x000000ff,0x0000ff00,0x00ff0000,0)`. When this format is detected, the code returns to 'D3DFMT_X8B8G8R8`.