### PR TITLE
Allow `ScratchImage` to be non-owning

### DIFF
--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -458,7 +458,7 @@ namespace DirectX
         ScratchImage(const ScratchImage&) = delete;
         ScratchImage& operator=(const ScratchImage&) = delete;
 
-        HRESULT __cdecl Initialize(_In_ const TexMetadata& mdata, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize(_In_ const TexMetadata& mdata, _In_ CP_FLAGS flags = CP_FLAGS_NONE, _In_ bool owning = true) noexcept;
 
         HRESULT __cdecl Initialize1D(_In_ DXGI_FORMAT fmt, _In_ size_t length, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
         HRESULT __cdecl Initialize2D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
@@ -476,6 +476,7 @@ namespace DirectX
 
         const TexMetadata& __cdecl GetMetadata() const noexcept { return m_metadata; }
         const Image* __cdecl GetImage(_In_ size_t mip, _In_ size_t item, _In_ size_t slice) const noexcept;
+        const Image* __cdecl SetNonOwningImagePixels(_In_ size_t mip, _In_ size_t item, _In_ size_t slice, _In_ uint8_t* pixels) const noexcept;
 
         const Image* __cdecl GetImages() const noexcept { return m_image; }
         size_t __cdecl GetImageCount() const noexcept { return m_nimages; }

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -335,7 +335,8 @@ namespace DirectX
         _Success_(return) bool __cdecl SetupImageArray(
             _In_reads_bytes_(pixelSize) uint8_t* pMemory, _In_ size_t pixelSize,
             _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
-            _Out_writes_(nImages) Image* images, _In_ size_t nImages) noexcept;
+            _Out_writes_(nImages) Image* images, _In_ size_t nImages,
+            _In_ bool owning = true) noexcept;
 
         //---------------------------------------------------------------------------------
         // Conversion helper functions


### PR DESCRIPTION
`ScratchImage` is very convenient as it automatically compute the number of images, pitches etc. On the other hand, when the user has an already loaded texture, it still always allocate own buffer and perform copying, which might be suboptimal, especially with large textures.

Extend `ScratchImage::Initialize()` with an additional argument (with the default value that behaves the same way as before) to allow it to be non-owning. This means that it still computes the number of images, pitches etc., but doesn't allocate the actual buffer. Then, the user can update individual images using `ScratchImage::SetNonOwningImagePixels()`.
The actual `ScratchImage` doesn't own this memory, doesn't have own buffer and doesn't perform any deallocation on destruction. Memory management and lifetimes are fully on the user's side.

A non-owning `ScratchImage` differs from owning by having a non-zero `m_size` and `m_memory == nullptr`.

An example of usage:

```cpp
// create ScratchImage using Initialize(meta, cp_flags, false)

// set pixels pointer for each image using
auto& image = *scratch.SetNonOwningImagePixels(mip, face, depth, ptr);
```

The return value is optional and is the same as `ScratchImage.GetImage(mip, face, depth)`, only to avoid 2 external calls per subimage when needed. For example, if the user has a contiguous buffer with a mipmapped 2D image:

```cpp
for (size_t i{0}, off{0}; i < scratch.GetMetadata().mipLevels; ++i)
    off += scratch.SetNonOwningImagePixels(i, 0, 0, ptr + off)->slicePitch;
```

A non-owning `ScratchImage` can currently be initialized only using `Initialize()` for simplicity and to indicate that the option is for advanced users only. Other `Initialize*()` methods can be expanded later if needed.