### PR TITLE
EncodeDDSHeader for Xbox can't take a nullptr

### DIFF
--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -490,11 +490,9 @@ HRESULT DirectX::SaveToEXRFile(const Image& image, const wchar_t* szFile)
     }
 
     // Create file and write header
-    ScopedHandle hFile(safe_handle(CreateFileW(
+    ScopedHandle hFile(safe_handle(CreateFile2(
         szFile,
-        GENERIC_WRITE, 0,
-        nullptr,
-        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+        GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
         nullptr)));
     if (!hFile)
     {

--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -492,7 +492,7 @@ HRESULT DirectX::SaveToEXRFile(const Image& image, const wchar_t* szFile)
     // Create file and write header
     ScopedHandle hFile(safe_handle(CreateFile2(
         szFile,
-        GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+        GENERIC_WRITE, 0, CREATE_ALWAYS,
         nullptr)));
     if (!hFile)
     {

--- a/Auxiliary/DirectXTexXbox.h
+++ b/Auxiliary/DirectXTexXbox.h
@@ -218,13 +218,6 @@ namespace Xbox
     {
         return EncodeDDSHeader(xbox, reinterpret_cast<uint8_t*>(pDestination), maxsize);
     }
-
-    inline HRESULT __cdecl EncodeDDSHeader(
-        const XboxImage& xbox,
-        _Reserved_ std::nullptr_t, _In_ size_t maxsize) noexcept
-    {
-        return EncodeDDSHeader(xbox, static_cast<uint8_t*>(nullptr), maxsize);
-    }
 #endif
 
 } // namespace


### PR DESCRIPTION
For the C++17 ``std::byte`` support (#545) I had to provide a ``std::nullptr_t`` overload for the standard **EncodeDDSHeader** because the pointer can be null, but for Xbox it can't be.

> Also in #564 I had picked the wrong code branch to keep in the EXR module which used ``CreateFileW`` when I wanted to always use ``CreateFile2``.