### PR TITLE
HDR file input validation fixes

### DIFF
--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -227,7 +227,7 @@ namespace
         // Get orientation
         char orientation[256] = {};
 
-        const size_t len = FindEOL(info, std::min<size_t>(sizeof(orientation), size - 1));
+        const size_t len = FindEOL(info, std::min<size_t>(sizeof(orientation) - 1, size));
         if (len == size_t(-1)
             || len <= 2)
         {
@@ -236,7 +236,7 @@ namespace
 
         strncpy_s(orientation, info, len);
 
-        if (orientation[0] != '-' && orientation[1] != 'Y')
+        if (orientation[0] != '-' || orientation[1] != 'Y')
         {
             // We only support the -Y +X orientation (see top of file)
             return (static_cast<unsigned long>(((orientation[0] == '+' || orientation[0] == '-') && (orientation[1] == 'X' || orientation[1] == 'Y'))))

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -219,7 +219,7 @@ namespace
             }
         }
 
-        if (!formatFound)
+        if (!formatFound || (size < 3))
         {
             return E_FAIL;
         }


### PR DESCRIPTION
* Fix handling for specific truncated header that otherwise results in overreading a input buffer.

* Fix detection of supported vs. unsupported orientation (only `-Y height +X width` is supported).