### PR TITLE
CoPilot recommends using https: instead of http

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,7 +163,7 @@ Every source file (`.cpp`, `.h`, `.hlsl`, etc.) must begin with this block:
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 ```
 

--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -93,7 +93,7 @@ namespace
 
         void seekg(uint64_t pos) override
         {
-            if (pos > m_DataSize)
+            if (pos > static_cast<uint64_t>(m_DataSize))
             {
                 throw std::out_of_range("Seek position is out of range");
             }

--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -98,7 +98,7 @@ namespace
                 throw std::out_of_range("Seek position is out of range");
             }
 
-            m_Position = pos;
+            m_Position = static_cast<size_t>(pos);
         }
 
     #if COMBINED_OPENEXR_VERSION > 30300

--- a/Auxiliary/DirectXTexEXR.cpp
+++ b/Auxiliary/DirectXTexEXR.cpp
@@ -75,6 +75,11 @@ namespace
 
         bool read(char c[], int n) override
         {
+            if (n < 0 || m_Position + n > m_DataSize)
+            {
+                throw std::out_of_range("Read request is out of range");
+            }
+
             memcpy(c, m_DataPtr + m_Position, n);
             m_Position += n;
 
@@ -88,6 +93,11 @@ namespace
 
         void seekg(uint64_t pos) override
         {
+            if (pos > m_DataSize)
+            {
+                throw std::out_of_range("Seek position is out of range");
+            }
+
             m_Position = pos;
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DirectXTex texture processing library
 
-http://go.microsoft.com/fwlink/?LinkId=248926
+https://go.microsoft.com/fwlink/?LinkId=248926
 
 Release available for download on [GitHub](https://github.com/microsoft/DirectXTex/releases)
 

--- a/DDSTextureLoader/DDSTextureLoader11.cpp
+++ b/DDSTextureLoader/DDSTextureLoader11.cpp
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/DDSTextureLoader/DDSTextureLoader11.h
+++ b/DDSTextureLoader/DDSTextureLoader11.h
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/DDSTextureLoader/DDSTextureLoader12.cpp
+++ b/DDSTextureLoader/DDSTextureLoader12.cpp
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 

--- a/DDSTextureLoader/DDSTextureLoader12.h
+++ b/DDSTextureLoader/DDSTextureLoader12.h
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 

--- a/DDSTextureLoader/DDSTextureLoader9.cpp
+++ b/DDSTextureLoader/DDSTextureLoader9.cpp
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/DDSTextureLoader/DDSTextureLoader9.h
+++ b/DDSTextureLoader/DDSTextureLoader9.h
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #pragma once

--- a/DirectXTex/BC.cpp
+++ b/DirectXTex/BC.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/BC.h
+++ b/DirectXTex/BC.h
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #pragma once

--- a/DirectXTex/BC4BC5.cpp
+++ b/DirectXTex/BC4BC5.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/BC6HBC7.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DDS.h
+++ b/DirectXTex/DDS.h
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------

--- a/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex.h
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #pragma once

--- a/DirectXTex/DirectXTex.inl
+++ b/DirectXTex/DirectXTex.inl
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #pragma once

--- a/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTexCompress.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexCompressGPU.cpp
+++ b/DirectXTex/DirectXTexCompressGPU.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTexConvert.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexD3D11.cpp
+++ b/DirectXTex/DirectXTexD3D11.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexD3D12.cpp
+++ b/DirectXTex/DirectXTexD3D12.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTexDDS.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexFlipRotate.cpp
+++ b/DirectXTex/DirectXTexFlipRotate.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexHDR.cpp
+++ b/DirectXTex/DirectXTexHDR.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTexImage.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTexMipmaps.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTexMisc.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexNormalMaps.cpp
+++ b/DirectXTex/DirectXTexNormalMaps.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTexP.h
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #pragma once

--- a/DirectXTex/DirectXTexPMAlpha.cpp
+++ b/DirectXTex/DirectXTexPMAlpha.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexResize.cpp
+++ b/DirectXTex/DirectXTexResize.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexTGA.cpp
+++ b/DirectXTex/DirectXTexTGA.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTexUtil.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/DirectXTex/DirectXTexWIC.cpp
+++ b/DirectXTex/DirectXTexWIC.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //-------------------------------------------------------------------------------------
 
 #include "DirectXTexP.h"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # DirectXTex texture processing library
 
-http://go.microsoft.com/fwlink/?LinkId=248926
+https://go.microsoft.com/fwlink/?LinkId=248926
 
 Copyright (c) Microsoft Corporation.
 

--- a/ScreenGrab/ScreenGrab11.cpp
+++ b/ScreenGrab/ScreenGrab11.cpp
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/ScreenGrab/ScreenGrab11.h
+++ b/ScreenGrab/ScreenGrab11.h
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/ScreenGrab/ScreenGrab12.cpp
+++ b/ScreenGrab/ScreenGrab12.cpp
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 

--- a/ScreenGrab/ScreenGrab12.h
+++ b/ScreenGrab/ScreenGrab12.h
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 

--- a/ScreenGrab/ScreenGrab9.cpp
+++ b/ScreenGrab/ScreenGrab9.cpp
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/ScreenGrab/ScreenGrab9.h
+++ b/ScreenGrab/ScreenGrab9.h
@@ -11,7 +11,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/Texassemble/AnimatedGif.cpp
+++ b/Texassemble/AnimatedGif.cpp
@@ -10,7 +10,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #ifdef  _MSC_VER

--- a/Texassemble/texassemble.cpp
+++ b/Texassemble/texassemble.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #ifdef  _MSC_VER

--- a/Texconv/ExtendedBMP.cpp
+++ b/Texconv/ExtendedBMP.cpp
@@ -9,7 +9,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #ifdef  _MSC_VER

--- a/Texconv/PortablePixMap.cpp
+++ b/Texconv/PortablePixMap.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #ifdef  _MSC_VER

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #ifdef  _MSC_VER

--- a/Texdiag/texdiag.cpp
+++ b/Texdiag/texdiag.cpp
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #ifdef  _MSC_VER

--- a/WICTextureLoader/WICTextureLoader11.cpp
+++ b/WICTextureLoader/WICTextureLoader11.cpp
@@ -17,7 +17,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/WICTextureLoader/WICTextureLoader11.h
+++ b/WICTextureLoader/WICTextureLoader11.h
@@ -17,7 +17,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/WICTextureLoader/WICTextureLoader12.cpp
+++ b/WICTextureLoader/WICTextureLoader12.cpp
@@ -14,7 +14,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 

--- a/WICTextureLoader/WICTextureLoader12.h
+++ b/WICTextureLoader/WICTextureLoader12.h
@@ -14,7 +14,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 

--- a/WICTextureLoader/WICTextureLoader9.cpp
+++ b/WICTextureLoader/WICTextureLoader9.cpp
@@ -13,7 +13,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 

--- a/WICTextureLoader/WICTextureLoader9.h
+++ b/WICTextureLoader/WICTextureLoader9.h
@@ -14,7 +14,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 //
-// http://go.microsoft.com/fwlink/?LinkId=248926
+// https://go.microsoft.com/fwlink/?LinkId=248926
 //--------------------------------------------------------------------------------------
 
 #pragma once


### PR DESCRIPTION
Also includes some recommendations for the EXR auxiliary code.