### PR TITLE
Update MinGW GitHub action to cover more compiler versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 
 ## General Guidelines
 
-- **Code Style**: The project uses an .editorconfig file to enforce coding standards. Follow the rules defined in `.editorconfig` for indentation, line endings, and other formatting. Additional information can be found on the wiki at [Implementation](https://github.com/microsoft/DirectXTK/wiki/Implementation). The library's public API requires C++11, and the project builds with C++17 (`CMAKE_CXX_STANDARD 17`). The command-line tools also use C++17, including `<filesystem>` for long file path support. This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW 12.2.
+- **Code Style**: The project uses an .editorconfig file to enforce coding standards. Follow the rules defined in `.editorconfig` for indentation, line endings, and other formatting. Additional information can be found on the wiki at [Implementation](https://github.com/microsoft/DirectXTex/wiki/Implementation). The library's public API requires C++11, and the project builds with C++17 (`CMAKE_CXX_STANDARD 17`). The command-line tools also use C++17, including `<filesystem>` for long file path support. This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW.
 > Notable `.editorconfig` rules: C/C++ and HLSL files use 4-space indentation, `crlf` line endings, and `latin1` charset — avoid non-ASCII characters in source files. HLSL files have separate indent/spacing rules defined in `.editorconfig`.
 - **Documentation**: The project provides documentation in the form of wiki pages available at [Documentation](https://github.com/microsoft/DirectXTex/wiki/).
 - **Error Handling**: Use C++ exceptions for error handling and uses RAII smart pointers to ensure resources are properly managed. For some functions that return HRESULT error codes, they are marked `noexcept`, use `std::nothrow` for memory allocation, and should not throw exceptions.
@@ -273,7 +273,7 @@ The following symbols are not custom error codes, but aliases for `HRESULT_FROM_
 
 When reviewing code, focus on the following aspects:
 
-- Adherence to coding standards defined in `.editorconfig` and on the [wiki](https://github.com/microsoft/DirectXTK/wiki/Implementation).
+- Adherence to coding standards defined in `.editorconfig` and on the [wiki](https://github.com/microsoft/DirectXTex/wiki/Implementation).
 - Make coding recommendations based on the *C++ Core Guidelines*.
 - Proper use of RAII and smart pointers.
 - Correct error handling practices and C++ Exception safety.

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -110,4 +110,4 @@ jobs:
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}
-        run: cmake --build out\build\${{ matrix.build_type }}
+        run: cmake --build out/build/${{ matrix.build_type }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -39,14 +39,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
-
     strategy:
       fail-fast: false
 
       matrix:
         build_type: [x64-Debug-MinGW, x64-Release-MinGW]
         shared: ['OFF', 'ON']
+        os: [windows-2022, windows-2025]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTex/se
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTex/blob/main/CHANGELOG.md).
 
-* The _directxtex_ NuGet package is deprecated. The best way to integrate the latest DirectXTex into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtex).
+* The _directxtex_desktop_win10_ and _directxtex_uwp_ NuGet packages are deprecated. The best way to integrate the latest DirectXTex into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtex).
 
 * The CMake projects require 3.21 or later.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copyright (c) Microsoft Corporation.
 
 This package contains DirectXTex, a shared source library for reading and writing ``.DDS`` files, and performing various texture content processing operations including resizing, format conversion, mip-map generation, block compression for Direct3D runtime texture resources, and height-map to normal-map conversion. This library makes use of the Windows Image Component (WIC) APIs. It also includes ``.TGA`` and ``.HDR`` readers and writers since these image file formats are commonly used for texture content processing pipelines, but are not currently supported by a built-in WIC codec.
 
-This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW 12.2. Use of the Windows 10 May 2020 Update SDK ([19041](https://walbourn.github.io/windows-10-may-2020-update-sdk/)) or later is required for Visual Studio. It can also be built for Windows Subsystem for Linux using GCC 11 or later.
+This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW. Use of the Windows 10 May 2020 Update SDK ([19041](https://walbourn.github.io/windows-10-may-2020-update-sdk/)) or later is required for Visual Studio. It can also be built for Windows Subsystem for Linux using GCC 11 or later.
 
 These components are designed to work without requiring any content from the legacy DirectX SDK. For details, see [Where is the DirectX SDK?](https://aka.ms/dxsdk).
 
@@ -99,6 +99,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTex/se
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTex/blob/main/CHANGELOG.md).
 
+* The *directxtex* NuGet package is deprecated. The best way to integrate the latest DirectXTex into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtex).
+
 * The CMake projects require 3.21 or later.
 
 * Starting with the October 2025 release, the _Auxiliary_ functions for loading and saving JPEG and PNG files now take a flag parameter after the filename.
@@ -172,6 +174,10 @@ The DirectXTex library is the work of Chuck Walbourn, with contributions from Ma
 
 Thanks to Paul Penson for his help with the implementation of ``MemoryStreamOnBlob``.
 
-Thanks to Andrew Farrier and Scott Matloff for their on-going help with code reviews.
-
 Thanks to Park DongHa for their contribution of the JPEG/PNG auxiliary functions.
+
+Thanks to Isaac Plunkett, Danny Chen, Jesse Natalie, and James Stanard for their help with the Standard Swizzle implementation.
+
+Thanks to Andrew Farrier, Jon Martin, and Scott Matloff for their help with code reviews.
+
+Thanks to Shawn Hargreaves and Nada Ouf for their continued support for this library.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTex/se
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTex/blob/main/CHANGELOG.md).
 
-* The *directxtex* NuGet package is deprecated. The best way to integrate the latest DirectXTex into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtex).
+* The _directxtex_ NuGet package is deprecated. The best way to integrate the latest DirectXTex into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtex).
 
 * The CMake projects require 3.21 or later.
 


### PR DESCRIPTION
Added a second case to the MinGW GHA to test a different version of the compiler: current 14.2 and 15.2.

> Includes some readme and copilot instructions edits as well.