### PR TITLE
GitHub Actions windows-2019 runner is being retired

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -38,14 +38,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     timeout-minutes: 60
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Release]
         arch: [amd64]
 
@@ -65,6 +65,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Set triplet'
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,62 +38,62 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
         include:
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Release
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Release
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Win8
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-Win8
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug-Clang
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Release-Clang
             arch: amd64_arm64
 
@@ -106,6 +106,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,51 +41,51 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     timeout-minutes: 60
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
         include:
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Release
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Release
             arch: amd64_arm64
 
@@ -105,6 +105,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Set triplet'
       shell: pwsh

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -34,46 +34,46 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Debug-VCPKG]
         arch: [amd64]
         shared: [OFF]
         include:
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Clang-VCPKG
             arch: amd64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug-VCPKG
             arch: amd64_x86
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-MinGW
             arch: amd64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-MinGW
             arch: amd64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-MinGW
             arch: amd64
             shared: ON
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-MinGW
             arch: amd64
             shared: ON
@@ -87,6 +87,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Set triplet'
       shell: pwsh


### PR DESCRIPTION
Switched all impacted pipelines to use *windows-2022*, but I still make use of v142 toolset for validation of the "VS 2019 (16.11)" compiler.