### PR TITLE
Add `LoadFromDDSStream{,Ex}()`

### DIFF
--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -82,10 +82,10 @@ namespace
         HRESULT result;
     };
 
-    class InputStream : public Imf::IStream
+    class EXRInputStream : public Imf::IStream
     {
     public:
-        InputStream(HANDLE hFile, const char fileName[]) :
+        EXRInputStream(HANDLE hFile, const char fileName[]) :
             IStream(fileName), m_hFile(hFile)
         {
             const LARGE_INTEGER dist = {};
@@ -103,11 +103,11 @@ namespace
             }
         }
 
-        InputStream(const InputStream&) = delete;
-        InputStream& operator = (const InputStream&) = delete;
+        EXRInputStream(const EXRInputStream&) = delete;
+        EXRInputStream& operator = (const EXRInputStream&) = delete;
 
-        InputStream(InputStream&&) = delete;
-        InputStream& operator=(InputStream&&) = delete;
+        EXRInputStream(EXRInputStream&&) = delete;
+        EXRInputStream& operator=(EXRInputStream&&) = delete;
 
         bool read(char c[], int n) override
         {
@@ -165,18 +165,18 @@ namespace
         LONGLONG m_EOF;
     };
 
-    class OutputStream : public Imf::OStream
+    class EXROutputStream : public Imf::OStream
     {
     public:
-        OutputStream(HANDLE hFile, const char fileName[]) :
+        EXROutputStream(HANDLE hFile, const char fileName[]) :
             OStream(fileName), m_hFile(hFile)
         {}
 
-        OutputStream(const OutputStream&) = delete;
-        OutputStream& operator = (const OutputStream&) = delete;
+        EXROutputStream(const EXROutputStream&) = delete;
+        EXROutputStream& operator = (const EXROutputStream&) = delete;
 
-        OutputStream(OutputStream&&) = delete;
-        OutputStream& operator=(OutputStream&&) = delete;
+        EXROutputStream(EXROutputStream&&) = delete;
+        EXROutputStream& operator=(EXROutputStream&&) = delete;
 
         void write(const char c[], int n) override
         {
@@ -250,7 +250,7 @@ HRESULT DirectX::GetMetadataFromEXRFile(const wchar_t* szFile, TexMetadata& meta
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    InputStream stream(hFile.get(), fileName.c_str());
+    EXRInputStream stream(hFile.get(), fileName.c_str());
 #else
     std::wstring wFileName(szFile);
     std::string fileName(wFileName.cbegin(), wFileName.cend());
@@ -359,7 +359,7 @@ HRESULT DirectX::LoadFromEXRFile(const wchar_t* szFile, TexMetadata* metadata, S
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    InputStream stream(hFile.get(), fileName.c_str());
+    EXRInputStream stream(hFile.get(), fileName.c_str());
 #else
     std::wstring wFileName(szFile);
     std::string fileName(wFileName.cbegin(), wFileName.cend());
@@ -502,7 +502,7 @@ HRESULT DirectX::SaveToEXRFile(const Image& image, const wchar_t* szFile)
 
     auto_delete_file delonfail(hFile.get());
 
-    OutputStream stream(hFile.get(), fileName.c_str());
+    EXROutputStream stream(hFile.get(), fileName.c_str());
 #else
     std::wstring wFileName(szFile);
     std::string fileName(wFileName.cbegin(), wFileName.cend());

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -576,9 +576,25 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Image I/O
 
+    class DIRECTX_TEX_API InputStream
+    {
+    public:
+        virtual ~InputStream() = default;
+
+        virtual bool Read(_Out_writes_bytes_(size) void* data, _In_ size_t size) = 0;
+
+        virtual bool Seek(_In_ size_t position) = 0;
+
+        virtual size_t Size() = 0;
+    };
+
     // DDS operations
     DIRECTX_TEX_API HRESULT __cdecl LoadFromDDSMemory(
         _In_reads_bytes_(size) const uint8_t* pSource, _In_ size_t size,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+    DIRECTX_TEX_API HRESULT __cdecl LoadFromDDSStream(
+        _In_ InputStream& stream,
         _In_ DDS_FLAGS flags,
         _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
     DIRECTX_TEX_API HRESULT __cdecl LoadFromDDSFile(
@@ -588,6 +604,12 @@ namespace DirectX
 
     DIRECTX_TEX_API HRESULT __cdecl LoadFromDDSMemoryEx(
         _In_reads_bytes_(size) const uint8_t* pSource, _In_ size_t size,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat,
+        _Out_ ScratchImage& image) noexcept;
+    DIRECTX_TEX_API HRESULT __cdecl LoadFromDDSStreamEx(
+        _In_ InputStream& stream,
         _In_ DDS_FLAGS flags,
         _Out_opt_ TexMetadata* metadata,
         _Out_opt_ DDSMetaData* ddPixelFormat,


### PR DESCRIPTION
Many games support own archive formats and implement own sort of a virtual file system. In that case, `LoadFromDDSFile()` doesn't fit, while `LoadFromDDSMemory()` requires 2x filesize: one buffer to read the file and another one to load the texture, since `ScratchImage` is always owning.

Add a simple `InputStream` class and `LoadDDSFromStream()` to avoid this memory overhead and allow games and apps to use their own functionality to operate with files or memory.
More formats could support this in future, as well as writing to an `OutputStream` if/when needed.