### PR TITLE
ScreenGrab9: Fix a missing return statement

### DIFF
--- a/ScreenGrab/ScreenGrab9.cpp
+++ b/ScreenGrab/ScreenGrab9.cpp
@@ -792,7 +792,7 @@ HRESULT DirectX::SaveWICTextureToFile(
         if (g_WIC2)
             pfGuid = GUID_WICPixelFormat32bppRGB;
         else
-            HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+            return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
         break;
 
     default:


### PR DESCRIPTION
Fixes a tiny oversight in `DirectX::SaveWICTextureToFile`, discarding the result of `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);` instead of returning it on error.