### PR TITLE
Add Auxiliary to BVT GitHub Action

### DIFF
--- a/.github/workflows/auxbvt.yml
+++ b/.github/workflows/auxbvt.yml
@@ -132,4 +132,4 @@ jobs:
 
       - name: 'Run BVTs'
         working-directory: ${{ github.workspace }}
-        run: ctest --preset=${{ matrix.build_type }} --output-on-failure -L EXR|JPG|PNG
+        run: ctest --preset=${{ matrix.build_type }} --output-on-failure -L "EXR|JPG|PNG"


### PR DESCRIPTION
This validates the OpenEXR functionality in a BVT GitHub Action, as well as the JPEG/PNG implementation for when WIC is not available.