### PR TITLE
CMake update for v4.1 change

### DIFF
--- a/build/CompilerAndLinker.cmake
+++ b/build/CompilerAndLinker.cmake
@@ -141,7 +141,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     list(APPEND COMPILER_SWITCHES /Zc:__cplusplus /Zc:inline /fp:fast /Qdiag-disable:161)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    list(APPEND COMPILER_SWITCHES /sdl /Zc:inline /fp:fast)
+    list(APPEND COMPILER_SWITCHES /sdl /Zc:forScope /Zc:inline /Zc:wchar_t /fp:fast)
 
     if(WINDOWS_STORE)
       list(APPEND COMPILER_SWITCHES /await)


### PR DESCRIPTION
In CMake 4.1, the VS Generator no longer adds `/Zc:forScope /Zc:inline /Zc:wchar_t` to compiler and `/DYNAMICBASE /NXCOMPAT /SAFESEH` to linker by default unless set in the CMake.

This adds them back to the project to ensure they are set in VS Generator scenarios. `/Zc:forScope /Zc:wchar_t` were already the compiler default, and the project already set the other ones so it shouldn't result in any real compilation change for existing CMake projects or the Ninja generator.
