### PR TITLE
texconv: added cases where BC4/BC5 need to decompress to 4 channels

### DIFF
--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -2400,7 +2400,8 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 if ((dwOptions & ((UINT64_C(1) << OPT_INVERT_Y) | (UINT64_C(1)) << OPT_RECONSTRUCT_Z))
                     || swizzleElements[1] != 1 || swizzleElements[2] != 2 || swizzleElements[3] != 3
                     || zeroElements[1] != 0 || zeroElements[2] != 0 || zeroElements[3] != 0
-                    || oneElements[1] != 0 || oneElements[2] != 0 || oneElements[3] != 0)
+                    || oneElements[1] != 0 || oneElements[2] != 0 || oneElements[3] != 0
+                    || dxt5nm || dxt5rxgb)
                 {
                     formatDecompress = DXGI_FORMAT_R8G8B8A8_SNORM;
                 }
@@ -2410,7 +2411,8 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 if ((dwOptions & (UINT64_C(1) << OPT_RECONSTRUCT_Z))
                     || swizzleElements[2] != 2 || swizzleElements[3] != 3
                     || zeroElements[2] != 0 || zeroElements[3] != 0
-                    || oneElements[2] != 0 || oneElements[3] != 0)
+                    || oneElements[2] != 0 || oneElements[3] != 0
+                    || dxt5nm || dxt5rxgb)
                 {
                     formatDecompress = DXGI_FORMAT_R8G8B8A8_SNORM;
                 }
@@ -2421,7 +2423,8 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 if ((dwOptions & ((UINT64_C(1) << OPT_INVERT_Y) | (UINT64_C(1)) << OPT_RECONSTRUCT_Z))
                     || swizzleElements[1] != 1 || swizzleElements[2] != 2 || swizzleElements[3] != 3
                     || zeroElements[1] != 0 || zeroElements[2] != 0 || zeroElements[3] != 0
-                    || oneElements[1] != 0 || oneElements[2] != 0 || oneElements[3] != 0)
+                    || oneElements[1] != 0 || oneElements[2] != 0 || oneElements[3] != 0
+                    || dxt5nm || dxt5rxgb)
                 {
                     formatDecompress = DXGI_FORMAT_R8G8B8A8_UNORM;
                 }
@@ -2432,7 +2435,8 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 if ((dwOptions & (UINT64_C(1) << OPT_RECONSTRUCT_Z))
                     || swizzleElements[2] != 2 || swizzleElements[3] != 3
                     || zeroElements[2] != 0 || zeroElements[3] != 0
-                    || oneElements[2] != 0 || oneElements[3] != 0)
+                    || oneElements[2] != 0 || oneElements[3] != 0
+                    || dxt5nm || dxt5rxgb)
                 {
                     formatDecompress = DXGI_FORMAT_R8G8B8A8_UNORM;
                 }

--- a/Texconv/texconv.cpp
+++ b/Texconv/texconv.cpp
@@ -2391,7 +2391,59 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
                 return 1;
             }
 
-            hr = Decompress(img, nimg, info, DXGI_FORMAT_UNKNOWN /* picks good default */, *timage);
+            DXGI_FORMAT formatDecompress = DXGI_FORMAT_UNKNOWN;
+
+            // Check common cases where we need more than 1 or 2 channels for later operations.
+            switch (info.format)
+            {
+            case DXGI_FORMAT_BC4_SNORM:
+                if ((dwOptions & ((UINT64_C(1) << OPT_INVERT_Y) | (UINT64_C(1)) << OPT_RECONSTRUCT_Z))
+                    || swizzleElements[1] != 1 || swizzleElements[2] != 2 || swizzleElements[3] != 3
+                    || zeroElements[1] != 0 || zeroElements[2] != 0 || zeroElements[3] != 0
+                    || oneElements[1] != 0 || oneElements[2] != 0 || oneElements[3] != 0)
+                {
+                    formatDecompress = DXGI_FORMAT_R8G8B8A8_SNORM;
+                }
+                break;
+
+            case DXGI_FORMAT_BC5_SNORM:
+                if ((dwOptions & (UINT64_C(1) << OPT_RECONSTRUCT_Z))
+                    || swizzleElements[2] != 2 || swizzleElements[3] != 3
+                    || zeroElements[2] != 0 || zeroElements[3] != 0
+                    || oneElements[2] != 0 || oneElements[3] != 0)
+                {
+                    formatDecompress = DXGI_FORMAT_R8G8B8A8_SNORM;
+                }
+                break;
+
+            case DXGI_FORMAT_BC4_TYPELESS:
+            case DXGI_FORMAT_BC4_UNORM:
+                if ((dwOptions & ((UINT64_C(1) << OPT_INVERT_Y) | (UINT64_C(1)) << OPT_RECONSTRUCT_Z))
+                    || swizzleElements[1] != 1 || swizzleElements[2] != 2 || swizzleElements[3] != 3
+                    || zeroElements[1] != 0 || zeroElements[2] != 0 || zeroElements[3] != 0
+                    || oneElements[1] != 0 || oneElements[2] != 0 || oneElements[3] != 0)
+                {
+                    formatDecompress = DXGI_FORMAT_R8G8B8A8_UNORM;
+                }
+                break;
+
+            case DXGI_FORMAT_BC5_TYPELESS:
+            case DXGI_FORMAT_BC5_UNORM:
+                if ((dwOptions & (UINT64_C(1) << OPT_RECONSTRUCT_Z))
+                    || swizzleElements[2] != 2 || swizzleElements[3] != 3
+                    || zeroElements[2] != 0 || zeroElements[3] != 0
+                    || oneElements[2] != 0 || oneElements[3] != 0)
+                {
+                    formatDecompress = DXGI_FORMAT_R8G8B8A8_UNORM;
+                }
+                break;
+
+            default:
+                // Let the decompressor pick the format.
+                break;
+            }
+
+            hr = Decompress(img, nimg, info, formatDecompress, *timage);
             if (FAILED(hr))
             {
                 wprintf(L" FAILED [decompress] (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));


### PR DESCRIPTION
Normally BC4 decompresses to R8 and BC5 decompresses to R8G8 to match the channel count of those formats. If doing swizzle operations for the B or A channel, inverting the G channel for BC4, or if reconstructing the B channel for normal maps, we need room for the new data or it gets lost. For cases where you are converting BC5 to DXT5nm, it also needs expanded to 4 channels.

This change has the decompressing going to RGBA32 (4-channels) in these cases rather than the narrower format.
